### PR TITLE
Updated API endpoints with respect to additional photo sizes with locally cache image urls

### DIFF
--- a/apis_v1/documentation_source/candidate_retrieve_doc.py
+++ b/apis_v1/documentation_source/candidate_retrieve_doc.py
@@ -59,7 +59,9 @@ def candidate_retrieve_doc_template_values(url_root):
                    '  "id": integer,\n' \
                    '  "we_vote_id": string,\n' \
                    '  "ballot_item_display_name": string,\n' \
-                   '  "candidate_photo_url": string,\n' \
+                   '  "candidate_photo_url_large": string,\n' \
+                   '  "candidate_photo_url_medium": string,\n' \
+                   '  "candidate_photo_url_tiny": string,\n' \
                    '  "order_on_ballot": integer,\n' \
                    '  "google_civic_election_id": integer,\n' \
                    '  "maplight_id": integer,\n' \

--- a/apis_v1/documentation_source/candidates_retrieve_doc.py
+++ b/apis_v1/documentation_source/candidates_retrieve_doc.py
@@ -57,7 +57,9 @@ def candidates_retrieve_doc_template_values(url_root):
                    '     "id": integer,\n' \
                    '     "we_vote_id": string,\n' \
                    '     "ballot_item_display_name": string,\n' \
-                   '     "candidate_photo_url": string,\n' \
+                   '     "candidate_photo_url_large": string,\n' \
+                   '     "candidate_photo_url_medium": string,\n'\
+                   '     "candidate_photo_url_tiny": string,\n' \
                    '     "party": string,\n' \
                    '     "order_on_ballot": integer,\n' \
                    '   ],\n' \

--- a/apis_v1/documentation_source/friend_list_doc.py
+++ b/apis_v1/documentation_source/friend_list_doc.py
@@ -61,7 +61,9 @@ def friend_list_doc_template_values(url_root):
                    '   [\n' \
                    '     "voter_we_vote_id": string,\n' \
                    '     "voter_display_name": string,\n' \
-                   '     "voter_photo_url": string,\n' \
+                   '     "voter_photo_url_large": string,\n' \
+                   '     "voter_photo_url_medium": string,\n' \
+                   '     "voter_photo_url_tiny": string,\n' \
                    '     "voter_twitter_handle": string,\n' \
                    '     "voter_twitter_description": string,\n' \
                    '     "voter_twitter_followers_count": number,\n' \

--- a/apis_v1/documentation_source/organization_retrieve_doc.py
+++ b/apis_v1/documentation_source/organization_retrieve_doc.py
@@ -70,7 +70,9 @@ def organization_retrieve_doc_template_values(url_root):
                    '  "organization_website": string (website address),\n' \
                    '  "organization_email": string,\n' \
                    '  "organization_facebook": string,\n' \
-                   '  "organization_photo_url": string,\n' \
+                   '  "organization_photo_url_large": string,\n' \
+                   '  "organization_photo_url_medium": string,\n' \
+                   '  "organization_photo_url_tiny": string,\n' \
                    '  "organization_twitter_handle": string (twitter address),\n' \
                    '  "twitter_followers_count": integer,\n' \
                    '  "twitter_description": string,\n' \

--- a/apis_v1/documentation_source/organizations_followed_retrieve_doc.py
+++ b/apis_v1/documentation_source/organizations_followed_retrieve_doc.py
@@ -62,7 +62,9 @@ def organizations_followed_retrieve_doc_template_values(url_root):
                    '     "twitter_followers_count": integer,\n' \
                    '     "organization_email": string,\n' \
                    '     "organization_facebook": string,\n' \
-                   '     "organization_photo_url": string,\n' \
+                   '     "organization_photo_url_large": string,\n' \
+                   '     "organization_photo_url_medium": string,\n' \
+                   '     "organization_photo_url_tiny": string,\n' \
                    '   ],\n' \
                    '}'
 

--- a/apis_v1/documentation_source/position_list_for_ballot_item_doc.py
+++ b/apis_v1/documentation_source/position_list_for_ballot_item_doc.py
@@ -106,7 +106,9 @@ def position_list_for_ballot_item_doc_template_values(url_root):
                    '     "position_we_vote_id": string,\n' \
                    '     "ballot_item_display_name": string (either measure name or candidate name),\n' \
                    '     "speaker_display_name": string,\n' \
-                   '     "speaker_image_url_https": string,\n' \
+                   '     "speaker_image_url_https_large": string,\n' \
+                   '     "speaker_image_url_https_medium": string,\n' \
+                   '     "speaker_image_url_https_tiny": string,\n' \
                    '     "speaker_twitter_handle": string,\n' \
                    '     "speaker_type": string, ' \
                    '      (One of these: \'ORGANIZATION\', \'VOTER\', \'PUBLIC_FIGURE\', \'UNKNOWN\',)\n' \

--- a/apis_v1/documentation_source/position_list_for_opinion_maker_doc.py
+++ b/apis_v1/documentation_source/position_list_for_opinion_maker_doc.py
@@ -121,7 +121,9 @@ def position_list_for_opinion_maker_doc_template_values(url_root):
                    '  "opinion_maker_id": integer,\n' \
                    '  "opinion_maker_we_vote_id": string,\n' \
                    '  "opinion_maker_display_name": string,\n' \
-                   '  "opinion_maker_image_url_https": string,\n' \
+                   '  "opinion_maker_image_url_https_large": string,\n' \
+                   '  "opinion_maker_image_url_https_medium": string,\n' \
+                   '  "opinion_maker_image_url_https_tiny": string,\n' \
                    '  "is_following": boolean (Is this voter following this org/public_figure?),\n' \
                    '  "is_ignoring": boolean (Is this voter ignoring this org/public_figure?),\n' \
                    '  "position_list": list\n' \
@@ -129,7 +131,9 @@ def position_list_for_opinion_maker_doc_template_values(url_root):
                    '     "position_we_vote_id": string,\n' \
                    '     "ballot_item_display_name": string (either measure name or candidate name),\n' \
                    '     "ballot_item_id": integer,\n' \
-                   '     "ballot_item_image_url_https": string,\n' \
+                   '     "ballot_item_image_url_https_large": string,\n' \
+                   '     "ballot_item_image_url_https_medium": string,\n' \
+                   '     "ballot_item_image_url_https_tiny": string,\n' \
                    '     "ballot_item_twitter_handle": string,\n' \
                    '     "ballot_item_we_vote_id": string,\n' \
                    '     "ballot_item_political_party": string,\n' \

--- a/apis_v1/documentation_source/position_list_for_voter_doc.py
+++ b/apis_v1/documentation_source/position_list_for_voter_doc.py
@@ -93,7 +93,9 @@ def position_list_for_voter_doc_template_values(url_root):
                    '   (One of these: \'FRIENDS_ONLY\', \'PUBLIC_ONLY\', \'FRIENDS_AND_PUBLIC\'),\n' \
                    '  "voter_we_vote_id": string,\n' \
                    '  "voter_display_name": string,\n' \
-                   '  "voter_image_url_https": string,\n' \
+                   '  "voter_image_url_https_large": string,\n' \
+                   '  "voter_image_url_https_medium": string,\n' \
+                   '  "voter_image_url_https_tiny": string,\n' \
                    '  "google_civic_election_id": integer,\n' \
                    '  "state_code": string,\n' \
                    '  "position_list": list\n' \
@@ -103,7 +105,9 @@ def position_list_for_voter_doc_template_values(url_root):
                    '     "position_we_vote_id": string,\n' \
                    '     "ballot_item_display_name": string (either measure name or candidate name),\n' \
                    '     "ballot_item_id": integer,\n' \
-                   '     "ballot_item_image_url_https": string,\n' \
+                   '     "ballot_item_image_url_https_large": string,\n' \
+                   '     "ballot_item_image_url_https_medium": string,\n' \
+                   '     "ballot_item_image_url_https_tiny": string,\n' \
                    '     "ballot_item_twitter_handle": string,\n' \
                    '     "ballot_item_we_vote_id": string,\n' \
                    '     "ballot_item_political_party": string,\n' \

--- a/apis_v1/documentation_source/position_retrieve_doc.py
+++ b/apis_v1/documentation_source/position_retrieve_doc.py
@@ -78,7 +78,9 @@ def position_retrieve_doc_template_values(url_root):
                    '  "ballot_item_display_name": string (either measure name or candidate name),\n' \
                    '  "position_we_vote_id": string (the position identifier that moves server-to-server),\n' \
                    '  "speaker_display_name": string,\n' \
-                   '  "speaker_image_url_https": string,\n' \
+                   '  "speaker_image_url_https_large": string,\n' \
+                   '  "speaker_image_url_https_medium": string,\n' \
+                   '  "speaker_image_url_https_tiny": string,\n' \
                    '  "speaker_twitter_handle": string,\n' \
                    '  "is_support": boolean,\n' \
                    '  "is_positive_rating": boolean,\n' \

--- a/apis_v1/documentation_source/twitter_identity_retrieve_doc.py
+++ b/apis_v1/documentation_source/twitter_identity_retrieve_doc.py
@@ -40,6 +40,12 @@ def twitter_identity_retrieve_doc_template_values(url_root):
                    ' TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE)\n' \
                    '  "twitter_photo_url": string, (ONLY RETURNED FOR kind_of_owner ==' \
                    ' TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE)\n' \
+                   '  "we_vote_hosted_profile_image_url_large": string, (ONLY RETURNED FOR kind_of_owner ==' \
+                   ' TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE)\n' \
+                   '  "we_vote_hosted_profile_image_url_medium": string, (ONLY RETURNED FOR kind_of_owner ==' \
+                   ' TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE)\n' \
+                   '  "we_vote_hosted_profile_image_url_tiny": string, (ONLY RETURNED FOR kind_of_owner ==' \
+                   ' TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE)\n' \
                    '  "twitter_user_website": string, (ONLY RETURNED FOR kind_of_owner ==' \
                    ' TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE)\n' \
                    '  "twitter_name": string, (ONLY RETURNED FOR kind_of_owner ==' \

--- a/apis_v1/documentation_source/twitter_sign_in_retrieve_doc.py
+++ b/apis_v1/documentation_source/twitter_sign_in_retrieve_doc.py
@@ -53,6 +53,9 @@ def twitter_sign_in_retrieve_doc_template_values(url_root):
                    '  "twitter_middle_name": string,\n' \
                    '  "twitter_last_name": string,\n' \
                    '  "twitter_profile_image_url_https": string,\n' \
