### PR TITLE
Create and store resized image urls to other tables

### DIFF
--- a/candidate/models.py
+++ b/candidate/models.py
@@ -438,6 +438,10 @@ class CandidateCampaign(models.Model):
                                                        blank=True, null=True)
     twitter_description = models.CharField(verbose_name="Text description of this organization from twitter.",
                                            max_length=255, null=True, blank=True)
+    we_vote_hosted_profile_image_url_medium = models.URLField(verbose_name='we vote hosted medium image url',
+                                                              blank=True, null=True)
+    we_vote_hosted_profile_image_url_tiny = models.URLField(verbose_name='we vote hosted tiny image url',
+                                                            blank=True, null=True)
 
     google_plus_url = models.URLField(verbose_name='google plus url of candidate campaign', blank=True, null=True)
     youtube_url = models.URLField(verbose_name='youtube url of candidate campaign', blank=True, null=True)
@@ -987,7 +991,9 @@ class CandidateCampaignManager(models.Model):
 
     def update_candidate_twitter_details(self, candidate, twitter_json, cached_twitter_profile_image_url_https,
                                          cached_twitter_profile_background_image_url_https,
-                                         cached_twitter_profile_banner_url_https):
+                                         cached_twitter_profile_banner_url_https,
+                                         we_vote_hosted_profile_image_url_medium,
+                                         we_vote_hosted_profile_image_url_tiny):
         """
         Update a candidate entry with details retrieved from the Twitter API.
         """
@@ -1038,6 +1044,12 @@ class CandidateCampaignManager(models.Model):
                     candidate.twitter_profile_background_image_url_https = \
                         twitter_json['profile_background_image_url_https']
                     values_changed = True
+            if positive_value_exists(we_vote_hosted_profile_image_url_medium):
+                candidate.we_vote_hosted_profile_image_url_medium = we_vote_hosted_profile_image_url_medium
+                values_changed=True
+            if positive_value_exists(we_vote_hosted_profile_image_url_tiny):
+                candidate.we_vote_hosted_profile_image_url_tiny = we_vote_hosted_profile_image_url_tiny
+                values_changed = True
 
             if positive_value_exists(twitter_json['description']):
                 if twitter_json['description'] != candidate.twitter_description:

--- a/image/controllers.py
+++ b/image/controllers.py
@@ -657,107 +657,131 @@ def create_resized_images_for_all_voters(voter_id):
 
     for we_vote_image in we_vote_image_list:
         # Iterate through all cached images
