### PR TITLE
Try to use production settings first.

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -13,9 +13,9 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 """
 
 try:
-    from config.local import *
+    from config.production import *
 except ImportError as e:
     try:
-        from config.production_heroku import *
+        from config.local import *
     except ImportError as e:
         pass


### PR DESCRIPTION
This change makes the server attempt to load production.py first, if it exists, and falls back to local.py for development servers. In production environments, we'll just provide the production.py (without checking into the repo.)