+                   '  "we_vote_hosted_profile_image_url_large": string,\n' \
+                   '  "we_vote_hosted_profile_image_url_medium": string,\n' \
+                   '  "we_vote_hosted_profile_image_url_tny": string,\n' \
                    '}'
 
     template_values = {

--- a/apis_v1/documentation_source/voter_ballot_items_retrieve_doc.py
+++ b/apis_v1/documentation_source/voter_ballot_items_retrieve_doc.py
@@ -83,7 +83,9 @@ def voter_ballot_items_retrieve_doc_template_values(url_root):
                    '        "id": integer,\n' \
                    '        "we_vote_id": string,\n' \
                    '        "ballot_item_display_name": string,\n' \
-                   '        "candidate_photo_url": string,\n' \
+                   '        "candidate_photo_url_large": string,\n' \
+                   '        "candidate_photo_url_medium": string,\n' \
+                   '        "candidate_photo_url_tiny": string,\n' \
                    '        "party": string,\n' \
                    '        "order_on_ballot": integer,\n' \
                    '      ],\n' \

--- a/apis_v1/documentation_source/voter_facebook_sign_in_retrieve_doc.py
+++ b/apis_v1/documentation_source/voter_facebook_sign_in_retrieve_doc.py
@@ -53,6 +53,9 @@ def voter_facebook_sign_in_retrieve_doc_template_values(url_root):
                    '  "facebook_middle_name": string,\n' \
                    '  "facebook_last_name": string,\n' \
                    '  "facebook_profile_image_url_https": string,\n' \
+                   '  "we_vote_hosted_profile_image_url_large": string,\n' \
+                   '  "we_vote_hosted_profile_image_url_medium": string,\n' \
+                   '  "we_vote_hosted_profile_image_url_tiny": string,\n' \
                    '}'
 
     template_values = {

--- a/apis_v1/documentation_source/voter_guides_followed_retrieve_doc.py
+++ b/apis_v1/documentation_source/voter_guides_followed_retrieve_doc.py
@@ -57,7 +57,12 @@ def voter_guides_followed_retrieve_doc_template_values(url_root):
                    '     "we_vote_id": string (We Vote ID of the voter guide),\n' \
                    '     "organization_we_vote_id": string (We Vote ID for the org that owns the voter guide),\n' \
                    '     "public_figure_we_vote_id": string (We Vote ID for the person that owns the voter guide),\n' \
-                   '     "voter_guide_image_url": string (We Vote ID for the person that owns the voter guide),\n' \
+                   '     "voter_guide_image_url_large": string ' \
+                   '(We Vote ID for the person that owns the voter guide),\n' \
+                   '     "voter_guide_image_url_medium": string ' \
+                   '(We Vote ID for the person that owns the voter guide),\n' \
+                   '     "voter_guide_image_url_tiny": string ' \
+                   '(We Vote ID for the person that owns the voter guide),\n' \
                    '     "last_updated": string (time in this format %Y-%m-%d %H:%M),\n' \
                    '     "google_civic_election_id": integer,\n' \
                    '     "twitter_description": string,\n' \

--- a/apis_v1/documentation_source/voter_guides_ignored_retrieve_doc.py
+++ b/apis_v1/documentation_source/voter_guides_ignored_retrieve_doc.py
@@ -57,7 +57,12 @@ def voter_guides_ignored_retrieve_doc_template_values(url_root):
                    '     "we_vote_id": string (We Vote ID of the voter guide),\n' \
                    '     "organization_we_vote_id": string (We Vote ID for the org that owns the voter guide),\n' \
                    '     "public_figure_we_vote_id": string (We Vote ID for the person that owns the voter guide),\n' \
-                   '     "voter_guide_image_url": string (We Vote ID for the person that owns the voter guide),\n' \
+                   '     "voter_guide_image_url_large": string ' \
+                   '(We Vote ID for the person that owns the voter guide),\n' \
+                   '     "voter_guide_image_url_medium": string ' \
+                   '(We Vote ID for the person that owns the voter guide),\n' \
+                   '     "voter_guide_image_url_tiny": string ' \
+                   '(We Vote ID for the person that owns the voter guide),\n' \
                    '     "last_updated": string (time in this format %Y-%m-%d %H:%M),\n' \
                    '     "google_civic_election_id": integer,\n' \
                    '     "twitter_description": string,\n' \

--- a/apis_v1/documentation_source/voter_guides_to_follow_retrieve_doc.py
+++ b/apis_v1/documentation_source/voter_guides_to_follow_retrieve_doc.py
@@ -92,7 +92,12 @@ def voter_guides_to_follow_retrieve_doc_template_values(url_root):
                    '     "we_vote_id": string (We Vote ID of the voter guide),\n' \
                    '     "organization_we_vote_id": string (We Vote ID for the org that owns the voter guide),\n' \
                    '     "public_figure_we_vote_id": string (We Vote ID for the person that owns the voter guide),\n' \
-                   '     "voter_guide_image_url": string (We Vote ID for the person that owns the voter guide),\n' \
+                   '     "voter_guide_image_url_large": string ' \
+                   '(We Vote ID for the person that owns the voter guide),\n' \
+                   '     "voter_guide_image_url_medium": string ' \
+                   '(We Vote ID for the person that owns the voter guide),\n' \
+                   '     "voter_guide_image_url_tiny": string ' \
+                   '(We Vote ID for the person that owns the voter guide),\n' \
                    '     "last_updated": string (time in this format %Y-%m-%d %H:%M),\n' \
                    '     "google_civic_election_id": integer,\n' \
                    '     "twitter_description": string,\n' \

--- a/apis_v1/documentation_source/voter_retrieve_doc.py
+++ b/apis_v1/documentation_source/voter_retrieve_doc.py
@@ -55,7 +55,9 @@ def voter_retrieve_doc_template_values(url_root):
                    '  "facebook_id": integer,\n' \
                    '  "facebook_email": string,\n' \
                    '  "facebook_profile_image_url_https": string,\n' \
-                   '  "voter_photo_url": string,\n' \
+                   '  "voter_photo_url_large": string,\n' \
+                   '  "voter_photo_url_medium": string,\n' \
+                   '  "voter_photo_url_tiny": string,\n' \
                    '  "twitter_screen_name": string,\n' \
                    '  "is_signed_in": boolean,\n' \
                    '  "signed_in_facebook": boolean,\n' \

--- a/apis_v1/tests/test_views_organization_suggestion_tasks.py
+++ b/apis_v1/tests/test_views_organization_suggestion_tasks.py
@@ -168,13 +168,14 @@ class WeVoteAPIsV1TestsOrganizationSuggestionTasks(TestCase):
         self.assertEqual('organization_suggestion_list' in json_data13, True,
                          "'organization_suggestion_list' expected in the json response, and not found")
         self.assertEqual(
-            json_data13['status'], ' TWITTER_WHO_I_FOLLOW_LIST_RETRIEVED  SUGGESTED_ORGANIZATION_TO_FOLLOW_UPDATED '
-                                   'RETRIEVE_TWITTER_LINK_TO_ORGANIZATION_FOUND_BY_TWITTER_USER_ID '
+            json_data13['status'], ' TWITTER_WHO_I_FOLLOW_LIST_RETRIEVED '
+                                   ' RETRIEVE_TWITTER_LINK_TO_ORGANIZATION_FOUND_BY_TWITTER_USER_ID '
                                    'SUGGESTED_ORGANIZATION_TO_FOLLOW_UPDATED '
-                                   'RETRIEVE_TWITTER_LINK_TO_ORGANIZATION_FOUND_BY_TWITTER_USER_ID',
-            "status: {status} ( TWITTER_WHO_I_FOLLOW_LIST_RETRIEVED  SUGGESTED_ORGANIZATION_TO_FOLLOW_UPDATED "
-            "RETRIEVE_TWITTER_LINK_TO_ORGANIZATION_FOUND_BY_TWITTER_USER_ID "
-            "SUGGESTED_ORGANIZATION_TO_FOLLOW_UPDATED RETRIEVE_TWITTER_LINK_TO_ORGANIZATION_FOUND_BY_TWITTER_USER_ID "
+                                   'RETRIEVE_TWITTER_LINK_TO_ORGANIZATION_FOUND_BY_TWITTER_USER_ID '
+                                   'SUGGESTED_ORGANIZATION_TO_FOLLOW_UPDATED',
+            "status: {status} ( TWITTER_WHO_I_FOLLOW_LIST_RETRIEVED "
+            " RETRIEVE_TWITTER_LINK_TO_ORGANIZATION_FOUND_BY_TWITTER_USER_ID SUGGESTED_ORGANIZATION_TO_FOLLOW_UPDATED "
+            "RETRIEVE_TWITTER_LINK_TO_ORGANIZATION_FOUND_BY_TWITTER_USER_ID SUGGESTED_ORGANIZATION_TO_FOLLOW_UPDATED"
             "expected), voter_device_id: {voter_device_id}".format
             (status=json_data13['status'], voter_device_id=json_data13['voter_device_id']))
         self.assertEqual(json_data13['success'], True, "success 'True' expected, True returned")

--- a/apis_v1/views.py
+++ b/apis_v1/views.py
@@ -1002,20 +1002,23 @@ def twitter_identity_retrieve_view(request):  # twitterIdentityRetrieve
     voter_device_id = get_voter_device_id(request)  # We standardize how we take in the voter_device_id
     results = twitter_identity_retrieve_for_api(twitter_handle, voter_device_id)
     json_data = {
-        'status':                   results['status'],
-        'success':                  results['success'],
-        'twitter_handle':           results['twitter_handle'],
-        'owner_found':              results['owner_found'],
-        'kind_of_owner':            results['kind_of_owner'],
-        'owner_we_vote_id':         results['owner_we_vote_id'],
-        'owner_id':                 results['owner_id'],
-        'google_civic_election_id': results['google_civic_election_id'],
+        'status':                                   results['status'],
+        'success':                                  results['success'],
+        'twitter_handle':                           results['twitter_handle'],
+        'owner_found':                              results['owner_found'],
+        'kind_of_owner':                            results['kind_of_owner'],
+        'owner_we_vote_id':                         results['owner_we_vote_id'],
+        'owner_id':                                 results['owner_id'],
+        'google_civic_election_id':                 results['google_civic_election_id'],
         # These values only returned if kind_of_owner == TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE
-        'twitter_description':      results['twitter_description'],
-        'twitter_followers_count':  results['twitter_followers_count'],
-        'twitter_photo_url':        results['twitter_photo_url'],
-        'twitter_user_website':     results['twitter_user_website'],
-        'twitter_name':             results['twitter_name'],
+        'twitter_description':                      results['twitter_description'],
+        'twitter_followers_count':                  results['twitter_followers_count'],
+        'twitter_photo_url':                        results['twitter_photo_url'],
+        'we_vote_hosted_profile_image_url_large':   results['we_vote_hosted_profile_image_url_large'],
+        'we_vote_hosted_profile_image_url_medium':  results['we_vote_hosted_profile_image_url_medium'],
+        'we_vote_hosted_profile_image_url_tiny':    results['we_vote_hosted_profile_image_url_tiny'],
+        'twitter_user_website':                     results['twitter_user_website'],
+        'twitter_name':                             results['twitter_name'],
         }
     return HttpResponse(json.dumps(json_data), content_type='application/json')
 
@@ -1130,6 +1133,10 @@ def twitter_sign_in_retrieve_view(request):  # twitterSignInRetrieve
         'twitter_sign_in_verified':                 results['twitter_sign_in_verified'],
         'twitter_sign_in_failed':                   results['twitter_sign_in_failed'],
         'twitter_secret_key':                       results['twitter_secret_key'],
+        'twitter_profile_image_url_https':          results['twitter_profile_image_url_https'],
+        'we_vote_hosted_profile_image_url_large':   results['we_vote_hosted_profile_image_url_large'],
+        'we_vote_hosted_profile_image_url_medium':  results['we_vote_hosted_profile_image_url_medium'],
+        'we_vote_hosted_profile_image_url_tiny':    results['we_vote_hosted_profile_image_url_tiny'],
         # 'twitter_who_i_follow':                   results['twitter_who_i_follow'],
         # There are more values we currently aren't returning
     }
@@ -1736,6 +1743,12 @@ def voter_facebook_sign_in_retrieve_view(request):  # voterFacebookSignInRetriev
         'facebook_sign_in_failed':                  results['facebook_sign_in_failed'],
         'facebook_secret_key':                      results['facebook_secret_key'],
         'voter_has_data_to_preserve':               results['voter_has_data_to_preserve'],
+        'facebook_user_id':                         results['facebook_user_id'],
+        'facebook_profile_image_url_https':         results['facebook_profile_image_url_https'],
+        'we_vote_hosted_profile_image_url_large':   results['we_vote_hosted_profile_image_url_large'],
+        'we_vote_hosted_profile_image_url_medium':  results['we_vote_hosted_profile_image_url_medium'],
+        'we_vote_hosted_profile_image_url_tiny':    results['we_vote_hosted_profile_image_url_tiny']
+
     }
     return HttpResponse(json.dumps(json_data), content_type='application/json')
 