-        voter_we_vote_id = we_vote_image.voter_we_vote_id
-        google_civic_election_id = we_vote_image.google_civic_election_id
-        we_vote_parent_image_id = we_vote_image.id
-        twitter_id = we_vote_image.twitter_id
-        image_format = we_vote_image.we_vote_image_file_location.split(".")[-1]
-        create_resized_images_results = {
-            'voter_we_vote_id':                         voter_we_vote_id,
-            'cached_medium_twitter_profile_image':      False,
-            'cached_tiny_twitter_profile_image':        False,
-            'cached_medium_twitter_background_image':   False,
-            'cached_tiny_twitter_background_image':     False,
-            'cached_medium_twitter_banner_image':       False,
-            'cached_tiny_twitter_banner_image':         False
-        }
-
-        if we_vote_image.kind_of_image_twitter_profile:
-            twitter_image_url_https = we_vote_image.twitter_profile_image_url_https
-            # Check if medium or tiny image versions exist or not
-            medium_or_tiny_version_exists_results = check_medium_or_tiny_version_exists(
-                voter_we_vote_id=voter_we_vote_id, twitter_image_url_https=twitter_image_url_https,
-                kind_of_image_twitter_profile=True)
-            if not medium_or_tiny_version_exists_results['medium_image_version_exists']:
-                # medium version does not exist so resize image and cache it
-                cache_resized_image_locally_results = cache_resized_image_locally(
-                    google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
-                    voter_we_vote_id=voter_we_vote_id, twitter_id=twitter_id, image_format=image_format,
-                    kind_of_image_twitter_profile=True, kind_of_image_medium=True)
-                create_resized_images_results['cached_medium_twitter_profile_image'] = \
-                    cache_resized_image_locally_results['success']
-            else:
-                create_resized_images_results['cached_medium_twitter_profile_image'] = IMAGE_ALREADY_CACHED
-
-            if not medium_or_tiny_version_exists_results['tiny_image_version_exists']:
-                # tiny version does not exist so resize image and cache it
-                cache_resized_image_locally_results = cache_resized_image_locally(
-                    google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
-                    voter_we_vote_id=voter_we_vote_id, twitter_id=twitter_id, image_format=image_format,
-                    kind_of_image_twitter_profile=True, kind_of_image_tiny=True)
-                create_resized_images_results['cached_tiny_twitter_profile_image'] = \
-                    cache_resized_image_locally_results['success']
-            else:
-                create_resized_images_results['cached_tiny_twitter_profile_image'] = IMAGE_ALREADY_CACHED
-
-        elif we_vote_image.kind_of_image_twitter_background:
-            twitter_image_url_https = we_vote_image.twitter_profile_background_image_url_https
-            # Check if medium or tiny image versions exist or not
-            medium_or_tiny_version_exists_results = check_medium_or_tiny_version_exists(
-                voter_we_vote_id=voter_we_vote_id, twitter_image_url_https=twitter_image_url_https,
-                kind_of_image_twitter_background=True)
-            if not medium_or_tiny_version_exists_results['medium_image_version_exists']:
-                # medium version does not exist so resize image and cache it
-                cache_resized_image_locally_results = cache_resized_image_locally(
-                    google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
-                    voter_we_vote_id=voter_we_vote_id, twitter_id=twitter_id, image_format=image_format,
-                    kind_of_image_twitter_background=True, kind_of_image_medium=True)
-                create_resized_images_results['cached_medium_twitter_background_image'] = \
-                    cache_resized_image_locally_results['success']
-            else:
-                create_resized_images_results['cached_medium_twitter_background_image'] = IMAGE_ALREADY_CACHED
-
-            if not medium_or_tiny_version_exists_results['tiny_image_version_exists']:
-                # tiny version does not exist so resize image and cache it
-                cache_resized_image_locally_results = cache_resized_image_locally(
-                    google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
-                    voter_we_vote_id=voter_we_vote_id, twitter_id=twitter_id, image_format=image_format,
-                    kind_of_image_twitter_background=True, kind_of_image_tiny=True)
-                create_resized_images_results['cached_tiny_twitter_background_image'] = \
-                    cache_resized_image_locally_results['success']
-            else:
-                create_resized_images_results['cached_tiny_twitter_background_image'] = IMAGE_ALREADY_CACHED
-
-        elif we_vote_image.kind_of_image_twitter_banner:
-            twitter_image_url_https = we_vote_image.twitter_profile_banner_url_https
-            # Check if medium or tiny image versions exist or not
-            medium_or_tiny_version_exists_results = check_medium_or_tiny_version_exists(
-                voter_we_vote_id=voter_we_vote_id, twitter_image_url_https=twitter_image_url_https,
-                kind_of_image_twitter_banner=True)
-            if not medium_or_tiny_version_exists_results['medium_image_version_exists']:
-                # medium version does not exist so resize image and cache it
-                cache_resized_image_locally_results = cache_resized_image_locally(
-                    google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
-                    voter_we_vote_id=voter_we_vote_id, twitter_id=twitter_id, image_format=image_format,
-                    kind_of_image_twitter_banner=True, kind_of_image_medium=True)
-                create_resized_images_results['cached_medium_twitter_banner_image'] = \
-                    cache_resized_image_locally_results['success']
-            else:
-                create_resized_images_results['cached_medium_twitter_banner_image'] = IMAGE_ALREADY_CACHED
-
-            if not medium_or_tiny_version_exists_results['tiny_image_version_exists']:
-                # medium version does not exist so resize image and cache it
-                cache_resized_image_locally_results = cache_resized_image_locally(
-                    google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
-                    voter_we_vote_id=voter_we_vote_id, twitter_id=twitter_id, image_format=image_format,
-                    kind_of_image_twitter_banner=True, kind_of_image_tiny=True)
-                create_resized_images_results['cached_tiny_twitter_banner_image'] = \
-                    cache_resized_image_locally_results['success']
-            else:
-                create_resized_images_results['cached_tiny_twitter_banner_image'] = IMAGE_ALREADY_CACHED
+        create_resized_images_results = create_resized_image(we_vote_image)
         create_all_resized_images_results.append(create_resized_images_results)