--- a/ballot/controllers.py
+++ b/ballot/controllers.py
@@ -883,7 +883,11 @@ def voter_ballot_items_retrieve_for_one_election_for_api(voter_device_id, voter_
                                 'id':                           candidate.id,
                                 'we_vote_id':                   candidate.we_vote_id,
                                 'ballot_item_display_name':     candidate.display_candidate_name(),
-                                'candidate_photo_url':          candidate.candidate_photo_url(),
+                                'candidate_photo_url_large':    candidate.we_vote_hosted_profile_image_url_large
+                                    if positive_value_exists(candidate.we_vote_hosted_profile_image_url_large)
+                                    else candidate.candidate_photo_url(),
+                                'candidate_photo_url_medium':   candidate.we_vote_hosted_profile_image_url_medium,
+                                'candidate_photo_url_tiny':     candidate.we_vote_hosted_profile_image_url_tiny,
                                 'party':                        candidate.political_party_display(),
                                 'order_on_ballot':              candidate.order_on_ballot,
                                 'kind_of_ballot_item':          CANDIDATE,

--- a/candidate/controllers.py
+++ b/candidate/controllers.py
@@ -386,7 +386,11 @@ def candidate_retrieve_for_api(candidate_id, candidate_we_vote_id):  # candidate
             'id':                           candidate_campaign.id,
             'we_vote_id':                   candidate_campaign.we_vote_id,
             'ballot_item_display_name':     candidate_campaign.display_candidate_name(),
-            'candidate_photo_url':          candidate_campaign.candidate_photo_url(),
+            'candidate_photo_url_large':    candidate_campaign.we_vote_hosted_profile_image_url_large
+                if positive_value_exists(candidate_campaign.we_vote_hosted_profile_image_url_large)
+                else candidate_campaign.candidate_photo_url(),
+            'candidate_photo_url_medium':   candidate_campaign.we_vote_hosted_profile_image_url_medium,
+            'candidate_photo_url_tiny':     candidate_campaign.we_vote_hosted_profile_image_url_tiny,
             'order_on_ballot':              candidate_campaign.order_on_ballot,
             'google_civic_election_id':     candidate_campaign.google_civic_election_id,
             'maplight_id':                  candidate_campaign.maplight_id,
@@ -469,7 +473,11 @@ def candidates_retrieve_for_api(office_id, office_we_vote_id):
                 'id':                           candidate.id,
                 'we_vote_id':                   candidate.we_vote_id,
                 'ballot_item_display_name':     candidate.display_candidate_name(),
-                'candidate_photo_url':          candidate.candidate_photo_url(),
+                'candidate_photo_url_large':    candidate.we_vote_hosted_profile_image_url_large
+                    if positive_value_exists(candidate.we_vote_hosted_profile_image_url_large)
+                    else candidate.candidate_photo_url(),
+                'candidate_photo_url_medium':   candidate.we_vote_hosted_profile_image_url_medium,
+                'candidate_photo_url_tiny':     candidate.we_vote_hosted_profile_image_url_tiny,
                 'party':                        candidate.political_party_display(),
                 'order_on_ballot':              candidate.order_on_ballot,
                 'kind_of_ballot_item':          CANDIDATE,

--- a/friend/controllers.py
+++ b/friend/controllers.py
@@ -982,7 +982,11 @@ def friend_list_for_api(voter_device_id,
                 one_friend = {
                     "voter_we_vote_id":                 friend_voter.we_vote_id,
                     "voter_display_name":               friend_voter.get_full_name(),
-                    "voter_photo_url":                  friend_voter.voter_photo_url(),
+                    "voter_photo_url_large":            friend_voter.we_vote_hosted_profile_image_url_large
+                         if positive_value_exists(friend_voter.we_vote_hosted_profile_image_url_large)
+                         else friend_voter.voter_photo_url(),
+                    'voter_photo_url_medium':           friend_voter.we_vote_hosted_profile_image_url_medium,
+                    'voter_photo_url_tiny':             friend_voter.we_vote_hosted_profile_image_url_tiny,
                     "voter_email_address":              friend_voter.email,
                     "voter_twitter_handle":             friend_voter.twitter_screen_name,
                     "voter_twitter_description":        "",  # To be implemented
@@ -1012,7 +1016,11 @@ def friend_list_for_api(voter_device_id,
                     one_friend = {
                         "voter_we_vote_id":                 friend_voter.we_vote_id,
                         "voter_display_name":               friend_voter.get_full_name(),
-                        "voter_photo_url":                  friend_voter.voter_photo_url(),
+                        "voter_photo_url_large":            friend_voter.we_vote_hosted_profile_image_url_large
+                            if positive_value_exists(friend_voter.we_vote_hosted_profile_image_url_large)
+                            else friend_voter.voter_photo_url(),
+                        'voter_photo_url_medium':           friend_voter.we_vote_hosted_profile_image_url_medium,
+                        'voter_photo_url_tiny':             friend_voter.we_vote_hosted_profile_image_url_tiny,
                         "voter_email_address":              friend_voter.email,
                         "voter_twitter_handle":             friend_voter.twitter_screen_name,
                         "voter_twitter_description":        "",  # To be implemented
@@ -1042,7 +1050,11 @@ def friend_list_for_api(voter_device_id,
                     one_friend = {
                         "voter_we_vote_id":                 friend_voter.we_vote_id,
                         "voter_display_name":               friend_voter.get_full_name(),
-                        "voter_photo_url":                  friend_voter.voter_photo_url(),
+                        "voter_photo_url_large":            friend_voter.we_vote_hosted_profile_image_url_large
+                            if positive_value_exists(friend_voter.we_vote_hosted_profile_image_url_large)
+                            else friend_voter.voter_photo_url(),
+                        'voter_photo_url_medium':           friend_voter.we_vote_hosted_profile_image_url_medium,
+                        'voter_photo_url_tiny':             friend_voter.we_vote_hosted_profile_image_url_tiny,
                         "voter_email_address":              friend_voter.email,
                         "voter_twitter_handle":             friend_voter.twitter_screen_name,
                         "voter_twitter_description":        "",  # To be implemented
@@ -1079,7 +1091,11 @@ def friend_list_for_api(voter_device_id,
                         one_friend = {
                             "voter_we_vote_id":                 friend_voter.we_vote_id,
                             "voter_display_name":               friend_voter.get_full_name(),
-                            "voter_photo_url":                  friend_voter.voter_photo_url(),
+                            "voter_photo_url_large":            friend_voter.we_vote_hosted_profile_image_url_large
+                                if positive_value_exists (friend_voter.we_vote_hosted_profile_image_url_large)
+                                else friend_voter.voter_photo_url(),
+                            'voter_photo_url_medium':           friend_voter.we_vote_hosted_profile_image_url_medium,
+                            'voter_photo_url_tiny':             friend_voter.we_vote_hosted_profile_image_url_tiny,
                             "voter_email_address":              friend_voter.email,
                             "voter_twitter_handle":             friend_voter.twitter_screen_name,
                             "voter_twitter_description":        "",  # To be implemented
@@ -1096,7 +1112,9 @@ def friend_list_for_api(voter_device_id,
                             one_friend = {
                                 "voter_we_vote_id":                 "",
                                 "voter_display_name":               "",
-                                "voter_photo_url":                  "",
+                                "voter_photo_url_large":            "",
+                                'voter_photo_url_medium':           "",
+                                'voter_photo_url_tiny':             "",
                                 "voter_twitter_handle":             "",
                                 "voter_twitter_description":        "",  # To be implemented
                                 "voter_twitter_followers_count":    0,  # To be implemented
@@ -1117,7 +1135,11 @@ def friend_list_for_api(voter_device_id,
                 one_friend = {
                     "voter_we_vote_id":                 suggested_friend.we_vote_id,
                     "voter_display_name":               suggested_friend.get_full_name(),
-                    "voter_photo_url":                  suggested_friend.voter_photo_url(),
+                    "voter_photo_url_large":            suggested_friend.we_vote_hosted_profile_image_url_large
+                        if positive_value_exists(suggested_friend.we_vote_hosted_profile_image_url_large)
+                        else suggested_friend.voter_photo_url(),
+                    'voter_photo_url_medium':           suggested_friend.we_vote_hosted_profile_image_url_medium,
+                    'voter_photo_url_tiny':             suggested_friend.we_vote_hosted_profile_image_url_tiny,
                     "voter_email_address":              suggested_friend.email,
                     "voter_twitter_handle":             suggested_friend.twitter_screen_name,
                     "voter_twitter_description":        "",  # To be implemented

--- a/image/models.py
+++ b/image/models.py
@@ -290,7 +290,7 @@ class WeVoteImageManager(models.Model):
         }
         return results
 
-    def set_active_version_false_for_other_images(self, candidate_we_vote_id=None,
+    def set_active_version_false_for_other_images(self, voter_we_vote_id=None, candidate_we_vote_id=None,
                                                   organization_we_vote_id=None, twitter_profile_image_url_https=None,
                                                   twitter_profile_background_image_url_https=None,
                                                   twitter_profile_banner_url_https=None,
@@ -320,6 +320,7 @@ class WeVoteImageManager(models.Model):
         try:
             we_vote_image_list = WeVoteImage.objects.all()
             we_vote_image_list = we_vote_image_list.filter(
+                voter_we_vote_id=voter_we_vote_id,
                 candidate_we_vote_id=candidate_we_vote_id, organization_we_vote_id=organization_we_vote_id,
                 is_active_version=True, kind_of_image_twitter_profile=kind_of_image_twitter_profile,
                 kind_of_image_twitter_background=kind_of_image_twitter_background,

--- a/import_export_facebook/controllers.py
+++ b/import_export_facebook/controllers.py
@@ -7,6 +7,8 @@ from email_outbound.models import EmailManager
 from follow.controllers import move_follow_entries_to_another_voter
 from friend.controllers import move_friend_invitations_to_another_voter, move_friends_to_another_voter
 from friend.models import FriendManager
+from image.controllers import FACEBOOK, cache_original_and_resized_image
+from image.models import WeVoteImageManager
 from import_export_facebook.models import FacebookManager
 from organization.controllers import move_organization_to_another_complete
 from organization.models import OrganizationManager
@@ -195,7 +197,7 @@ def facebook_friends_action_for_api(voter_device_id):   # facebookFriendsAction
             'voter_device_id':                  voter_device_id,
             'facebook_friend_suggestion_found': facebook_friend_suggestion_found,
             'facebook_suggested_friend_count':  facebook_suggested_friend_count,
-            'facebook_friend_suggested':        facebook_friend_suggested,
+            'facebook_friends_suggested':       facebook_friend_suggested,
         }
         return error_results
 
@@ -208,10 +210,11 @@ def facebook_friends_action_for_api(voter_device_id):   # facebookFriendsAction
             'voter_device_id':                  voter_device_id,
             'facebook_friend_suggestion_found': facebook_friend_suggestion_found,
             'facebook_suggested_friend_count':  facebook_suggested_friend_count,
-            'facebook_friend_suggested':        facebook_friend_suggested,
+            'facebook_friends_suggested':       facebook_friend_suggested,
         }
         return error_results
 
+    we_vote_image_manager = WeVoteImageManager()
     facebook_friends_from_facebook_results = facebook_manager.retrieve_facebook_friends_from_facebook(voter_device_id)
     facebook_users_list = facebook_friends_from_facebook_results['facebook_users_list']
     status += facebook_friends_from_facebook_results['status']
@@ -219,9 +222,27 @@ def facebook_friends_action_for_api(voter_device_id):   # facebookFriendsAction
     if facebook_friends_from_facebook_results['facebook_friends_list_found']:
         # Update FacebookUser table with all users
         for facebook_user_entry in facebook_users_list:
-            facebook_user_update_results = facebook_manager.create_or_update_facebook_user(facebook_user_entry)
-            status += ' ' + facebook_user_update_results['status']
-            success = facebook_user_update_results['success']
+            facebook_user_id = facebook_user_entry['facebook_user_id']
+            facebook_user_name = facebook_user_entry['facebook_user_name']
+            facebook_user_first_name = facebook_user_entry['facebook_user_first_name']
+            facebook_user_middle_name = facebook_user_entry['facebook_user_middle_name']
+            facebook_user_last_name = facebook_user_entry['facebook_user_last_name']
+            facebook_user_location_id = facebook_user_entry['facebook_user_location_id']
+            facebook_user_location_name = facebook_user_entry['facebook_user_location_name']
+            facebook_user_gender = facebook_user_entry['facebook_user_gender']
+            facebook_user_birthday = facebook_user_entry['facebook_user_birthday']
+            facebook_user_cover_source = facebook_user_entry['facebook_user_cover_source']
+            facebook_user_profile_url_https = facebook_user_entry['facebook_user_profile_url_https']
+            facebook_user_about = facebook_user_entry['facebook_user_about']
+            facebook_user_is_verified = facebook_user_entry['facebook_user_is_verified']
+            facebook_user_friend_total_count = facebook_user_entry['facebook_user_friend_total_count']
+            facebook_user_results = facebook_manager.create_or_update_facebook_user(
+                facebook_user_id, facebook_user_first_name, facebook_user_middle_name, facebook_user_last_name,
+                facebook_user_name, facebook_user_location_id, facebook_user_location_name, facebook_user_gender,
+                facebook_user_birthday, facebook_user_cover_source, facebook_user_profile_url_https,
+                facebook_user_about, facebook_user_is_verified, facebook_user_friend_total_count)
+            status += ' ' + facebook_user_results['status']
+            success = facebook_user_results['success']
 
     # finding facebook_link_to_voter for all users and then updating SuggestedFriend table
     facebook_auth_response = auth_response_results['facebook_auth_response']
@@ -231,6 +252,28 @@ def facebook_friends_action_for_api(voter_device_id):   # facebookFriendsAction
     if my_facebook_link_to_voter_results['facebook_link_to_voter_found']:
         friend_manager = FriendManager()
         viewer_voter_we_vote_id = my_facebook_link_to_voter_results['facebook_link_to_voter'].voter_we_vote_id
+        # Update the facebook user with cached original and resized image urls
+        facebook_user_results = facebook_manager.retrieve_facebook_user_by_facebook_user_id(
+            facebook_auth_response.facebook_user_id)
+        if facebook_user_results['facebook_user_found']:
+            facebook_user = facebook_user_results['facebook_user']
+            # Cache original and resized images
+            cache_results = cache_original_and_resized_image(
+                voter_we_vote_id=viewer_voter_we_vote_id,
+                facebook_user_id=facebook_user.facebook_user_id,
+                facebook_profile_image_url_https=facebook_user.facebook_profile_image_url_https,
+                facebook_background_image_url_https=facebook_user.facebook_background_image_url_https,
+                image_source=FACEBOOK)
+            cached_facebook_profile_image_url_https = cache_results['cached_facebook_profile_image_url_https']
+            cached_facebook_background_image_url_https = cache_results['cached_facebook_background_image_url_https']
+            we_vote_hosted_profile_image_url_large = cache_results['we_vote_hosted_profile_image_url_large']
+            we_vote_hosted_profile_image_url_medium = cache_results['we_vote_hosted_profile_image_url_medium']
+            we_vote_hosted_profile_image_url_tiny = cache_results['we_vote_hosted_profile_image_url_tiny']
+            facebook_user_update_results = facebook_manager.update_facebook_user_details(
+                facebook_user, cached_facebook_profile_image_url_https, cached_facebook_background_image_url_https,
+                we_vote_hosted_profile_image_url_large, we_vote_hosted_profile_image_url_medium,
+                we_vote_hosted_profile_image_url_tiny)
+            status += facebook_user_update_results
         for facebook_user_entry in facebook_users_list:
             facebook_user_link_to_voter_results = facebook_manager.retrieve_facebook_link_to_voter(
                 facebook_user_entry['facebook_user_id'])
@@ -340,6 +383,9 @@ def voter_facebook_sign_in_retrieve_for_api(voter_device_id):  # voterFacebookSi
             'facebook_middle_name':                     "",
             'facebook_last_name':                       "",
             'facebook_profile_image_url_https':         "",
+            'we_vote_hosted_profile_image_url_large':   "",
+            'we_vote_hosted_profile_image_url_medium':  "",
+            'we_vote_hosted_profile_image_url_tiny':    ""
         }
         return error_results
     voter = voter_results['voter']
@@ -372,6 +418,9 @@ def voter_facebook_sign_in_retrieve_for_api(voter_device_id):  # voterFacebookSi
             'facebook_middle_name':                     "",
             'facebook_last_name':                       "",
             'facebook_profile_image_url_https':         "",
+            'we_vote_hosted_profile_image_url_large':   "",
+            'we_vote_hosted_profile_image_url_medium':  "",
+            'we_vote_hosted_profile_image_url_tiny':    ""
         }
         return error_results
 
@@ -401,6 +450,9 @@ def voter_facebook_sign_in_retrieve_for_api(voter_device_id):  # voterFacebookSi
             'facebook_middle_name':                     "",
             'facebook_last_name':                       "",
             'facebook_profile_image_url_https':         "",
+            'we_vote_hosted_profile_image_url_large':   "",
+            'we_vote_hosted_profile_image_url_medium':  "",
+            'we_vote_hosted_profile_image_url_tiny':    ""
         }
         return error_results
 
@@ -530,11 +582,40 @@ def voter_facebook_sign_in_retrieve_for_api(voter_device_id):  # voterFacebookSi
         else:
             voter_we_vote_id_attached_to_facebook_email = ""
 
-    if positive_value_exists(voter_we_vote_id_attached_to_facebook) or \
-            positive_value_exists(voter_we_vote_id_attached_to_facebook_email):
+    if positive_value_exists(voter_we_vote_id_attached_to_facebook):
         existing_facebook_account_found = True
+        voter_we_vote_id_for_cache = voter_we_vote_id_attached_to_facebook
+    elif positive_value_exists(voter_we_vote_id_attached_to_facebook_email):
+        existing_facebook_account_found = True
+        voter_we_vote_id_for_cache = voter_we_vote_id_attached_to_facebook_email
     else:
         existing_facebook_account_found = False
+        voter_we_vote_id_for_cache = voter_we_vote_id
+
+    # Cache original and resized images
+    cache_results = cache_original_and_resized_image(
+        voter_we_vote_id=voter_we_vote_id_for_cache,
+        facebook_user_id=facebook_auth_response.facebook_user_id,
+        facebook_profile_image_url_https=facebook_auth_response.facebook_profile_image_url_https,
+        image_source=FACEBOOK)
+    cached_facebook_profile_image_url_https = cache_results['cached_facebook_profile_image_url_https']
+    we_vote_hosted_profile_image_url_large = cache_results['we_vote_hosted_profile_image_url_large']
+    we_vote_hosted_profile_image_url_medium = cache_results['we_vote_hosted_profile_image_url_medium']
+    we_vote_hosted_profile_image_url_tiny = cache_results['we_vote_hosted_profile_image_url_tiny']
+
+    if positive_value_exists(cached_facebook_profile_image_url_https):
+        facebook_profile_image_url_https = cached_facebook_profile_image_url_https
+    else:
+        facebook_profile_image_url_https = facebook_auth_response.facebook_profile_image_url_https
+
+    facebook_user_results = facebook_manager.create_or_update_facebook_user(
+        facebook_auth_response.facebook_user_id, facebook_auth_response.facebook_first_name,
+        facebook_auth_response.facebook_middle_name, facebook_auth_response.facebook_last_name,
+        facebook_user_profile_url_https=facebook_profile_image_url_https,
+        we_vote_hosted_profile_image_url_large=we_vote_hosted_profile_image_url_large,
+        we_vote_hosted_profile_image_url_medium=we_vote_hosted_profile_image_url_medium,
+        we_vote_hosted_profile_image_url_tiny=we_vote_hosted_profile_image_url_tiny)
+    status += facebook_user_results['status']
 
     json_data = {
         'success':                                  success,
@@ -556,7 +637,10 @@ def voter_facebook_sign_in_retrieve_for_api(voter_device_id):  # voterFacebookSi
         'facebook_first_name':                      facebook_auth_response.facebook_first_name,
         'facebook_middle_name':                     facebook_auth_response.facebook_middle_name,
         'facebook_last_name':                       facebook_auth_response.facebook_last_name,
-        'facebook_profile_image_url_https':         facebook_auth_response.facebook_profile_image_url_https,
+        'facebook_profile_image_url_https':         facebook_profile_image_url_https,
+        'we_vote_hosted_profile_image_url_large':   we_vote_hosted_profile_image_url_large,
+        'we_vote_hosted_profile_image_url_medium':  we_vote_hosted_profile_image_url_medium,
+        'we_vote_hosted_profile_image_url_tiny':    we_vote_hosted_profile_image_url_tiny
     }
     return json_data
 

--- a/import_export_facebook/models.py
+++ b/import_export_facebook/models.py
@@ -105,7 +105,15 @@ class FacebookUser(models.Model):
         verbose_name="User's birthday from Facebook", max_length=255, null=True, blank=True, unique=False)
     facebook_user_last_name = models.CharField(
         verbose_name="User's last_name from Facebook", max_length=255, null=True, blank=True, unique=False)
-    facebook_user_cover_source = models.URLField(verbose_name='url of cover image from facebook', blank=True, null=True)
+    facebook_background_image_url_https = models.URLField(verbose_name='url of cover image from facebook', blank=True, null=True)
+    facebook_profile_image_url_https = models.URLField(verbose_name='url of cover image from facebook',
+                                                      blank=True, null=True)
+    we_vote_hosted_profile_image_url_large = models.URLField(verbose_name='we vote hosted large image url',
+                                                             blank=True, null=True)
+    we_vote_hosted_profile_image_url_medium = models.URLField(verbose_name='we vote hosted medium image url',
+                                                              blank=True, null=True)
+    we_vote_hosted_profile_image_url_tiny = models.URLField(verbose_name='we vote hosted tiny image url',
+                                                            blank=True, null=True)
     facebook_user_about = models.CharField(
         verbose_name="User's About from Facebook", max_length=255, null=True, blank=True, unique=False)
     facebook_user_is_verified = models.BooleanField(
@@ -240,41 +248,69 @@ class FacebookManager(models.Model):
             }
         return results
 
-    def create_or_update_facebook_user(self, facebook_user_entry):
+    def create_or_update_facebook_user(self, facebook_user_id, facebook_user_first_name, facebook_user_middle_name,
+                                       facebook_user_last_name, facebook_user_name=None, facebook_user_location_id=None,
+                                       facebook_user_location_name=None, facebook_user_gender=None,
+                                       facebook_user_birthday=None, facebook_user_cover_source=None,
+                                       facebook_user_profile_url_https=None, facebook_user_about=None,
+                                       facebook_user_is_verified=False, facebook_user_friend_total_count=None,
+                                       we_vote_hosted_profile_image_url_large=None,
+                                       we_vote_hosted_profile_image_url_medium=None,
+                                       we_vote_hosted_profile_image_url_tiny=None):
         """
         We use this subroutine to create or update FacebookUser table with my friends details.
-        :param facebook_users:
+        :param facebook_user_id:
+        :param facebook_user_name:
+        :param facebook_user_first_name:
+        :param facebook_user_middle_name:
+        :param facebook_user_last_name:
+        :param facebook_user_location_id:
+        :param facebook_user_location_name:
+        :param facebook_user_gender:
+        :param facebook_user_birthday:
+        :param facebook_user_cover_source:
+        :param facebook_user_profile_url_https:
+        :param facebook_user_about:
+        :param facebook_user_is_verified:
+        :param facebook_user_friend_total_count:
+        :param we_vote_hosted_profile_image_url_large:
+        :param we_vote_hosted_profile_image_url_medium:
+        :param we_vote_hosted_profile_image_url_tiny
         :return:
         """
         facebook_user = FacebookUser()
         try:
             # for facebook_user_entry in facebook_users:
             facebook_user, created = FacebookUser.objects.update_or_create(
-                facebook_user_id=facebook_user_entry['facebook_user_id'],
+                facebook_user_id=facebook_user_id,
                 defaults={
-                    'facebook_user_id':                 facebook_user_entry['facebook_user_id'],
-                    'facebook_user_name':               facebook_user_entry['facebook_user_name'],
-                    'facebook_user_first_name':         facebook_user_entry['facebook_user_first_name'],
-                    'facebook_user_middle_name':        facebook_user_entry['facebook_user_middle_name'],
-                    'facebook_user_last_name':          facebook_user_entry['facebook_user_last_name'],
-                    'facebook_user_location_id':        facebook_user_entry['facebook_user_location_id'],
-                    'facebook_user_location_name':      facebook_user_entry['facebook_user_location_name'],
-                    'facebook_user_gender':             facebook_user_entry['facebook_user_gender'],
-                    'facebook_user_birthday':           facebook_user_entry['facebook_user_birthday'],
-                    'facebook_user_cover_source':       facebook_user_entry['facebook_user_cover_source'],
-                    'facebook_user_about':              facebook_user_entry['facebook_user_about'],
-                    'facebook_user_is_verified':        facebook_user_entry['facebook_user_is_verified'],
-                    'facebook_user_friend_total_count': facebook_user_entry['facebook_user_friend_total_count'],
+                    'facebook_user_id':                         facebook_user_id,
+                    'facebook_user_name':                       facebook_user_name,
+                    'facebook_user_first_name':                 facebook_user_first_name,
+                    'facebook_user_middle_name':                facebook_user_middle_name,
+                    'facebook_user_last_name':                  facebook_user_last_name,
+                    'facebook_user_location_id':                facebook_user_location_id,
+                    'facebook_user_location_name':              facebook_user_location_name,
+                    'facebook_user_gender':                     facebook_user_gender,
+                    'facebook_user_birthday':                   facebook_user_birthday,
+                    'facebook_background_image_url_https':      facebook_user_cover_source,
+                    'facebook_profile_image_url_https':         facebook_user_profile_url_https,
+                    'facebook_user_about':                      facebook_user_about,
+                    'facebook_user_is_verified':                facebook_user_is_verified,
+                    'facebook_user_friend_total_count':         facebook_user_friend_total_count,
+                    'we_vote_hosted_profile_image_url_large':   we_vote_hosted_profile_image_url_large,
+                    'we_vote_hosted_profile_image_url_medium':  we_vote_hosted_profile_image_url_medium,
+                    'we_vote_hosted_profile_image_url_tiny':    we_vote_hosted_profile_image_url_tiny
                 }
             )
             facebook_user_saved = True
             success = True
-            status = "FACEBOOK_USERS_CREATED"
+            status = " FACEBOOK_USER_CREATED"
         except Exception as e:
             facebook_user_saved = False
             facebook_user = FacebookUser()
             success = False
-            status = "FACEBOOK_USERS_NOT_CREATED"
+            status = " FACEBOOK_USER_NOT_CREATED"
         results = {
             'success':              success,
             'status':               status,
@@ -282,6 +318,52 @@ class FacebookManager(models.Model):
             'facebook_user':        facebook_user,
             }
         return results
+
+    def update_facebook_user_details(self, facebook_user,
+                                     cached_facebook_profile_image_url_https=False,
+                                     cached_facebook_background_image_url_https=False,
+                                     we_vote_hosted_profile_image_url_large=False,
+                                     we_vote_hosted_profile_image_url_medium=False,
+                                     we_vote_hosted_profile_image_url_tiny=False):
+        """
+        Update an facebook user entry with cached image urls
+        """
+        success = False
+        status = "ENTERING_UPDATE_FACEBOOK_USER_DETAILS"
+        values_changed = False
+
+        if facebook_user:
+            if positive_value_exists(cached_facebook_profile_image_url_https):
+                facebook_user.facebook_profile_image_url_https = cached_facebook_profile_image_url_https
+                values_changed = True
+            if positive_value_exists(cached_facebook_background_image_url_https):
+                facebook_user.facebook_background_image_url_https = cached_facebook_background_image_url_https
+                values_changed = True
+            if positive_value_exists(we_vote_hosted_profile_image_url_large):
+                facebook_user.we_vote_hosted_profile_image_url_large = we_vote_hosted_profile_image_url_large
+                values_changed = True
+            if positive_value_exists(we_vote_hosted_profile_image_url_medium):
+                facebook_user.we_vote_hosted_profile_image_url_medium = we_vote_hosted_profile_image_url_medium
+                values_changed = True
+            if positive_value_exists(we_vote_hosted_profile_image_url_tiny):
+                facebook_user.we_vote_hosted_profile_image_url_tiny = we_vote_hosted_profile_image_url_tiny
+                values_changed = True
+
+            if values_changed:
+                facebook_user.save()
+                success = True
+                status = "SAVED_FACEBOOK_USER_DETAILS"
+            else:
+                success = True
+                status = "NO_CHANGES_SAVED_TO_FACBOOK_USER_DETAILS"
+
+        results = {
+            'success':                  success,
+            'status':                   status,
+            'facebook_user':             facebook_user,
+        }
+        return results
+
 
     def retrieve_facebook_auth_response(self, voter_device_id):
         """
@@ -475,6 +557,9 @@ class FacebookManager(models.Model):
         facebook_friend_dict['facebook_user_cover_source'] = (facebook_friend_api_details_entry.get('cover').get(
             'source') if 'cover' in facebook_friend_api_details_entry.keys() and facebook_friend_api_details_entry.get(
             'cover', {}).get('source', {}) else "")
+        facebook_friend_dict['facebook_user_profile_url_https'] = (facebook_friend_api_details_entry.get('picture').get(
+            'data').get('url') if 'picture' in facebook_friend_api_details_entry.keys() and
+            facebook_friend_api_details_entry.get('picture', {}).get('data', {}).get('url', {}) else "")
         facebook_friend_dict['facebook_user_about'] = (facebook_friend_api_details_entry.get('about')
                                                        if 'about' in facebook_friend_api_details_entry.keys() else "")
         facebook_friend_dict['facebook_user_is_verified'] = (facebook_friend_api_details_entry.get('is_verified')
@@ -494,8 +579,9 @@ class FacebookManager(models.Model):
         facebook_users_list = []
         # required fields need to be updated in FacebookUser table
         facebook_api_fields = "id, name, first_name, middle_name, last_name, location{id, name}, gender, birthday, " \
-                              "cover{source}, about, is_verified, friends{id, name, first_name, middle_name, " \
-                              "last_name, location{id, name}, gender, birthday, cover{source}, about, is_verified} "
+                              "cover{source}, picture.width(200).height(200){url}, about, is_verified, " \
+                              "friends{id, name, first_name, middle_name, last_name, location{id, name}, gender, " \
+                              "birthday, cover{source}, picture.width(200).height(200){url}, about, is_verified} "
         auth_response_results = self.retrieve_facebook_auth_response(voter_device_id)
         if not auth_response_results['facebook_auth_response_found']:
             error_results = {
@@ -510,7 +596,8 @@ class FacebookManager(models.Model):
         try:
             facebook_graph = facebook.GraphAPI(facebook_auth_response.facebook_access_token, version='2.7')
             facebook_friends_api_details = facebook_graph.get_connections(id=facebook_auth_response.facebook_user_id,
-                                                                 connection_name="friends", fields=facebook_api_fields)
+                                                                          connection_name="friends",
+                                                                          fields=facebook_api_fields)
 
             # graph.get_connections returns three dictionary keys i.e. data, paging, summary,
             # here data key contains list of friends with the given fields values and paging contains cursors positions
@@ -638,7 +725,7 @@ class FacebookManager(models.Model):
         results = {
             'success':                     success,
             'status':                      status,
-            'facebook_user_found':          facebook_user_found,
-            'facebook_user':                facebook_user,
+            'facebook_user_found':         facebook_user_found,
+            'facebook_user':               facebook_user,
         }
         return results

--- a/organization/controllers.py
+++ b/organization/controllers.py
@@ -376,9 +376,12 @@ def organizations_followed_retrieve_for_api(voter_device_id, maximum_number_to_r
                     organization.organization_email if positive_value_exists(organization.organization_email) else '',
                 'organization_facebook': organization.organization_facebook
                     if positive_value_exists(organization.organization_facebook) else '',
-                'organization_photo_url': organization.organization_photo_url()
-                    if positive_value_exists(organization.organization_photo_url()) else '',
-          }
+                'organization_photo_url_large': organization.we_vote_hosted_profile_image_url_large
+                    if positive_value_exists(organization.we_vote_hosted_profile_image_url_large)
+                    else organization.organization_photo_url(),
+                'organization_photo_url_medium': organization.we_vote_hosted_profile_image_url_medium,
+                'organization_photo_url_tiny': organization.we_vote_hosted_profile_image_url_tiny,
+            }
             organizations_for_api.append(one_organization.copy())
             if positive_value_exists(maximum_number_to_retrieve):
                 number_added_to_list += 1
@@ -688,19 +691,21 @@ def organization_retrieve_for_api(organization_id, organization_we_vote_id):  # 
     we_vote_id = organization_we_vote_id.strip().lower()
     if not positive_value_exists(organization_id) and not positive_value_exists(organization_we_vote_id):
         json_data = {
-            'status':                       "ORGANIZATION_RETRIEVE_BOTH_IDS_MISSING",
-            'success':                      False,
-            'organization_id':              organization_id,
-            'organization_we_vote_id':      organization_we_vote_id,
-            'organization_name':            '',
-            'organization_email':           '',
-            'organization_website':         '',
-            'organization_twitter_handle':  '',
-            'twitter_description':          '',
-            'twitter_followers_count':      '',
-            'facebook_id':                  0,
-            'organization_facebook':        '',
-            'organization_photo_url':       '',
+            'status':                           "ORGANIZATION_RETRIEVE_BOTH_IDS_MISSING",
+            'success':                          False,
+            'organization_id':                  organization_id,
+            'organization_we_vote_id':          organization_we_vote_id,
+            'organization_name':                '',
+            'organization_email':               '',
+            'organization_website':             '',
+            'organization_twitter_handle':      '',
+            'twitter_description':              '',
+            'twitter_followers_count':          '',
+            'facebook_id':                      0,
+            'organization_facebook':            '',
+            'organization_photo_url_large':     '',
+            'organization_photo_url_medium':    '',
+            'organization_photo_url_tiny':      '',
         }
         return HttpResponse(json.dumps(json_data), content_type='application/json')
 
@@ -740,25 +745,30 @@ def organization_retrieve_for_api(organization_id, organization_we_vote_id):  # 
                 organization.organization_facebook if positive_value_exists(organization.organization_facebook) else '',
             'facebook_id':
                 organization.facebook_id if positive_value_exists(organization.facebook_id) else 0,
-            'organization_photo_url': organization.organization_photo_url()
-                if positive_value_exists(organization.organization_photo_url()) else '',
+            'organization_photo_url_large': organization.we_vote_hosted_profile_image_url_large
+                if positive_value_exists(organization.we_vote_hosted_profile_image_url_large)
+                else organization.organization_photo_url(),
+            'organization_photo_url_medium': organization.we_vote_hosted_profile_image_url_medium,
+            'organization_photo_url_tiny':  organization.we_vote_hosted_profile_image_url_tiny,
         }
         return HttpResponse(json.dumps(json_data), content_type='application/json')
     else:
         json_data = {
-            'status':                       results['status'],
-            'success':                      False,
-            'organization_id':              organization_id,
-            'organization_we_vote_id':      we_vote_id,
-            'organization_name':            '',
-            'organization_email':           '',
-            'organization_website':         '',
-            'organization_twitter_handle':  '',
-            'twitter_description':          '',
-            'twitter_followers_count':      '',
-            'organization_facebook':        '',
-            'facebook_id':                  0,
-            'organization_photo_url':       '',
+            'status':                           results['status'],
+            'success':                          False,
+            'organization_id':                  organization_id,
+            'organization_we_vote_id':          we_vote_id,
+            'organization_name':                '',
+            'organization_email':               '',
+            'organization_website':             '',
+            'organization_twitter_handle':      '',
+            'twitter_description':              '',
+            'twitter_followers_count':          '',
+            'organization_facebook':            '',
+            'facebook_id':                      0,
+            'organization_photo_url_large':     '',
+            'organization_photo_url_medium':    '',
+            'organization_photo_url_tiny':      '',
         }
         return HttpResponse(json.dumps(json_data), content_type='application/json')
 

--- a/position/controllers.py
+++ b/position/controllers.py
@@ -594,13 +594,15 @@ def position_retrieve_for_api(position_we_vote_id, voter_device_id):  # position
     we_vote_id = position_we_vote_id.strip().lower()
     if not positive_value_exists(position_we_vote_id):
         json_data = {
-            'status':                   "POSITION_RETRIEVE_BOTH_IDS_MISSING",
-            'success':                  False,
-            'position_we_vote_id':      position_we_vote_id,
-            'ballot_item_display_name': '',
-            'speaker_display_name':     '',
-            'speaker_image_url_https':  '',
-            'speaker_twitter_handle':   '',
+            'status':                           "POSITION_RETRIEVE_BOTH_IDS_MISSING",
+            'success':                          False,
+            'position_we_vote_id':              position_we_vote_id,
+            'ballot_item_display_name':         '',
+            'speaker_display_name':             '',
+            'speaker_image_url_https_large':    '',
+            'speaker_image_url_https_medium':   '',
+            'speaker_image_url_https_tiny':     '',
+            'speaker_twitter_handle':           '',
             'is_support':                       False,
             'is_positive_rating':               False,
             'is_support_or_positive_rating':    False,
@@ -638,13 +640,17 @@ def position_retrieve_for_api(position_we_vote_id, voter_device_id):  # position
     if results['position_found']:
         position = results['position']
         json_data = {
-            'success':                  True,
-            'status':                   results['status'],
-            'position_we_vote_id':      position.we_vote_id,
-            'ballot_item_display_name': position.ballot_item_display_name,
-            'speaker_display_name':     position.speaker_display_name,
-            'speaker_image_url_https':  position.speaker_image_url_https,
-            'speaker_twitter_handle':   position.speaker_twitter_handle,
+            'success':                          True,
+            'status':                           results['status'],
+            'position_we_vote_id':              position.we_vote_id,
+            'ballot_item_display_name':         position.ballot_item_display_name,
+            'speaker_display_name':             position.speaker_display_name,
+            'speaker_image_url_https_large':    position.speaker_image_url_https_large
+                if positive_value_exists(position.speaker_image_url_https_large)
+                else position.speaker_image_url_https,
+            'speaker_image_url_https_medium':   position.speaker_image_url_https_medium,
+            'speaker_image_url_https_tiny':     position.speaker_image_url_https_tiny,
+            'speaker_twitter_handle':           position.speaker_twitter_handle,
             'is_support':                       results['is_support'],
             'is_positive_rating':               results['is_positive_rating'],
             'is_support_or_positive_rating':    results['is_support_or_positive_rating'],
@@ -669,13 +675,15 @@ def position_retrieve_for_api(position_we_vote_id, voter_device_id):  # position
         return HttpResponse(json.dumps(json_data), content_type='application/json')
     else:
         json_data = {
-            'status':                   results['status'],
-            'success':                  results['success'],
-            'position_we_vote_id':      we_vote_id,
-            'ballot_item_display_name': '',
-            'speaker_display_name':     '',
-            'speaker_image_url_https':  '',
-            'speaker_twitter_handle':   '',
+            'status':                           results['status'],
+            'success':                          results['success'],
+            'position_we_vote_id':              we_vote_id,
+            'ballot_item_display_name':         '',
+            'speaker_display_name':             '',
+            'speaker_image_url_https_large':    '',
+            'speaker_image_url_https_medium':   '',
+            'speaker_image_url_https_tiny':     '',
+            'speaker_twitter_handle':           '',
             'is_support':                       False,
             'is_positive_rating':               False,
             'is_support_or_positive_rating':    False,
@@ -1207,7 +1215,11 @@ def position_list_for_ballot_item_for_api(voter_device_id, friends_vs_public,  #
                 'position_we_vote_id':              one_position.we_vote_id,
                 'ballot_item_display_name':         one_position.ballot_item_display_name,
                 'speaker_display_name':             speaker_display_name,
-                'speaker_image_url_https':          one_position.speaker_image_url_https,
+                'speaker_image_url_https_large':    one_position.speaker_image_url_https_large
+                    if positive_value_exists(one_position.speaker_image_url_https_large)
+                    else one_position.speaker_image_url_https,
+                'speaker_image_url_https_medium':   one_position.speaker_image_url_https_medium,
+                'speaker_image_url_https_tiny':     one_position.speaker_image_url_https_tiny,
                 'speaker_twitter_handle':           one_position.speaker_twitter_handle,
                 'speaker_type':                     speaker_type,
                 'speaker_id':                       speaker_id,
@@ -1256,7 +1268,9 @@ def position_list_for_opinion_maker_for_api(voter_device_id,  # positionListForO
     is_following = False
     is_ignoring = False
     opinion_maker_display_name = ''
-    opinion_maker_image_url_https = ''
+    opinion_maker_image_url_https_large = ''
+    opinion_maker_image_url_https_medium = ''
+    opinion_maker_image_url_https_tiny = ''
     status = ''
     position_list_raw = []
 
@@ -1283,22 +1297,24 @@ def position_list_for_opinion_maker_for_api(voter_device_id,  # positionListForO
     if not results['success']:
         position_list = []
         json_data = {
-            'status':                           'VALID_VOTER_DEVICE_ID_MISSING_OPINION_MAKER_POSITION_LIST',
-            'success':                          False,
-            'count':                            0,
-            'kind_of_opinion_maker':            kind_of_opinion_maker_text,
-            'opinion_maker_id':                 opinion_maker_id,
-            'opinion_maker_we_vote_id':         opinion_maker_we_vote_id,
-            'opinion_maker_display_name':       opinion_maker_display_name,
-            'opinion_maker_image_url_https':    opinion_maker_image_url_https,
-            'is_following':                     is_following,
-            'is_ignoring':                      is_ignoring,
-            'google_civic_election_id':         google_civic_election_id,
-            'state_code':                       state_code,
-            'position_list':                    position_list,
-            'filter_for_voter':                 filter_for_voter,
-            'filter_out_voter':                 filter_out_voter,
-            'friends_vs_public':                friends_vs_public,
+            'status':                               'VALID_VOTER_DEVICE_ID_MISSING_OPINION_MAKER_POSITION_LIST',
+            'success':                              False,
+            'count':                                0,
+            'kind_of_opinion_maker':                kind_of_opinion_maker_text,
+            'opinion_maker_id':                     opinion_maker_id,
+            'opinion_maker_we_vote_id':             opinion_maker_we_vote_id,
+            'opinion_maker_display_name':           opinion_maker_display_name,
+            'opinion_maker_image_url_https_large':  opinion_maker_image_url_https_large,
+            'opinion_maker_image_url_https_medium': opinion_maker_image_url_https_medium,
+            'opinion_maker_image_url_https_tiny':   opinion_maker_image_url_https_tiny,
+            'is_following':                         is_following,
+            'is_ignoring':                          is_ignoring,
+            'google_civic_election_id':             google_civic_election_id,
+            'state_code':                           state_code,
+            'position_list':                        position_list,
+            'filter_for_voter':                     filter_for_voter,
+            'filter_out_voter':                     filter_out_voter,
+            'friends_vs_public':                    friends_vs_public,
         }
         return HttpResponse(json.dumps(json_data), content_type='application/json')
 
@@ -1306,22 +1322,24 @@ def position_list_for_opinion_maker_for_api(voter_device_id,  # positionListForO
     if not positive_value_exists(voter_id):
         position_list = []
         json_data = {
-            'status':                           "VALID_VOTER_ID_MISSING_OPINION_MAKER_POSITION_LIST ",
-            'success':                          False,
-            'count':                            0,
-            'kind_of_opinion_maker':            kind_of_opinion_maker_text,
-            'opinion_maker_id':                 opinion_maker_id,
-            'opinion_maker_we_vote_id':         opinion_maker_we_vote_id,
-            'opinion_maker_display_name':       opinion_maker_display_name,
-            'opinion_maker_image_url_https':    opinion_maker_image_url_https,
-            'is_following':                     is_following,
-            'is_ignoring':                      is_ignoring,
-            'google_civic_election_id':         google_civic_election_id,
-            'state_code':                       state_code,
-            'position_list':                    position_list,
-            'filter_for_voter':                 filter_for_voter,
-            'filter_out_voter':                 filter_out_voter,
-            'friends_vs_public':                friends_vs_public,
+            'status':                               "VALID_VOTER_ID_MISSING_OPINION_MAKER_POSITION_LIST ",
+            'success':                              False,
+            'count':                                0,
+            'kind_of_opinion_maker':                kind_of_opinion_maker_text,
+            'opinion_maker_id':                     opinion_maker_id,
+            'opinion_maker_we_vote_id':             opinion_maker_we_vote_id,
+            'opinion_maker_display_name':           opinion_maker_display_name,
+            'opinion_maker_image_url_https_large':  opinion_maker_image_url_https_large,
+            'opinion_maker_image_url_https_medium': opinion_maker_image_url_https_medium,
+            'opinion_maker_image_url_https_tiny':   opinion_maker_image_url_https_tiny,
+            'is_following':                         is_following,
+            'is_ignoring':                          is_ignoring,
+            'google_civic_election_id':             google_civic_election_id,
+            'state_code':                           state_code,
+            'position_list':                        position_list,
+            'filter_for_voter':                     filter_for_voter,
+            'filter_out_voter':                     filter_out_voter,
+            'friends_vs_public':                    friends_vs_public,
         }
         return HttpResponse(json.dumps(json_data), content_type='application/json')
 
@@ -1342,7 +1360,11 @@ def position_list_for_opinion_maker_for_api(voter_device_id,  # positionListForO
             opinion_maker_id = organization.id
             opinion_maker_we_vote_id = organization.we_vote_id
             opinion_maker_display_name = organization.organization_name
-            opinion_maker_image_url_https = organization.organization_photo_url()
+            opinion_maker_image_url_https_large = organization.we_vote_hosted_profile_image_url_large \
+                if positive_value_exists(organization.we_vote_hosted_profile_image_url_large) \
+                else organization.organization_photo_url()
+            opinion_maker_image_url_https_medium = organization.we_vote_hosted_profile_image_url_medium
+            opinion_maker_image_url_https_tiny = organization.we_vote_hosted_profile_image_url_tiny
             opinion_maker_found = True
 
             follow_organization_manager = FollowOrganizationManager()
@@ -1386,44 +1408,48 @@ def position_list_for_opinion_maker_for_api(voter_device_id,  # positionListForO
     else:
         position_list = []
         json_data = {
-            'status':                           'POSITION_LIST_RETRIEVE_MISSING_OPINION_MAKER_ID',
-            'success':                          False,
-            'count':                            0,
-            'kind_of_opinion_maker':            kind_of_opinion_maker_text,
-            'opinion_maker_id':                 opinion_maker_id,
-            'opinion_maker_we_vote_id':         opinion_maker_we_vote_id,
-            'opinion_maker_display_name':       opinion_maker_display_name,
-            'opinion_maker_image_url_https':    opinion_maker_image_url_https,
-            'is_following':                     is_following,
-            'is_ignoring':                      is_ignoring,
-            'google_civic_election_id':         google_civic_election_id,
-            'state_code':                       state_code,
-            'position_list':                    position_list,
-            'filter_for_voter':                 filter_for_voter,
-            'filter_out_voter':                 filter_out_voter,
-            'friends_vs_public':                friends_vs_public,
+            'status':                               'POSITION_LIST_RETRIEVE_MISSING_OPINION_MAKER_ID',
+            'success':                              False,
+            'count':                                0,
+            'kind_of_opinion_maker':                kind_of_opinion_maker_text,
+            'opinion_maker_id':                     opinion_maker_id,
+            'opinion_maker_we_vote_id':             opinion_maker_we_vote_id,
+            'opinion_maker_display_name':           opinion_maker_display_name,
+            'opinion_maker_image_url_https_large':  opinion_maker_image_url_https_large,
+            'opinion_maker_image_url_https_medium': opinion_maker_image_url_https_medium,
+            'opinion_maker_image_url_https_tiny':   opinion_maker_image_url_https_tiny,
+            'is_following':                         is_following,
+            'is_ignoring':                          is_ignoring,
+            'google_civic_election_id':             google_civic_election_id,
+            'state_code':                           state_code,
+            'position_list':                        position_list,
+            'filter_for_voter':                     filter_for_voter,
+            'filter_out_voter':                     filter_out_voter,
+            'friends_vs_public':                    friends_vs_public,
         }
         return HttpResponse(json.dumps(json_data), content_type='application/json')
 
     if not opinion_maker_found:
         position_list = []
         json_data = {
-            'status':                           'POSITION_LIST_RETRIEVE_OPINION_MAKER_NOT_FOUND',
-            'success':                          False,
-            'count':                            0,
-            'kind_of_opinion_maker':            kind_of_opinion_maker_text,
-            'opinion_maker_id':                 opinion_maker_id,
-            'opinion_maker_we_vote_id':         opinion_maker_we_vote_id,
-            'opinion_maker_display_name':       opinion_maker_display_name,
-            'opinion_maker_image_url_https':    opinion_maker_image_url_https,
-            'is_following':                     is_following,
-            'is_ignoring':                      is_ignoring,
-            'google_civic_election_id':         google_civic_election_id,
-            'state_code':                       state_code,
-            'position_list':                    position_list,
-            'filter_for_voter':                 filter_for_voter,
-            'filter_out_voter':                 filter_out_voter,
-            'friends_vs_public':                friends_vs_public,
+            'status':                               'POSITION_LIST_RETRIEVE_OPINION_MAKER_NOT_FOUND',
+            'success':                              False,
+            'count':                                0,
+            'kind_of_opinion_maker':                kind_of_opinion_maker_text,
+            'opinion_maker_id':                     opinion_maker_id,
+            'opinion_maker_we_vote_id':             opinion_maker_we_vote_id,
+            'opinion_maker_display_name':           opinion_maker_display_name,
+            'opinion_maker_image_url_https_large':  opinion_maker_image_url_https_large,
+            'opinion_maker_image_url_https_medium': opinion_maker_image_url_https_medium,
+            'opinion_maker_image_url_https_tiny':   opinion_maker_image_url_https_tiny,
+            'is_following':                         is_following,
+            'is_ignoring':                          is_ignoring,
+            'google_civic_election_id':             google_civic_election_id,
+            'state_code':                           state_code,
+            'position_list':                        position_list,
+            'filter_for_voter':                     filter_for_voter,
+            'filter_out_voter':                     filter_out_voter,
+            'friends_vs_public':                    friends_vs_public,
         }
         return HttpResponse(json.dumps(json_data), content_type='application/json')
 
@@ -1472,35 +1498,39 @@ def position_list_for_opinion_maker_for_api(voter_device_id,  # positionListForO
                     or missing_office_information:
                 one_position = position_manager.refresh_cached_position_info(one_position, force_update)
             one_position_dict_for_api = {
-                'position_we_vote_id':          one_position.we_vote_id,
+                'position_we_vote_id':                  one_position.we_vote_id,
                 'ballot_item_display_name':
                     one_position.ballot_item_display_name
                     if positive_value_exists(one_position.ballot_item_display_name) else "",  # Candidate or Measure
-                'ballot_item_image_url_https':  one_position.ballot_item_image_url_https,
-                'ballot_item_twitter_handle':   one_position.ballot_item_twitter_handle,
-                'ballot_item_political_party':  one_position.political_party,
-                'kind_of_ballot_item':          kind_of_ballot_item,
-                'ballot_item_id':               ballot_item_id,
-                'ballot_item_we_vote_id':       ballot_item_we_vote_id,
-                'ballot_item_state_code':       one_position.state_code,
-                'contest_office_id':            one_position.contest_office_id,
-                'contest_office_we_vote_id':    one_position.contest_office_we_vote_id,
-                'contest_office_name':          one_position.contest_office_name,
-                'is_support':                       one_position.is_support(),
-                'is_positive_rating':               one_position.is_positive_rating(),
-                'is_support_or_positive_rating':    one_position.is_support_or_positive_rating(),
-                'is_oppose':                        one_position.is_oppose(),
-                'is_negative_rating':               one_position.is_negative_rating(),
-                'is_oppose_or_negative_rating':     one_position.is_oppose_or_negative_rating(),
-                'is_information_only':              one_position.is_information_only(),
-                'is_public_position':           one_position.is_public_position,
-                'speaker_display_name':         one_position.speaker_display_name,  # Organization name
-                'vote_smart_rating':            one_position.vote_smart_rating,
-                'vote_smart_time_span':         one_position.vote_smart_time_span,
-                'google_civic_election_id':     one_position.google_civic_election_id,
-                'more_info_url':                one_position.more_info_url,
-                'statement_text':               one_position.statement_text,
-                'last_updated':                 one_position.last_updated(),
+                'ballot_item_image_url_https_large':    one_position.ballot_item_image_url_https_large
+                    if positive_value_exists(one_position.ballot_item_image_url_https_large)
+                    else one_position.ballot_item_image_url_https,
+                'ballot_item_image_url_https_medium':   one_position.ballot_item_image_url_https_medium,
+                'ballot_item_image_url_https_tiny':     one_position.ballot_item_image_url_https_tiny,
+                'ballot_item_twitter_handle':           one_position.ballot_item_twitter_handle,
+                'ballot_item_political_party':          one_position.political_party,
+                'kind_of_ballot_item':                  kind_of_ballot_item,
+                'ballot_item_id':                       ballot_item_id,
+                'ballot_item_we_vote_id':               ballot_item_we_vote_id,
+                'ballot_item_state_code':               one_position.state_code,
+                'contest_office_id':                    one_position.contest_office_id,
+                'contest_office_we_vote_id':            one_position.contest_office_we_vote_id,
+                'contest_office_name':                  one_position.contest_office_name,
+                'is_support':                           one_position.is_support(),
+                'is_positive_rating':                   one_position.is_positive_rating(),
+                'is_support_or_positive_rating':        one_position.is_support_or_positive_rating(),
+                'is_oppose':                            one_position.is_oppose(),
+                'is_negative_rating':                   one_position.is_negative_rating(),
+                'is_oppose_or_negative_rating':         one_position.is_oppose_or_negative_rating(),
+                'is_information_only':                  one_position.is_information_only(),
+                'is_public_position':                   one_position.is_public_position,
+                'speaker_display_name':                 one_position.speaker_display_name,  # Organization name
+                'vote_smart_rating':                    one_position.vote_smart_rating,
+                'vote_smart_time_span':                 one_position.vote_smart_time_span,
+                'google_civic_election_id':             one_position.google_civic_election_id,
+                'more_info_url':                        one_position.more_info_url,
+                'statement_text':                       one_position.statement_text,
+                'last_updated':                         one_position.last_updated(),
             }
             position_list.append(one_position_dict_for_api)
 
@@ -1526,22 +1556,24 @@ def position_list_for_opinion_maker_for_api(voter_device_id,  # positionListForO
     status += ' POSITION_LIST_FOR_OPINION_MAKER_SUCCEEDED'
     success = True
     json_data = {
-        'status':                           status,
-        'success':                          success,
-        'count':                            len(position_list),
-        'kind_of_opinion_maker':            kind_of_opinion_maker_text,
-        'opinion_maker_id':                 opinion_maker_id,
-        'opinion_maker_we_vote_id':         opinion_maker_we_vote_id,
-        'opinion_maker_display_name':       opinion_maker_display_name,
-        'opinion_maker_image_url_https':    opinion_maker_image_url_https,
-        'is_following':                     is_following,
-        'is_ignoring':                      is_ignoring,
-        'google_civic_election_id':         google_civic_election_id,
-        'state_code':                       state_code,
-        'position_list':                    sorted_position_list,
-        'filter_for_voter':                 filter_for_voter,
-        'filter_out_voter':                 filter_out_voter,
-        'friends_vs_public':                friends_vs_public,
+        'status':                               status,
+        'success':                              success,
+        'count':                                len(position_list),
+        'kind_of_opinion_maker':                kind_of_opinion_maker_text,
+        'opinion_maker_id':                     opinion_maker_id,
+        'opinion_maker_we_vote_id':             opinion_maker_we_vote_id,
+        'opinion_maker_display_name':           opinion_maker_display_name,
+        'opinion_maker_image_url_https_large':  opinion_maker_image_url_https_large,
+        'opinion_maker_image_url_https_medium': opinion_maker_image_url_https_medium,
+        'opinion_maker_image_url_https_tiny':   opinion_maker_image_url_https_tiny,
+        'is_following':                         is_following,
+        'is_ignoring':                          is_ignoring,
+        'google_civic_election_id':             google_civic_election_id,
+        'state_code':                           state_code,
+        'position_list':                        sorted_position_list,
+        'filter_for_voter':                     filter_for_voter,
+        'filter_out_voter':                     filter_out_voter,
+        'friends_vs_public':                    friends_vs_public,
     }
     return HttpResponse(json.dumps(json_data), content_type='application/json')
 
@@ -1559,7 +1591,9 @@ def position_list_for_voter_for_api(voter_device_id,
     """
     voter_we_vote_id = ""
     voter_display_name = ''
-    voter_image_url_https = ''
+    voter_image_url_https_large = ''
+    voter_image_url_https_medium = ''
+    voter_image_url_https_tiny= ''
     status = ''
     position_list_raw = []
 
@@ -1580,7 +1614,9 @@ def position_list_for_voter_for_api(voter_device_id,
             'state_code':                       state_code,
             'voter_we_vote_id':                 voter_we_vote_id,
             'voter_display_name':               voter_display_name,
-            'voter_image_url_https':            voter_image_url_https,
+            'voter_image_url_https_large':      voter_image_url_https_large,
+            'voter_image_url_https_medium':     voter_image_url_https_medium,
+            'voter_image_url_https_tiny':       voter_image_url_https_tiny,
         }
         return HttpResponse(json.dumps(json_data), content_type='application/json')
 
@@ -1601,11 +1637,19 @@ def position_list_for_voter_for_api(voter_device_id,
             'state_code':                       state_code,
             'voter_we_vote_id':                 voter_we_vote_id,
             'voter_display_name':               voter_display_name,
-            'voter_image_url_https':            voter_image_url_https,
+            'voter_image_url_https_large':      voter_image_url_https_large,
+            'voter_image_url_https_medium':     voter_image_url_https_medium,
+            'voter_image_url_https_tiny':       voter_image_url_https_tiny,
         }
         return HttpResponse(json.dumps(json_data), content_type='application/json')
 
     voter = voter_results['voter']
+    '''
+    voter_display_name = voter.first_name
+    voter_image_url_https_large = voter.we_vote_hosted_profile_image_url_large
+    voter_image_url_https_medium = voter.we_vote_hosted_profile_image_url_medium
+    voter_image_url_https_tiny = voter.we_vote_hosted_profile_image_url_tiny
+    '''
     position_list_manager = PositionListManager()
     if show_only_this_election:
         this_election_vs_others = THIS_ELECTION_ONLY
@@ -1662,31 +1706,36 @@ def position_list_for_voter_for_api(voter_device_id,
                     or missing_office_information:
                 one_position = position_manager.refresh_cached_position_info(one_position)
             one_position_dict_for_api = {
-                'position_we_vote_id':          one_position.we_vote_id,
-                'ballot_item_display_name':     one_position.ballot_item_display_name,  # Candidate name or Measure
-                'ballot_item_image_url_https':  one_position.ballot_item_image_url_https,
-                'ballot_item_twitter_handle':   one_position.ballot_item_twitter_handle,
-                'ballot_item_political_party':  one_position.political_party,
-                'ballot_item_state_code':       one_position.state_code,
-                'kind_of_ballot_item':          kind_of_ballot_item,
-                'ballot_item_id':               ballot_item_id,
-                'ballot_item_we_vote_id':       ballot_item_we_vote_id,
-                'contest_office_id':            one_position.contest_office_id,
-                'contest_office_we_vote_id':    one_position.contest_office_we_vote_id,
-                'contest_office_name':          one_position.contest_office_name,
-                'is_support':                       one_position.is_support(),
-                'is_positive_rating':               one_position.is_positive_rating(),
-                'is_support_or_positive_rating':    one_position.is_support_or_positive_rating(),
-                'is_oppose':                        one_position.is_oppose(),
-                'is_negative_rating':               one_position.is_negative_rating(),
-                'is_oppose_or_negative_rating':     one_position.is_oppose_or_negative_rating(),
-                'is_information_only':              one_position.is_information_only(),
-                'is_public_position':           one_position.is_public_position,
-                'speaker_display_name':         one_position.speaker_display_name,  # Voter name
-                'google_civic_election_id':     one_position.google_civic_election_id,
-                'more_info_url':                one_position.more_info_url,
-                'statement_text':               one_position.statement_text,
-                'last_updated':                 one_position.last_updated(),
+                'position_we_vote_id':                  one_position.we_vote_id,
+                'ballot_item_display_name':             one_position.ballot_item_display_name,  # Candidate name or
+                                                                                                # Measure
+                'ballot_item_image_url_https_large':    one_position.ballot_item_image_url_https_large
+                    if positive_value_exists(one_position.ballot_item_image_url_https_large)
+                    else one_position.ballot_item_image_url_https,
+                'ballot_item_image_url_https_medium':   one_position.ballot_item_image_url_https_medium,
+                'ballot_item_image_url_https_tiny':     one_position.ballot_item_image_url_https_tiny,
+                'ballot_item_twitter_handle':           one_position.ballot_item_twitter_handle,
+                'ballot_item_political_party':          one_position.political_party,
+                'ballot_item_state_code':               one_position.state_code,
+                'kind_of_ballot_item':                  kind_of_ballot_item,
+                'ballot_item_id':                       ballot_item_id,
+                'ballot_item_we_vote_id':               ballot_item_we_vote_id,
+                'contest_office_id':                    one_position.contest_office_id,
+                'contest_office_we_vote_id':            one_position.contest_office_we_vote_id,
+                'contest_office_name':                  one_position.contest_office_name,
+                'is_support':                           one_position.is_support(),
+                'is_positive_rating':                   one_position.is_positive_rating(),
+                'is_support_or_positive_rating':        one_position.is_support_or_positive_rating(),
+                'is_oppose':                            one_position.is_oppose(),
+                'is_negative_rating':                   one_position.is_negative_rating(),
+                'is_oppose_or_negative_rating':         one_position.is_oppose_or_negative_rating(),
+                'is_information_only':                  one_position.is_information_only(),
+                'is_public_position':                   one_position.is_public_position,
+                'speaker_display_name':                 one_position.speaker_display_name,  # Voter name
+                'google_civic_election_id':             one_position.google_civic_election_id,
+                'more_info_url':                        one_position.more_info_url,
+                'statement_text':                       one_position.statement_text,
+                'last_updated':                         one_position.last_updated(),
             }
             position_list.append(one_position_dict_for_api)
 
@@ -1704,7 +1753,10 @@ def position_list_for_voter_for_api(voter_device_id,
         'state_code':                       state_code,
         'voter_we_vote_id':                 voter_we_vote_id,
         'voter_display_name':               voter_display_name,
-        'voter_image_url_https':            voter_image_url_https,
+        'voter_image_url_https_large':      voter_image_url_https_large,
+        'voter_image_url_https_medium':     voter_image_url_https_medium,
+        'voter_image_url_https_tiny':       voter_image_url_https_tiny,
+        # 'voter_we_vote_id':                 voter.we_vote_id,
     }
     return HttpResponse(json.dumps(json_data), content_type='application/json')
 

--- a/position/models.py
+++ b/position/models.py
@@ -3757,8 +3757,8 @@ class PositionManager(models.Model):
         """
         values_changed = False
         if positive_value_exists(candidate_campaign.candidate_photo_url()) and \
-                position_object.ballot_item_image_url_https_medium != candidate_campaign.candidate_photo_url():
-            position_object.ballot_item_image_url_https_medium = candidate_campaign.candidate_photo_url()
+                position_object.ballot_item_image_url_https != candidate_campaign.candidate_photo_url():
+            position_object.ballot_item_image_url_https = candidate_campaign.candidate_photo_url()
             values_changed = True
         if positive_value_exists(candidate_campaign.we_vote_hosted_profile_image_url_large) and \
                 position_object.ballot_item_image_url_https_large != \

--- a/twitter/controllers.py
+++ b/twitter/controllers.py
@@ -21,6 +21,9 @@ def twitter_identity_retrieve_for_api(twitter_handle, voter_device_id=''):
     twitter_description = ''
     twitter_followers_count = ''
     twitter_photo_url = ''
+    we_vote_hosted_profile_image_url_large = ''
+    we_vote_hosted_profile_image_url_medium = ''
+    we_vote_hosted_profile_image_url_tiny = ''
     twitter_user_website = ''
     twitter_name = ''
 
@@ -79,6 +82,9 @@ def twitter_identity_retrieve_for_api(twitter_handle, voter_device_id=''):
             twitter_description = one_organization.twitter_description
             twitter_followers_count = one_organization.twitter_followers_count
             twitter_photo_url = one_organization.twitter_profile_image_url_https
+            we_vote_hosted_profile_image_url_large = one_organization.we_vote_hosted_profile_image_url_large
+            we_vote_hosted_profile_image_url_medium = one_organization.we_vote_hosted_profile_image_url_medium
+            we_vote_hosted_profile_image_url_tiny = one_organization.we_vote_hosted_profile_image_url_tiny
             twitter_user_website = one_organization.organization_website
             twitter_name = one_organization.twitter_name
 
@@ -94,24 +100,30 @@ def twitter_identity_retrieve_for_api(twitter_handle, voter_device_id=''):
             twitter_description = twitter_user.twitter_description
             twitter_followers_count = twitter_user.twitter_followers_count
             twitter_photo_url = twitter_user.twitter_profile_image_url_https
+            we_vote_hosted_profile_image_url_large = twitter_user.we_vote_hosted_profile_image_url_large
+            we_vote_hosted_profile_image_url_medium = twitter_user.we_vote_hosted_profile_image_url_medium
+            we_vote_hosted_profile_image_url_tiny = twitter_user.we_vote_hosted_profile_image_url_tiny
             twitter_user_website = twitter_user.twitter_url
             twitter_name = twitter_user.twitter_name
             kind_of_owner = "TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE"
             status = "TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE"
 
     results = {
-        'status':                   status,
-        'success':                  success,
-        'twitter_handle':           twitter_handle,
-        'kind_of_owner':            kind_of_owner,
-        'owner_found':              owner_found,
-        'owner_we_vote_id':         owner_we_vote_id,
-        'owner_id':                 owner_id,
-        'google_civic_election_id': google_civic_election_id,
-        'twitter_description':      twitter_description,
-        'twitter_followers_count':  twitter_followers_count,
-        'twitter_photo_url':        twitter_photo_url,
-        'twitter_user_website':     twitter_user_website,
-        'twitter_name':             twitter_name,
+        'status':                                   status,
+        'success':                                  success,
+        'twitter_handle':                           twitter_handle,
+        'kind_of_owner':                            kind_of_owner,
+        'owner_found':                              owner_found,
+        'owner_we_vote_id':                         owner_we_vote_id,
+        'owner_id':                                 owner_id,
+        'google_civic_election_id':                 google_civic_election_id,
+        'twitter_description':                      twitter_description,
+        'twitter_followers_count':                  twitter_followers_count,
+        'twitter_photo_url':                        twitter_photo_url,
+        'we_vote_hosted_profile_image_url_large':   we_vote_hosted_profile_image_url_large,
+        'we_vote_hosted_profile_image_url_medium':  we_vote_hosted_profile_image_url_medium,
+        'we_vote_hosted_profile_image_url_tiny':    we_vote_hosted_profile_image_url_tiny,
+        'twitter_user_website':                     twitter_user_website,
+        'twitter_name':                             twitter_name,
     }
     return results

--- a/voter/controllers.py
+++ b/voter/controllers.py
@@ -1168,7 +1168,9 @@ def voter_retrieve_for_api(voter_device_id):  # voterRetrieve
                 organization_website = ""
                 organization_email = ""
                 organization_facebook = ""
-                organization_image = voter.voter_photo_url()
+                organization_image = voter.we_vote_hosted_profile_image_url_large \
+                    if positive_value_exists(voter.we_vote_hosted_profile_image_url_large) \
+                    else voter.voter_photo_url()
                 organization_manager = OrganizationManager()
                 create_results = organization_manager.create_organization(
                     organization_name, organization_website, organization_twitter_handle,
@@ -1213,7 +1215,11 @@ def voter_retrieve_for_api(voter_device_id):  # voterRetrieve
             'has_data_to_preserve':             voter.has_data_to_preserve(),
             'has_email_with_verified_ownership':    voter.has_email_with_verified_ownership(),
             'linked_organization_we_vote_id':   voter.linked_organization_we_vote_id,
-            'voter_photo_url':                  voter.voter_photo_url(),
+            'voter_photo_url_large':            voter.we_vote_hosted_profile_image_url_large
+                if positive_value_exists(voter.we_vote_hosted_profile_image_url_large)
+                else voter.voter_photo_url(),
+            'voter_photo_url_medium':           voter.we_vote_hosted_profile_image_url_medium,
+            'voter_photo_url_tiny':             voter.we_vote_hosted_profile_image_url_tiny
         }
         return json_data
 
@@ -1245,7 +1251,9 @@ def voter_retrieve_for_api(voter_device_id):  # voterRetrieve
             'has_data_to_preserve':             False,
             'has_email_with_verified_ownership':    False,
             'linked_organization_we_vote_id':   '',
-            'voter_photo_url':                  '',
+            'voter_photo_url_large':            '',
+            'voter_photo_url_medium':           '',
+            'voter_photo_url_tiny':             '',
         }
         return json_data
 

--- a/voter_guide/controllers.py
+++ b/voter_guide/controllers.py
@@ -362,20 +362,24 @@ def voter_guides_to_follow_retrieve_for_api(voter_device_id,  # voterGuidesToFol
 
             position_found = False
             one_voter_guide = {
-                'we_vote_id': voter_guide.we_vote_id,
-                'google_civic_election_id': voter_guide.google_civic_election_id,
-                'time_span': voter_guide.vote_smart_time_span,
-                'voter_guide_display_name': voter_guide.voter_guide_display_name(),
-                'voter_guide_image_url': voter_guide.voter_guide_image_url(),
-                'voter_guide_owner_type': voter_guide.voter_guide_owner_type,
-                'organization_we_vote_id': voter_guide.organization_we_vote_id,
-                'public_figure_we_vote_id': voter_guide.public_figure_we_vote_id,
-                'twitter_description': voter_guide.twitter_description,
-                'twitter_followers_count': voter_guide.twitter_followers_count,
-                'twitter_handle': voter_guide.twitter_handle,
-                'owner_voter_id': voter_guide.owner_voter_id,
+                'we_vote_id':                   voter_guide.we_vote_id,
+                'google_civic_election_id':     voter_guide.google_civic_election_id,
+                'time_span':                    voter_guide.vote_smart_time_span,
+                'voter_guide_display_name':     voter_guide.voter_guide_display_name(),
+                'voter_guide_image_url_large':  voter_guide.we_vote_hosted_profile_image_url_large
+                    if positive_value_exists(voter_guide.we_vote_hosted_profile_image_url_large)
+                    else voter_guide.voter_guide_image_url(),
+                'voter_guide_image_url_medium': voter_guide.we_vote_hosted_profile_image_url_medium,
+                'voter_guide_image_url_tiny':   voter_guide.we_vote_hosted_profile_image_url_tiny,
+                'voter_guide_owner_type':       voter_guide.voter_guide_owner_type,
+                'organization_we_vote_id':      voter_guide.organization_we_vote_id,
+                'public_figure_we_vote_id':     voter_guide.public_figure_we_vote_id,
+                'twitter_description':          voter_guide.twitter_description,
+                'twitter_followers_count':      voter_guide.twitter_followers_count,
+                'twitter_handle':               voter_guide.twitter_handle,
+                'owner_voter_id':               voter_guide.owner_voter_id,
                 'ballot_item_we_vote_ids_this_org_supports': ballot_item_we_vote_ids_this_org_supports,
-                'last_updated': voter_guide.last_updated.strftime('%Y-%m-%d %H:%M'),
+                'last_updated':                 voter_guide.last_updated.strftime('%Y-%m-%d %H:%M'),
             }
             if positive_value_exists(ballot_item_we_vote_id):
                 if kind_of_ballot_item == CANDIDATE:
@@ -844,19 +848,23 @@ def voter_guides_followed_retrieve_for_api(voter_device_id, maximum_number_to_re
         number_added_to_list = 0
         for voter_guide in voter_guide_list:
             one_voter_guide = {
-                'we_vote_id': voter_guide.we_vote_id,
-                'google_civic_election_id': voter_guide.google_civic_election_id,
-                'time_span': voter_guide.vote_smart_time_span,
-                'voter_guide_display_name': voter_guide.voter_guide_display_name(),
-                'voter_guide_image_url': voter_guide.voter_guide_image_url(),
-                'voter_guide_owner_type': voter_guide.voter_guide_owner_type,
-                'organization_we_vote_id': voter_guide.organization_we_vote_id,
-                'public_figure_we_vote_id': voter_guide.public_figure_we_vote_id,
-                'twitter_description': voter_guide.twitter_description,
-                'twitter_followers_count': voter_guide.twitter_followers_count,
-                'twitter_handle': voter_guide.twitter_handle,
-                'owner_voter_id': voter_guide.owner_voter_id,
-                'last_updated': voter_guide.last_updated.strftime('%Y-%m-%d %H:%M'),
+                'we_vote_id':                   voter_guide.we_vote_id,
+                'google_civic_election_id':     voter_guide.google_civic_election_id,
+                'time_span':                    voter_guide.vote_smart_time_span,
+                'voter_guide_display_name':     voter_guide.voter_guide_display_name(),
+                'voter_guide_image_url_large':  voter_guide.we_vote_hosted_profile_image_url_large
+                    if positive_value_exists(voter_guide.we_vote_hosted_profile_image_url_large)
+                    else voter_guide.voter_guide_image_url(),
+                'voter_guide_image_url_medium': voter_guide.we_vote_hosted_profile_image_url_medium,
+                'voter_guide_image_url_tiny':   voter_guide.we_vote_hosted_profile_image_url_tiny,
+                'voter_guide_owner_type':       voter_guide.voter_guide_owner_type,
+                'organization_we_vote_id':      voter_guide.organization_we_vote_id,
+                'public_figure_we_vote_id':     voter_guide.public_figure_we_vote_id,
+                'twitter_description':          voter_guide.twitter_description,
+                'twitter_followers_count':      voter_guide.twitter_followers_count,
+                'twitter_handle':               voter_guide.twitter_handle,
+                'owner_voter_id':               voter_guide.owner_voter_id,
+                'last_updated':                 voter_guide.last_updated.strftime('%Y-%m-%d %H:%M'),
             }
             voter_guides.append(one_voter_guide.copy())
             if positive_value_exists(maximum_number_to_retrieve):
@@ -915,6 +923,7 @@ def retrieve_voter_guides_followed(voter_id):  # voterGuidesFollowedRetrieve
     }
     return results
 
+
 def voter_guides_ignored_retrieve_for_api(voter_device_id, maximum_number_to_retrieve=0):
     """
     Start with the organizations followed and return a list of voter_guides. voterGuidesIgnoredRetrieve
@@ -953,19 +962,23 @@ def voter_guides_ignored_retrieve_for_api(voter_device_id, maximum_number_to_ret
         number_added_to_list = 0
         for voter_guide in voter_guide_list:
             one_voter_guide = {
-                'we_vote_id': voter_guide.we_vote_id,
-                'google_civic_election_id': voter_guide.google_civic_election_id,
-                'time_span': voter_guide.vote_smart_time_span,
-                'voter_guide_display_name': voter_guide.voter_guide_display_name(),
-                'voter_guide_image_url': voter_guide.voter_guide_image_url(),
-                'voter_guide_owner_type': voter_guide.voter_guide_owner_type,
-                'organization_we_vote_id': voter_guide.organization_we_vote_id,
-                'public_figure_we_vote_id': voter_guide.public_figure_we_vote_id,
-                'twitter_description': voter_guide.twitter_description,
-                'twitter_followers_count': voter_guide.twitter_followers_count,
-                'twitter_handle': voter_guide.twitter_handle,
-                'owner_voter_id': voter_guide.owner_voter_id,
-                'last_updated': voter_guide.last_updated.strftime('%Y-%m-%d %H:%M'),
+                'we_vote_id':                   voter_guide.we_vote_id,
+                'google_civic_election_id':     voter_guide.google_civic_election_id,
+                'time_span':                    voter_guide.vote_smart_time_span,
+                'voter_guide_display_name':     voter_guide.voter_guide_display_name(),
+                'voter_guide_image_url_large':  voter_guide.we_vote_hosted_profile_image_url_large
+                    if positive_value_exists(voter_guide.we_vote_hosted_profile_image_url_large)
+                    else voter_guide.voter_guide_image_url(),
+                'voter_guide_image_url_medium': voter_guide.we_vote_hosted_profile_image_url_medium,
+                'voter_guide_image_url_tiny':   voter_guide.we_vote_hosted_profile_image_url_tiny,
+                'voter_guide_owner_type':       voter_guide.voter_guide_owner_type,
+                'organization_we_vote_id':      voter_guide.organization_we_vote_id,
+                'public_figure_we_vote_id':     voter_guide.public_figure_we_vote_id,
+                'twitter_description':          voter_guide.twitter_description,
+                'twitter_followers_count':      voter_guide.twitter_followers_count,
+                'twitter_handle':               voter_guide.twitter_handle,
+                'owner_voter_id':               voter_guide.owner_voter_id,
+                'last_updated':                 voter_guide.last_updated.strftime('%Y-%m-%d %H:%M'),
             }
             voter_guides.append(one_voter_guide.copy())
             if positive_value_exists(maximum_number_to_retrieve):

--- a/voter_guide/models.py
+++ b/voter_guide/models.py
@@ -404,19 +404,19 @@ class VoterGuideManager(models.Manager):
                         if voter_guide.image_url != organization.organization_photo_url():
                             voter_guide.image_url = organization.organization_photo_url()
                             values_changed = True
-                        if voter_guide.voter_guide_image_url_large != \
+                        if voter_guide.we_vote_hosted_profile_image_url_large != \
                                 organization.we_vote_hosted_profile_image_url_large:
-                            voter_guide.voter_guide_image_url_large = \
+                            voter_guide.we_vote_hosted_profile_image_url_large = \
                                 organization.we_vote_hosted_profile_image_url_large
                             values_changed = True
-                        if voter_guide.voter_guide_image_url_medium != \
+                        if voter_guide.we_vote_hosted_profile_image_url_medium != \
                                 organization.we_vote_hosted_profile_image_url_medium:
-                            voter_guide.voter_guide_image_url_medium = \
+                            voter_guide.we_vote_hosted_profile_image_url_medium = \
                                 organization.we_vote_hosted_profile_image_url_medium
                             values_changed = True
-                        if voter_guide.voter_guide_image_url_tiny != \
+                        if voter_guide.we_vote_hosted_profile_image_url_tiny != \
                                 organization.we_vote_hosted_profile_image_url_tiny:
-                            voter_guide.voter_guide_image_url_tiny = \
+                            voter_guide.we_vote_hosted_profile_image_url_tiny = \
                                 organization.we_vote_hosted_profile_image_url_tiny
                             values_changed = True
 
@@ -578,12 +578,12 @@ class VoterGuide(models.Model):
 
     image_url = models.URLField(verbose_name='image url of logo/photo associated with voter guide',
                                 blank=True, null=True)
-    voter_guide_image_url_large = models.URLField(verbose_name='large version image url of logo/photo associated '
-                                                               'with voter guide', blank=True, null=True)
-    voter_guide_image_url_medium = models.URLField(verbose_name='medium version image url of logo/photo associated '
-                                                                'with voter guide', blank=True, null=True)
-    voter_guide_image_url_tiny = models.URLField(verbose_name='tiny version image url of logo/photo associated '
-                                                              'with voter guide', blank=True, null=True)
+    we_vote_hosted_profile_image_url_large = models.URLField(
+        verbose_name='large version image url of logo/photo associated with voter guide', blank=True, null=True)
+    we_vote_hosted_profile_image_url_medium = models.URLField(
+        verbose_name='medium version image url of logo/photo associated with voter guide', blank=True, null=True)
+    we_vote_hosted_profile_image_url_tiny = models.URLField(
+        verbose_name='tiny version image url of logo/photo associated with voter guide', blank=True, null=True)
 
     voter_guide_owner_type = models.CharField(
         verbose_name="is owner org, public figure, or voter?", max_length=1, choices=VOTER_GUIDE_TYPE_CHOICES,


### PR DESCRIPTION
Updated below API endpoints with respect to additional photo sizes with locally cache image urls:
- voterRetrieve (Tested but did not get cached image urls as voter table is not updated with cached images, need to discuss about voter Update API)
- voterFacebookSignInRetrieve (cached profile image in voterFacebookSignInRetrieve API and background image in facebookFriendsAction API)
- twitterIdentityRetrieve
- twitterSignInRetrieve
- voterBallotItemsRetrieve (not tested)
- candidateRetrieve
- candidatesRetrieve (not tested)
- positionListForBallotItem (not tested)
- positionListForOpinionMaker (not tested)
- positionListForVoter (not tested)
- positionRetrieve
- organizationRetrieve
- organizationsFollowedRetrieve
- voterGuidesFollowedRetrieve
- voterGuidesToFollowRetrieve (not tested)
- voterGuidesIgnoredRetrieve (not tested)
- friendList