-
     return create_all_resized_images_results
+
+
+def create_resized_image(we_vote_image):
+    """
+    Create resized images as per cached we_vote_image object
+    :param we_vote_image:
+    :return:
+    """
+
+    voter_we_vote_id = we_vote_image.voter_we_vote_id
+    candidate_we_vote_id = we_vote_image.candidate_we_vote_id
+    organization_we_vote_id = we_vote_image.organization_we_vote_id
+    google_civic_election_id = we_vote_image.google_civic_election_id
+    we_vote_parent_image_id = we_vote_image.id
+    twitter_id = we_vote_image.twitter_id
+    image_format = we_vote_image.we_vote_image_file_location.split(".")[-1]
+    create_resized_image_results = {
+        'voter_we_vote_id':                         voter_we_vote_id,
+        'candidate_we_vote_id':                     candidate_we_vote_id,
+        'organization_we_vote_id':                  organization_we_vote_id,
+        'cached_medium_twitter_profile_image':      False,
+        'cached_tiny_twitter_profile_image':        False,
+        'cached_medium_twitter_background_image':   False,
+        'cached_tiny_twitter_background_image':     False,
+        'cached_medium_twitter_banner_image':       False,
+        'cached_tiny_twitter_banner_image':         False
+    }
+
+    if we_vote_image.kind_of_image_twitter_profile:
+        twitter_image_url_https = we_vote_image.twitter_profile_image_url_https
+        # Check if medium or tiny image versions exist or not
+        medium_or_tiny_version_exists_results = check_medium_or_tiny_version_exists(
+            voter_we_vote_id=voter_we_vote_id, candidate_we_vote_id=candidate_we_vote_id,
+            organization_we_vote_id=organization_we_vote_id, twitter_image_url_https=twitter_image_url_https,
+            kind_of_image_twitter_profile=True)
+        if not medium_or_tiny_version_exists_results['medium_image_version_exists']:
+            # medium version does not exist so resize image and cache it
+            cache_resized_image_locally_results = cache_resized_image_locally(
+                google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
+                voter_we_vote_id=voter_we_vote_id, candidate_we_vote_id=candidate_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id, twitter_id=twitter_id, image_format=image_format,
+                kind_of_image_twitter_profile=True, kind_of_image_medium=True)
+            create_resized_image_results['cached_medium_twitter_profile_image'] = \
+                cache_resized_image_locally_results['success']
+        else:
+            create_resized_image_results['cached_medium_twitter_profile_image'] = IMAGE_ALREADY_CACHED
+
+        if not medium_or_tiny_version_exists_results['tiny_image_version_exists']:
+            # tiny version does not exist so resize image and cache it
+            cache_resized_image_locally_results = cache_resized_image_locally(
+                google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
+                voter_we_vote_id=voter_we_vote_id, candidate_we_vote_id=candidate_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id, twitter_id=twitter_id, image_format=image_format,
+                kind_of_image_twitter_profile=True, kind_of_image_tiny=True)
+            create_resized_image_results['cached_tiny_twitter_profile_image'] = \
+                cache_resized_image_locally_results['success']
+        else:
+            create_resized_image_results['cached_tiny_twitter_profile_image'] = IMAGE_ALREADY_CACHED
+
+    elif we_vote_image.kind_of_image_twitter_background:
+        twitter_image_url_https = we_vote_image.twitter_profile_background_image_url_https
+        # Check if medium or tiny image versions exist or not
+        medium_or_tiny_version_exists_results = check_medium_or_tiny_version_exists(
+            voter_we_vote_id=voter_we_vote_id, candidate_we_vote_id=candidate_we_vote_id,
+            organization_we_vote_id=organization_we_vote_id, twitter_image_url_https=twitter_image_url_https,
+            kind_of_image_twitter_background=True)
+        if not medium_or_tiny_version_exists_results['medium_image_version_exists']:
+            # medium version does not exist so resize image and cache it
+            cache_resized_image_locally_results = cache_resized_image_locally(
+                google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
+                voter_we_vote_id=voter_we_vote_id, candidate_we_vote_id=candidate_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id, twitter_id=twitter_id, image_format=image_format,
+                kind_of_image_twitter_background=True, kind_of_image_medium=True)
+            create_resized_image_results['cached_medium_twitter_background_image'] = \
+                cache_resized_image_locally_results['success']
+        else:
+            create_resized_image_results['cached_medium_twitter_background_image'] = IMAGE_ALREADY_CACHED
+
+        if not medium_or_tiny_version_exists_results['tiny_image_version_exists']:
+            # tiny version does not exist so resize image and cache it
+            cache_resized_image_locally_results = cache_resized_image_locally(
+                google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
+                voter_we_vote_id=voter_we_vote_id, candidate_we_vote_id=candidate_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id, twitter_id=twitter_id, image_format=image_format,
+                kind_of_image_twitter_background=True, kind_of_image_tiny=True)
+            create_resized_image_results['cached_tiny_twitter_background_image'] = \
+                cache_resized_image_locally_results['success']
+        else:
+            create_resized_image_results['cached_tiny_twitter_background_image'] = IMAGE_ALREADY_CACHED
+
+    elif we_vote_image.kind_of_image_twitter_banner:
+        twitter_image_url_https = we_vote_image.twitter_profile_banner_url_https
+        # Check if medium or tiny image versions exist or not
+        medium_or_tiny_version_exists_results = check_medium_or_tiny_version_exists(
+            voter_we_vote_id=voter_we_vote_id, candidate_we_vote_id=candidate_we_vote_id,
+            organization_we_vote_id=organization_we_vote_id, twitter_image_url_https=twitter_image_url_https,
+            kind_of_image_twitter_banner=True)
+        if not medium_or_tiny_version_exists_results['medium_image_version_exists']:
+            # medium version does not exist so resize image and cache it
+            cache_resized_image_locally_results = cache_resized_image_locally(
+                google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
+                voter_we_vote_id=voter_we_vote_id, candidate_we_vote_id=candidate_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id, twitter_id=twitter_id, image_format=image_format,
+                kind_of_image_twitter_banner=True, kind_of_image_medium=True)
+            create_resized_image_results['cached_medium_twitter_banner_image'] = \
+                cache_resized_image_locally_results['success']
+        else:
+            create_resized_image_results['cached_medium_twitter_banner_image'] = IMAGE_ALREADY_CACHED
+
+        if not medium_or_tiny_version_exists_results['tiny_image_version_exists']:
+            # medium version does not exist so resize image and cache it
+            cache_resized_image_locally_results = cache_resized_image_locally(
+                google_civic_election_id, twitter_image_url_https, we_vote_parent_image_id,
+                voter_we_vote_id=voter_we_vote_id, candidate_we_vote_id=candidate_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id, twitter_id=twitter_id, image_format=image_format,
+                kind_of_image_twitter_banner=True, kind_of_image_tiny=True)
+            create_resized_image_results['cached_tiny_twitter_banner_image'] = \
+                cache_resized_image_locally_results['success']
+        else:
+            create_resized_image_results['cached_tiny_twitter_banner_image'] = IMAGE_ALREADY_CACHED
+
+    return create_resized_image_results
 
 
 def check_medium_or_tiny_version_exists(voter_we_vote_id=None, candidate_we_vote_id=None, organization_we_vote_id=None,
@@ -766,6 +790,8 @@ def check_medium_or_tiny_version_exists(voter_we_vote_id=None, candidate_we_vote
     """
     Check if medium or tiny image versions already exist or not
     :param voter_we_vote_id:
+    :param candidate_we_vote_id:
+    :param organization_we_vote_id:
     :param twitter_image_url_https:
     :param kind_of_image_twitter_profile:
     :param kind_of_image_twitter_background:
@@ -812,7 +838,9 @@ def cache_resized_image_locally(google_civic_election_id, twitter_image_url_http
                                 kind_of_image_tiny=False):
     """
     Resize the image as per image version and cache the same
-    :param we_vote_id:
+    :param voter_we_vote_id:
+    :param candidate_we_vote_id:
+    :param organization_we_vote_id:
     :param google_civic_election_id:
     :param twitter_image_url_https:
     :param we_vote_parent_image_id:
@@ -838,6 +866,7 @@ def cache_resized_image_locally(google_civic_election_id, twitter_image_url_http
     image_stored_locally = False
     image_stored_to_aws = False
     image_versions = []
+    we_vote_image_file_location = None
 
     we_vote_image_manager = WeVoteImageManager()
 

--- a/image/models.py
+++ b/image/models.py
@@ -379,13 +379,13 @@ class WeVoteImageManager(models.Model):
         else:
             return None
 
-    def retrieve_master_we_vote_image_from_url(self, voter_we_vote_id=None, candidate_we_vote_id=None,
-                                               organization_we_vote_id=None, twitter_profile_image_url_https=None,
-                                               twitter_profile_background_image_url_https=None,
-                                               twitter_profile_banner_url_https=None,
-                                               kind_of_image_medium=False, kind_of_image_tiny=False):
+    def retrieve_we_vote_image_from_url(self, voter_we_vote_id=None, candidate_we_vote_id=None,
+                                        organization_we_vote_id=None, twitter_profile_image_url_https=None,
+                                        twitter_profile_background_image_url_https=None,
+                                        twitter_profile_banner_url_https=None,
+                                        kind_of_image_medium=False, kind_of_image_tiny=False):
         """
-        Retrieve master we vote image from a url match
+        Retrieve  we vote image from a url match
         :param voter_we_vote_id:
         :param candidate_we_vote_id:
         :param organization_we_vote_id:

--- a/organization/models.py
+++ b/organization/models.py
@@ -702,7 +702,9 @@ class OrganizationManager(models.Manager):
 
     def update_organization_twitter_details(self, organization, twitter_json, cached_twitter_profile_image_url_https,
                                             cached_twitter_profile_background_image_url_https,
-                                            cached_twitter_profile_banner_url_https):
+                                            cached_twitter_profile_banner_url_https,
+                                            we_vote_hosted_profile_image_url_medium,
+                                            we_vote_hosted_profile_image_url_tiny):
         """
         Update an organization entry with details retrieved from the Twitter API.
         """
@@ -756,6 +758,12 @@ class OrganizationManager(models.Manager):
                     organization.twitter_profile_background_image_url_https = \
                         twitter_json['profile_background_image_url_https']
                     values_changed = True
+            if positive_value_exists(we_vote_hosted_profile_image_url_medium):
+                organization.we_vote_hosted_profile_image_url_medium = we_vote_hosted_profile_image_url_medium
+                values_changed=True
+            if positive_value_exists(we_vote_hosted_profile_image_url_tiny):
+                organization.we_vote_hosted_profile_image_url_tiny = we_vote_hosted_profile_image_url_tiny
+                values_changed = True
 
             if positive_value_exists(twitter_json['description']):
                 if twitter_json['description'] != organization.twitter_description:
@@ -1169,6 +1177,10 @@ class Organization(models.Model):
                                                        blank=True, null=True)
     twitter_description = models.CharField(verbose_name="Text description of this organization from twitter.",
                                            max_length=255, null=True, blank=True)
+    we_vote_hosted_profile_image_url_medium = models.URLField(verbose_name='we vote hosted medium image url',
+                                                              blank=True, null=True)
+    we_vote_hosted_profile_image_url_tiny = models.URLField(verbose_name='we vote hosted tiny image url',
+                                                            blank=True, null=True)
 
     wikipedia_page_id = models.BigIntegerField(verbose_name="pageid", null=True, blank=True)
     wikipedia_page_title = models.CharField(

--- a/position/controllers.py
+++ b/position/controllers.py
@@ -2699,3 +2699,77 @@ def retrieve_ballot_item_we_vote_ids_for_organizations_to_follow(voter_id,
         'ballot_item_we_vote_ids_list': ballot_item_we_vote_ids_list,
     }
     return results
+
+
+def update_all_position_details_from_candidate(candidate_campaign):
+    """
+    Update all position image urls PositionEntered and PositionForFriends from candidate details
+    :param candidate_campaign:
+    :return:
+    """
+    position_list_manager = PositionListManager()
+    position_manager = PositionManager()
+    update_all_position_image_urls_results = []
+
+    retrieve_public_positions = True
+    public_position_list = position_list_manager.retrieve_all_positions_for_candidate_campaign(
+        retrieve_public_positions, candidate_campaign.id, candidate_campaign.we_vote_id)
+    for position_object in public_position_list:
+        update_position_image_urls_results = position_manager.update_position_image_urls_from_candidate(
+            position_object, candidate_campaign)
+        update_all_position_image_urls_results.append(update_position_image_urls_results)
+
+    retrieve_public_positions = False
+    friends_position_list = position_list_manager.retrieve_all_positions_for_candidate_campaign(
+        retrieve_public_positions, candidate_campaign.id, candidate_campaign.we_vote_id,
+        retrieve_all_admin_override=True)
+    for position_object in friends_position_list:
+        update_position_image_urls_results = position_manager.update_position_image_urls_from_candidate(
+            position_object, candidate_campaign)
+        update_all_position_image_urls_results.append(update_position_image_urls_results)
+
+    return update_all_position_image_urls_results
+
+
+def update_position_entered_details_from_organization(organization):
+    """
+    Update all position image urls PositionEntered from organization details
+    :param organization:
+    :return:
+    """
+    position_list_manager = PositionListManager()
+    position_manager = PositionManager()
+    update_all_position_image_urls_results = []
+    stance_we_are_looking_for = ANY_STANCE
+    friends_vs_public = PUBLIC_ONLY
+
+    public_position_list = position_list_manager.retrieve_all_positions_for_organization(
+        organization.id, organization.we_vote_id, stance_we_are_looking_for, friends_vs_public)
+    for position_object in public_position_list:
+        update_position_image_urls_results = position_manager.update_position_image_urls_from_organization(
+            position_object, organization)
+        update_all_position_image_urls_results.append(update_position_image_urls_results)
+
+    return update_all_position_image_urls_results
+
+
+def update_position_for_friends_details_from_voter(voter):
+    """
+    Update all position image urls PositionEntered from voter details
+    :param organization:
+    :return:
+    """
+    position_list_manager = PositionListManager()
+    position_manager = PositionManager()
+    update_all_position_image_urls_results = []
+    stance_we_are_looking_for = ANY_STANCE
+    friends_vs_public = FRIENDS_ONLY
+
+    friends_position_list = position_list_manager.retrieve_all_positions_for_voter(
+        voter.id, voter.we_vote_id, stance_we_are_looking_for, friends_vs_public)
+    for position_object in friends_position_list:
+        update_position_image_urls_results = position_manager.update_position_image_urls_from_voter(
+            position_object, voter)
+        update_all_position_image_urls_results.append(update_position_image_urls_results)
+
+    return update_all_position_image_urls_results

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -701,9 +701,9 @@ class TwitterUserManager(models.Model):
         }
         return results
 
-    def update_twitter_user_details(self, twitter_id, twitter_json, cached_twitter_profile_image_url_https,
-                                    cached_twitter_profile_background_image_url_https,
-                                    cached_twitter_profile_banner_url_https):
+    def update_or_create_twitter_user(self, twitter_id, twitter_json, cached_twitter_profile_image_url_https,
+                                      cached_twitter_profile_background_image_url_https,
+                                      cached_twitter_profile_banner_url_https):
         """
         Update a twitter user entry with details retrieved from the Twitter API or
         create a twitter user entry if not exists.
@@ -714,8 +714,6 @@ class TwitterUserManager(models.Model):
         :param cached_twitter_profile_banner_url_https:
         :return:
         """
-        success = False
-        status = "ENTERING_UPDATE_TWITTER_USER_DETAILS"
         values_changed = False
 
         twitter_results = self.retrieve_twitter_user(twitter_id)
@@ -786,19 +784,19 @@ class TwitterUserManager(models.Model):
             else:
                 success = True
                 status = "NO_CHANGES_SAVED_TO_USER_TWITTER_DETAILS"
+            results = {
+                'success':          success,
+                'status':           status,
+                'twitter_user':     twitter_user,
+            }
+            return results
+
         else:
             # Twitter user does not exist so create new twitter user with latest twitter details
             twitter_save_results = self.save_new_twitter_user_from_twitter_json(
                 twitter_json, cached_twitter_profile_image_url_https,
                 cached_twitter_profile_background_image_url_https, cached_twitter_profile_banner_url_https)
-            twitter_user = twitter_save_results['twitter_user']
-
-        results = {
-            'success':          success,
-            'status':           status,
-            'twitter_user':     twitter_user,
-        }
-        return results
+            return twitter_save_results
 
     def delete_twitter_user(self, twitter_id):
         twitter_id = convert_to_int(twitter_id)

--- a/voter_guide/models.py
+++ b/voter_guide/models.py
@@ -401,6 +401,19 @@ class VoterGuideManager(models.Manager):
                         if voter_guide.twitter_followers_count != organization.twitter_followers_count:
                             voter_guide.twitter_followers_count = organization.twitter_followers_count
                             values_changed = True
+                        if voter_guide.image_url != organization.organization_photo_url():
+                            voter_guide.image_url = organization.organization_photo_url()
+                            values_changed = True
+                        if voter_guide.voter_guide_image_url_medium != \
+                                organization.we_vote_hosted_profile_image_url_medium:
+                            voter_guide.voter_guide_image_url_medium = \
+                                organization.we_vote_hosted_profile_image_url_medium
+                            values_changed = True
+                        if voter_guide.voter_guide_image_url_tiny != \
+                                organization.we_vote_hosted_profile_image_url_tiny:
+                            voter_guide.voter_guide_image_url_tiny = \
+                                organization.we_vote_hosted_profile_image_url_tiny
+                            values_changed = True
 
             if positive_value_exists(values_changed):
                 voter_guide.save()
@@ -560,6 +573,10 @@ class VoterGuide(models.Model):
 
     image_url = models.URLField(verbose_name='image url of logo/photo associated with voter guide',
                                 blank=True, null=True)
+    voter_guide_image_url_medium = models.URLField(verbose_name='medium version image url of logo/photo associated '
+                                                                'with voter guide', blank=True, null=True)
+    voter_guide_image_url_tiny = models.URLField(verbose_name='tiny version image url of logo/photo associated '
+                                                              'with voter guide', blank=True, null=True)
 
     voter_guide_owner_type = models.CharField(
         verbose_name="is owner org, public figure, or voter?", max_length=1, choices=VOTER_GUIDE_TYPE_CHOICES,


### PR DESCRIPTION
-  Cache resized (medium and tiny version)twitter images during refresh twitter details for candidate and organization.
- Added two new fields for  medium and tiny version of cached image aws urls in candidate, organization, politician, voter and voter_guides
- Added four new fields for medium and tiny version of cached ballot and speaker image aws urls in positionEntered and positionForFriends