### PR TITLE
Steve wevoteserver may1

### DIFF
--- a/apis_v1/documentation_source/voter_retrieve_doc.py
+++ b/apis_v1/documentation_source/voter_retrieve_doc.py
@@ -49,17 +49,17 @@ def voter_retrieve_doc_template_values(url_root):
                    '  "voter_created": boolean,\n' \
                    '  "voter_found": boolean,\n' \
                    '  "we_vote_id": string,\n' \
-                   '  "first_name": string,\n' \
-                   '  "last_name": string,\n' \
-                   '  "email": string,\n' \
                    '  "facebook_id": integer,\n' \
+                   '  "email": string,\n' \
                    '  "facebook_email": string,\n' \
                    '  "facebook_profile_image_url_https": string,\n' \
-                   '  "voter_photo_url_large": string,\n' \
-                   '  "voter_photo_url_medium": string,\n' \
-                   '  "voter_photo_url_tiny": string,\n' \
+                   '  "full_name": string,\n' \
+                   '  "first_name": string,\n' \
+                   '  "last_name": string,\n' \
                    '  "twitter_screen_name": string,\n' \
                    '  "is_signed_in": boolean,\n' \
+                   '  "is_admin": boolean,\n' \
+                   '  "is_verified_volunteer": boolean,\n' \
                    '  "signed_in_facebook": boolean,\n' \
                    '  "signed_in_google": boolean,\n' \
                    '  "signed_in_twitter": boolean,\n' \
@@ -68,6 +68,21 @@ def voter_retrieve_doc_template_values(url_root):
                    '  "has_data_to_preserve": boolean,\n' \
                    '  "has_email_with_verified_ownership": boolean,\n' \
                    '  "linked_organization_we_vote_id": string,\n' \
+                   '  "voter_photo_url_large": string,\n' \
+                   '  "voter_photo_url_medium": string,\n' \
+                   '  "voter_photo_url_tiny": string,\n' \
+                   '  "voter_donation_history_list": [ list,\n' \
+                   '    "created": datetime,\n' \
+                   '    "amount" : integer,\n' \
+                   '    "currency" : integer,\n' \
+                   '    "one_time_donation" : boolean,\n' \
+                   '    "brand" : string,\n' \
+                   '    "exp_month" : string,\n' \
+                   '    "exp_year" : string,\n' \
+                   '    "last4" : string,\n' \
+                   '    "stripe_status" : string,\n' \
+                   '    "charge_id" : string,\n' \
+                   '   ]\n' \
                    '}'
 
     template_values = {

--- a/apis_v1/documentation_source/voter_retrieve_doc.py
+++ b/apis_v1/documentation_source/voter_retrieve_doc.py
@@ -54,6 +54,7 @@ def voter_retrieve_doc_template_values(url_root):
                    '  "facebook_email": string,\n' \
                    '  "facebook_profile_image_url_https": string,\n' \
                    '  "full_name": string,\n' \
+                   '  "full_name": string,\n' \
                    '  "first_name": string,\n' \
                    '  "last_name": string,\n' \
                    '  "twitter_screen_name": string,\n' \

--- a/apis_v1/documentation_source/voter_retrieve_doc.py
+++ b/apis_v1/documentation_source/voter_retrieve_doc.py
@@ -54,7 +54,6 @@ def voter_retrieve_doc_template_values(url_root):
                    '  "facebook_email": string,\n' \
                    '  "facebook_profile_image_url_https": string,\n' \
                    '  "full_name": string,\n' \
-                   '  "full_name": string,\n' \
                    '  "first_name": string,\n' \
                    '  "last_name": string,\n' \
                    '  "twitter_screen_name": string,\n' \

--- a/donate/controllers.py
+++ b/donate/controllers.py
@@ -17,7 +17,6 @@ def donation_with_stripe_for_api(request, token, email, donation_amount, monthly
 
     donation_manager = DonationManager()
     success = False
-    saved_stripe_customer_id = False
     saved_stripe_donation = False
     donation_entry_saved = False
     donation_date_time = datetime.today()
@@ -25,12 +24,38 @@ def donation_with_stripe_for_api(request, token, email, donation_amount, monthly
     action_taken = 'VOTER_SUBMITTED_DONATION'
     action_taken_date_time = donation_date_time
     charge_id = ''
+    amount = 0
+    currency = ''
     stripe_customer_id = ''
     subscription_saved = 'NOT_APPLICABLE'
     status = ''
     charge_processed_successfully = bool
     error_text_description = ''
     error_message = ''
+    one_time_donation = True
+    subscription_id = ''
+    funding = ''
+    livemode = False
+    created = 0
+    failure_code = ''
+    failure_message = ''
+    network_status = ''
+    reason = ''
+    seller_message = ''
+    stripe_type = ''
+    paid = ''
+    amount_refunded = 0
+    refund_count = 0
+    name = ''
+    address_zip = ''
+    brand = ''
+    country = ''
+    exp_month = ''
+    exp_year = ''
+    last4 = ''
+    id_card = ''
+    stripe_object = ''
+    stripe_status = ''
 
     ip_address = get_ip_from_headers(request)
 
@@ -92,25 +117,56 @@ def donation_with_stripe_for_api(request, token, email, donation_amount, monthly
                 subscription_saved = recurring_donation['voter_subscription_saved']
                 status += recurring_donation['status']
                 success = recurring_donation['success']
+                one_time_donation = False
+                subscription_id = recurring_donation['subscription_id']
                 charge_processed_successfully = recurring_donation['success']
-            else:
-                charge = stripe.Charge.create(
-                    amount=donation_amount,
-                    currency="usd",
-                    customer=stripe_customer_id
-                )
-                status = 'STRIPE_CHARGE_SUCCESSFUL'
-                charge_id = charge.id
-                success = positive_value_exists(charge_id)
-                charge_processed_successfully = positive_value_exists(charge_id)
+                # TODO April 2017: Following lines were not being executed if recurring, but what we want to do is make
+                # record, and make a charge record for the first payment.
+                # Previous 3 code lines will do nothing, need to rethink
 
-        if charge_processed_successfully:
+            charge = stripe.Charge.create(
+                amount=donation_amount,
+                currency="usd",
+                customer=stripe_customer_id
+            )
+            status = 'STRIPE_CHARGE_SUCCESSFUL'
+            charge_id = charge.id
+            success = positive_value_exists(charge_id)
+
+        if positive_value_exists(charge_id):
             saved_donation = donation_manager.create_donation_from_voter(stripe_customer_id, voter_we_vote_id,
                                                                          donation_amount, email,
                                                                          donation_date_time, charge_id,
                                                                          charge_processed_successfully)
             saved_stripe_donation = saved_donation['success']
             donation_status = saved_donation['status'] + ' DONATION_PROCESSED_SUCCESSFULLY '
+            stripe_detail = stripe.Charge.retrieve(charge_id)
+            amount = stripe_detail['amount']
+            currency = stripe_detail['currency']
+            amount_refunded = stripe_detail['amount_refunded']
+            funding = stripe_detail['source']['funding']
+            livemode = stripe_detail['livemode']
+            utc_dt = datetime.utcfromtimestamp(stripe_detail['created'])
+            created = utc_dt.isoformat()
+            failure_code = str(stripe_detail['failure_code'])
+            failure_message = str(stripe_detail['failure_message'])
+            network_status = stripe_detail['outcome']['network_status']
+            reason = str(stripe_detail['outcome']['reason'])
+            seller_message = stripe_detail['outcome']['seller_message']
+            stripe_type = stripe_detail['outcome']['type']
+            paid = str(stripe_detail['paid'])
+            amount_refunded = stripe_detail['amount_refunded']
+            refund_count = stripe_detail['refunds']['total_count']
+            name = stripe_detail['source']['name']
+            address_zip = stripe_detail['source']['address_zip']
+            brand = stripe_detail['source']['brand']
+            country = stripe_detail['source']['country']
+            exp_month = stripe_detail['source']['exp_month']
+            exp_year = stripe_detail['source']['exp_year']
+            last4 = int(stripe_detail['source']['last4'])
+            id_card = stripe_detail['source']['id']
+            stripe_object = stripe_detail['source']['object']
+            stripe_status = stripe_detail['status']
 
     except stripe.error.CardError as e:
         body = e.json_body
@@ -140,13 +196,22 @@ def donation_with_stripe_for_api(request, token, email, donation_amount, monthly
         error_message = 'Your payment was unsuccessful. Please try again later.'
 
     result_taken = donation_status  # TODO: Update this to match "action_result" below
+    action_result = donation_status  # TODO: Update this to match "action_result" below
     result_taken_date_time = donation_date_time
 
+    # steve:  These are good, will need to be expanded when webhooks are setup, to indicate recurring payments etc
     # action_taken should be VOTER_SUBMITTED_DONATION, VOTER_CANCELED_DONATION or CANCEL_REQUEST_SUBMITTED
     # action_result should be CANCEL_REQUEST_FAILED, CANCEL_REQUEST_SUCCEEDED or DONATION_PROCESSED_SUCCESSFULLY
     donation_log_results = donation_manager.create_donation_log_entry(
         ip_address, stripe_customer_id, voter_we_vote_id, charge_id, action_taken, action_taken_date_time,
         result_taken, result_taken_date_time, error_text_description, error_message)
+
+    donation_history_results = donation_manager.create_donation_history_entry(
+        ip_address, stripe_customer_id, voter_we_vote_id, charge_id, amount, currency, one_time_donation,
+        subscription_id, funding, livemode, action_taken, action_result, created, failure_code, failure_message,
+        network_status, reason, seller_message, stripe_type, paid, amount_refunded, refund_count, name, address_zip,
+        brand, country, exp_month, exp_year, last4, id_card, stripe_object, stripe_status, status)
+
     donation_entry_saved = donation_log_results['success']
 
     results = {
@@ -159,7 +224,6 @@ def donation_with_stripe_for_api(request, token, email, donation_amount, monthly
         'monthly_donation': monthly_donation,
         'subscription': subscription_saved,
         'error_message_for_voter': error_message
-
     }
 
     return results
@@ -175,3 +239,33 @@ def translate_stripe_error_to_voter_explanation_text(donation_http_status, error
         error_message_for_voter = generic_voter_error_message
 
     return error_message_for_voter
+
+# Get a list of all prior donations by the voter that is associated with this voter_we_vote_id
+# If they donated without logging in they are out of luck for tracking past donations
+def donation_history_for_a_voter(voter_we_vote_id):
+    donation_manager = DonationManager()
+    donation_list = donation_manager.retrieve_donation_history_list(voter_we_vote_id)
+
+    i = 0
+    simple_donation_list = []
+    element_tuple = []
+    names = ['created','amount','currency','one_time_donation','brand','exp_month','exp_year','last4','stripe_status','charge_id']
+    for donation_row in donation_list['voters_donation_list']:
+        row = donation_row
+        json_data = {
+            'created': str(row[0].isoformat()),
+            'amount': row[1],
+            'currency': row[2],
+            'one_time_donation': row[3],
+            'brand': row[4],
+            'exp_month': row[5],
+            'exp_year': row[6],
+            'last4': row[7],
+            'stripe_status': row[8],
+            'charge_id': row[9]
+        }
+
+        simple_donation_list.append(json_data)
+
+
+    return simple_donation_list

--- a/donate/controllers.py
+++ b/donate/controllers.py
@@ -240,16 +240,14 @@ def translate_stripe_error_to_voter_explanation_text(donation_http_status, error
 
     return error_message_for_voter
 
+
 # Get a list of all prior donations by the voter that is associated with this voter_we_vote_id
 # If they donated without logging in they are out of luck for tracking past donations
 def donation_history_for_a_voter(voter_we_vote_id):
     donation_manager = DonationManager()
     donation_list = donation_manager.retrieve_donation_history_list(voter_we_vote_id)
 
-    i = 0
     simple_donation_list = []
-    element_tuple = []
-    names = ['created','amount','currency','one_time_donation','brand','exp_month','exp_year','last4','stripe_status','charge_id']
     for donation_row in donation_list['voters_donation_list']:
         row = donation_row
         json_data = {
@@ -266,6 +264,5 @@ def donation_history_for_a_voter(voter_we_vote_id):
         }
 
         simple_donation_list.append(json_data)
-
 
     return simple_donation_list

--- a/donate/models.py
+++ b/donate/models.py
@@ -61,12 +61,20 @@ class DonationSubscription(models.Model):
     """
     stripe_customer_id = models.CharField(verbose_name="stripe unique customer id", max_length=255,
                                           unique=False, null=False, blank=False)
-    voter_we_vote_id = models.CharField(verbose_name="unique we vote user id", unique=False, null=False, max_length=255,
-                                        blank=False)
-    donation_plan_id = models.CharField(verbose_name="unique recurring donation plan id", default="", max_length=255,
-                                        null=False, blank=False)
-    start_date_time = models.DateField(verbose_name="subscription start date", auto_now=False, auto_now_add=True)
-
+    voter_we_vote_id = models.CharField(verbose_name="unique we vote user id", unique=False, null=False,
+                                        max_length=255, blank=False)
+    donation_plan_id = models.CharField(verbose_name="unique recurring donation plan id", default="",
+                                        max_length=255, null=False, blank=False)
+    start_date_time = models.DateField(verbose_name="subscription start date", auto_now=False,
+                                       auto_now_add=True)
+    subscription_id = models.CharField(verbose_name="stripe unique subscription id", max_length=32,
+                                       default="", null=False, blank=False)
+    subscription_ended_at = models.DateField(verbose_name="subscription ended date", null=True)
+    subscription_canceled_at = models.DateField(verbose_name="subscription canceled date", null=True)
+    subscription_livemode = models.BooleanField(verbose_name="subscription was made in live mode", default=False,
+                                                null=False, blank=False)
+    subscription_update = models.PositiveIntegerField(verbose_name="number of updates to this subscription",
+                                                       default=0, null=False)  # for when we get webhook updates
 
 class DonationVoterCreditCard(models.Model):
     """
@@ -136,6 +144,72 @@ class DonationLog(models.Model):
                                                blank=True)
 
 
+class DonationHistory(models.Model):
+    """
+     This is a generated table that will tracks donation and refund activity
+     """
+    ip_address = models.GenericIPAddressField(verbose_name="user ip address", protocol='both', unpack_ipv4=False,
+                                              null=True, blank=True, unique=False)
+    stripe_customer_id = models.CharField(verbose_name="stripe unique customer id", max_length=32,
+                                          unique=False, null=False, blank=False)
+    voter_we_vote_id = models.CharField(verbose_name="unique we vote user id", max_length=32, unique=False, null=False,
+                                        blank=False)
+    charge_id = models.CharField(verbose_name="unique charge id per specific donation", max_length=32, default="",
+                                 null=True, blank=True)
+    amount = models.PositiveIntegerField(verbose_name="donation amount", default=0, null=False)
+    currency = models.CharField(verbose_name="donation currency country code", max_length=8, default="", null=True,
+                                blank=True)
+    one_time_donation = models.BooleanField(
+        verbose_name="True: one time donation, False: a payment for a recurring donation", default=False, blank=False)
+    subscription_id = models.CharField(verbose_name="stripe unique subscription id", max_length=32, default="",
+                                       unique=False, null=True, blank=True)
+    funding = models.CharField(verbose_name="stripe returns 'credit' also might be debit, etc", max_length=32,
+                               default="", null=True, blank=True)
+    livemode = models.BooleanField(verbose_name="True: Live transaction, False: Test transaction", default=False,
+                                   blank=False)
+    action_taken = models.CharField(verbose_name="action taken", max_length=64, default="", null=True, blank=True)
+    action_result = models.CharField(verbose_name="action result", max_length=64, default="", null=True, blank=True)
+    created = models.DateTimeField(verbose_name="stripe record creation timestamp", auto_now=False,
+                                   auto_now_add=False)
+    failure_code = models.CharField(verbose_name="failure code reported by stripe", max_length=32, default="",
+                                    null=True, blank=True)
+    failure_message = models.CharField(verbose_name="failure message reported by stripe", max_length=255, default="",
+                                       null=True, blank=True)
+    network_status = models.CharField(verbose_name="network status reported by stripe", max_length=64, default="",
+                                      null=True, blank=True)
+    reason = models.CharField(verbose_name="reason for failure reported by stripe", max_length=255, default="",
+                              null=True, blank=True)
+    seller_message = models.CharField(verbose_name="plain text message to us from stripe", max_length=255, default="",
+                                      null=True, blank=True)
+    stripe_type = models.CharField(verbose_name="authorization outcome message to us from stripe", max_length=64,
+                                   default="", null=True, blank=True)
+    paid = models.CharField(verbose_name="payment outcome message to us from stripe", max_length=64, default="",
+                            null=True, blank=True)
+    amount_refunded = models.PositiveIntegerField(verbose_name="refund amount", default=0, null=False)
+    refund_count = models.PositiveIntegerField(
+        verbose_name="Number of refunds, in the case of partials (currently not supported)", default=0, null=False)
+    name = models.CharField(verbose_name="stripe returns the donor's email address as a name", max_length=255,
+                            default="", null=True, blank=True)
+    address_zip = models.CharField(verbose_name="stripe returns the donor's zip code", max_length=32, default="",
+                                   null=True, blank=True)
+    brand = models.CharField(verbose_name="the brand of the credit card, eg. Visa, Amex", max_length=32, default="",
+                             null=True, blank=True)
+    country = models.CharField(verbose_name="the country code of the bank that issued the credit card", max_length=8,
+                               default="", null=True, blank=True)
+    exp_month = models.PositiveIntegerField(verbose_name="the expiration month of the credit card", default=0,
+                                            null=False)
+    exp_year = models.PositiveIntegerField(verbose_name="the expiration year of the credit card", default=0, null=False)
+    last4 = models.PositiveIntegerField(verbose_name="the last 4 digits of the credit card", default=0, null=False)
+    id_card = models.CharField(verbose_name="stripe's internal id code for the credit card", max_length=32, default="",
+                               null=True, blank=True)
+    stripe_object = models.CharField(verbose_name="stripe returns 'card' for card, maybe different for bitcoin, etc.",
+                                     max_length=32, default="", null=True, blank=True)
+    stripe_status = models.CharField(verbose_name="status string reported by stripe", max_length=64, default="",
+                                     null=True, blank=True)
+    status = models.CharField(verbose_name="our generated status message", max_length=255, default="", null=True,
+                             blank=True)
+
+
 class DonationManager(models.Model):
 
     def create_donate_link_to_voter(self, stripe_customer_id, voter_we_vote_id):
@@ -173,18 +247,19 @@ class DonationManager(models.Model):
         charge_refunded = False
 
         try:
-            new_donation_from_voter_created = DonationFromVoter.objects.create(stripe_customer_id=stripe_customer_id,
-                                                                               voter_we_vote_id=voter_we_vote_id,
-                                                                               normalized_email_address=email,
-                                                                               donation_amount=donation_amount,
-                                                                               donation_date_time=donation_date_time,
-                                                                               stripe_card_id=stripe_card_id,
-                                                                               charge_id=charge_id,
-                                                                               charge_to_be_processed=charge_to_be_processed,
-                                                                               charge_processed_successfully=charge_processed_successfully,
-                                                                               charge_cancel_request=charge_cancel_request,
-                                                                               charge_failed_requires_voter_action=charge_failed_requires_voter_action,
-                                                                               charge_refunded=charge_refunded)
+            new_donation_from_voter_created = DonationFromVoter.objects.create(
+                stripe_customer_id=stripe_customer_id,
+                voter_we_vote_id=voter_we_vote_id,
+                normalized_email_address=email,
+                donation_amount=donation_amount,
+                donation_date_time=donation_date_time,
+                stripe_card_id=stripe_card_id,
+                charge_id=charge_id,
+                charge_to_be_processed=charge_to_be_processed,
+                charge_processed_successfully=charge_processed_successfully,
+                charge_cancel_request=charge_cancel_request,
+                charge_failed_requires_voter_action=charge_failed_requires_voter_action,
+                charge_refunded=charge_refunded)
 
             success = True
             status = 'STRIPE_DONATION_FROM_VOTER_SAVED'
@@ -206,7 +281,8 @@ class DonationManager(models.Model):
         success = bool
         if positive_value_exists(voter_we_vote_id):
             try:
-                stripe_customer_id_queryset = DonateLinkToVoter.objects.filter(voter_we_vote_id=voter_we_vote_id).values()
+                stripe_customer_id_queryset = DonateLinkToVoter.objects.filter(
+                    voter_we_vote_id=voter_we_vote_id).values()
                 stripe_customer_id = stripe_customer_id_queryset[0]['stripe_customer_id']
                 # print("model stripe_customer_id_query " + stripe_customer_id)
                 if positive_value_exists(stripe_customer_id):
@@ -257,7 +333,7 @@ class DonationManager(models.Model):
 
     def retrieve_or_create_recurring_donation_plan(self, donation_amount):
 
-        donation_plan_id = "monthly-" + str(donation_amount)
+        recurring_donation_plan_id = "monthly-" + str(donation_amount)
         # plan_name = donation_plan_id + " Plan"
         billing_interval = "monthly"
         currency = "usd"
@@ -268,12 +344,13 @@ class DonationManager(models.Model):
         try:
             # the donation plan needs to exist in two places: our stripe account and our database
             # plans can be created here or in our stripe account dashboard
-            donation_plan_query, is_new = DonationPlanDefinition.objects.get_or_create(donation_plan_id=donation_plan_id,
-                                                                                       plan_name=donation_plan_id,
-                                                                                       base_cost=donation_amount,
-                                                                                       billing_interval=billing_interval,
-                                                                                       currency=currency,
-                                                                                       donation_plan_is_active=donation_plan_is_active)
+            donation_plan_query, is_new = DonationPlanDefinition.objects.get_or_create(
+                donation_plan_id=recurring_donation_plan_id,
+                plan_name=recurring_donation_plan_id,
+                base_cost=donation_amount,
+                billing_interval=billing_interval,
+                currency=currency,
+                donation_plan_is_active=donation_plan_is_active)
             if is_new:
                 # if a donation plan is not found, we've added it to our database
                 success = True
@@ -283,7 +360,7 @@ class DonationManager(models.Model):
                 success = True
                 status += 'DONATION_PLAN_ALREADY_EXISTS_IN_DATABASE '
 
-            plan_id_query = stripe.Plan.retrieve(donation_plan_id)
+            plan_id_query = stripe.Plan.retrieve(recurring_donation_plan_id)
             if positive_value_exists(plan_id_query.id):
                 stripe_plan_id = plan_id_query.id
                 print("plan_id_query.id " + plan_id_query.id)
@@ -303,8 +380,8 @@ class DonationManager(models.Model):
                 amount=donation_amount,
                 interval="month",
                 currency="usd",
-                name=donation_plan_id,
-                id=donation_plan_id,
+                name=recurring_donation_plan_id,
+                id=recurring_donation_plan_id,
             )
             if plan.id:
                 success = True
@@ -316,18 +393,58 @@ class DonationManager(models.Model):
             'success': success,
             'status': status,
             'MultipleObjectsReturned': exception_multiple_object_returned,
-            'recurring_donation_plan_id': donation_plan_id,
+            'recurring_donation_plan_id': recurring_donation_plan_id,
         }
         return results
 
-    def create_subscription_entry(self, stripe_customer_id, voter_we_vote_id, donation_plan_id, start_date_time):
+    def create_donation_history_entry(
+            self, ip_address, stripe_customer_id, voter_we_vote_id, charge_id, amount, currency, one_time_donation,
+            subscription_id, funding, livemode, action_taken, action_result, created, failure_code, failure_message,
+            network_status, reason, seller_message, stripe_type, paid, amount_refunded, refund_count, name, address_zip,
+            brand, country, exp_month, exp_year, last4, id_card, stripe_object, stripe_status, status):
+
+        new_history_entry = 0
+        success = False
+        try:
+            new_history_entry = DonationHistory.objects.create(
+                ip_address=ip_address, stripe_customer_id=stripe_customer_id, voter_we_vote_id=voter_we_vote_id,
+                charge_id=charge_id, amount=amount, currency=currency, one_time_donation=one_time_donation,
+                subscription_id=subscription_id, funding=funding, livemode=livemode, action_taken=action_taken,
+                action_result=action_result, created=created, failure_code=failure_code,
+                failure_message=failure_message, network_status=network_status, reason=reason,
+                seller_message=seller_message, stripe_type=stripe_type, paid=paid, amount_refunded=amount_refunded,
+                refund_count=refund_count, name=name, address_zip=address_zip, brand=brand, country=country,
+                exp_month=exp_month, exp_year=exp_year, last4=last4, id_card=id_card, stripe_object=stripe_object,
+                stripe_status=stripe_status, status=status)
+
+            success = True
+            status = 'NEW_HISTORY_ENTRY_SAVED'
+        except Exception:
+            success = False
+            status = 'NEW_HISTORY_ENTRY_NOT_SAVED'
+
+        saved_results = {
+            'success': success,
+            'status': status,
+            'history_entry_saved': new_history_entry
+        }
+        return saved_results
+
+
+    def create_subscription_entry(self, stripe_customer_id, voter_we_vote_id, donation_plan_id, start_date_time,
+                                  donation_amount, subscription_id, ended_at, canceled_at, livemode):
 
         new_donation_subscription_entry = False
         try:
             new_donation_subscription_entry = DonationSubscription.objects.create(stripe_customer_id=stripe_customer_id,
                                                                                   voter_we_vote_id=voter_we_vote_id,
                                                                                   donation_plan_id=donation_plan_id,
-                                                                                  start_date_time=start_date_time)
+                                                                                  start_date_time=start_date_time,
+                                                                                  donation_amount=start_date_time,
+                                                                                  subscription_id=subscription_id,
+                                                                                  ended_at=ended_at,
+                                                                                  canceled_at=canceled_at,
+                                                                                  livemode=livemode)
             success = True
             status = 'NEW_SUBSCRIPTION_ENTRY_SAVED'
         # except Exception as e:
@@ -337,10 +454,12 @@ class DonationManager(models.Model):
         except:
             success = False
             status = 'NEW_SUBSCRIPTION_ENTRY_NOT_SAVED'
+            subscription_id = ""
 
         saved_results = {
             'success': success,
             'status': status,
+            'subscription_id' : subscription_id,
             'donation_entry_saved': new_donation_subscription_entry
         }
         return saved_results
@@ -356,13 +475,21 @@ class DonationManager(models.Model):
             status = donation_plan_id_query['status']
 
             try:
-                stripe.Subscription.create(
+                subscription = stripe.Subscription.create(
                     customer=stripe_customer_id,
                     plan=donation_plan_id
                 )
                 success = True
+                canceled_at = subscription['canceled_at']
+                ended_at = subscription['ended_at']
+                subscription_id = subscription['id']
+                livemode = subscription['livemode']
                 status += "USER_SUCCESSFULLY_SUBSCRIBED_TO_PLAN"
-                subscription_entry = self.create_subscription_entry(stripe_customer_id, voter_we_vote_id, donation_plan_id, start_date_time)
+                subscription_entry = self.create_subscription_entry(stripe_customer_id, voter_we_vote_id,
+                                                                    donation_plan_id, start_date_time, donation_amount,
+                                                                    subscription_id, ended_at, canceled_at, livemode )
+
+
 
             except stripe.error.StripeError as e:
                 body = e.json_body
@@ -425,3 +552,38 @@ class DonationManager(models.Model):
 
         return voter_card_error_message
 
+    def retrieve_donation_history_list(self, we_vote_id):
+        voters_donation_list = []
+        status = ''
+
+        try:
+            donation_queryset = DonationHistory.objects.values_list('created', 'amount', 'currency',
+                                                                    'one_time_donation', 'brand', 'exp_month',
+                                                                    'exp_year', 'last4', 'stripe_status', 'charge_id')
+            donation_queryset = donation_queryset.filter(voter_we_vote_id=we_vote_id)
+            voters_donation_list = donation_queryset
+
+            if len(donation_queryset):
+                success = True
+                status += ' CACHED_WE_VOTE_HISTORY_LIST_RETRIEVED '
+            else:
+                voters_donation_list = []
+                success = True
+                status += ' NO_HISTORY_EXISTS_FOR_THIS_VOTER '
+
+        except DonationHistory.DoesNotExist as e:
+            status += " WE_VOTE_HISTORY_DOES_NOT_EXIST "
+            success = True
+
+        except Exception as e:
+            status += " FAILED_TO RETRIEVE_CACHED_WE_VOTE_HISTORY_LIST "
+            success = False
+            # handle_exception(e, logger=logger, exception_message=status)
+
+        results = {
+            'success': success,
+            'status': status,
+            'voters_donation_list': voters_donation_list
+        }
+
+        return results

--- a/donate/models.py
+++ b/donate/models.py
@@ -440,7 +440,7 @@ class DonationManager(models.Model):
                                                                                   voter_we_vote_id=voter_we_vote_id,
                                                                                   donation_plan_id=donation_plan_id,
                                                                                   start_date_time=start_date_time,
-                                                                                  donation_amount=start_date_time,
+                                                                                  donation_amount=donation_amount,
                                                                                   subscription_id=subscription_id,
                                                                                   ended_at=ended_at,
                                                                                   canceled_at=canceled_at,

--- a/voter/controllers.py
+++ b/voter/controllers.py
@@ -7,7 +7,7 @@ from .models import BALLOT_ADDRESS, fetch_voter_id_from_voter_device_link, Voter
 from django.http import HttpResponse
 from email_outbound.controllers import move_email_address_entries_to_another_voter
 from email_outbound.models import EmailManager
-from follow.controllers import move_follow_entries_to_another_voter, move_organization_followers_to_another_organization
+from follow.controllers import move_follow_entries_to_another_voter
 from friend.controllers import fetch_friend_invitation_recipient_voter_we_vote_id, friend_accepted_invitation_send, \
     move_friend_invitations_to_another_voter, move_friends_to_another_voter
 from friend.models import FriendManager
@@ -20,6 +20,7 @@ from position.controllers import move_positions_to_another_voter
 from twitter.models import TwitterLinkToVoter, TwitterUserManager
 import wevote_functions.admin
 from wevote_functions.functions import generate_voter_device_id, is_voter_device_id_valid, positive_value_exists
+from donate.controllers import donation_history_for_a_voter
 
 logger = wevote_functions.admin.get_logger(__name__)
 
@@ -1224,6 +1225,7 @@ def voter_retrieve_for_api(voter_device_id):  # voterRetrieve
                     except Exception as e:
                         status += "UNABLE_TO_CREATE_NEW_ORGANIZATION_TO_VOTER_FROM_RETRIEVE_VOTER "
 
+        donation_list = donation_history_for_a_voter(voter.we_vote_id)
         json_data = {
             'status':                           status,
             'success':                          True,
@@ -1254,7 +1256,8 @@ def voter_retrieve_for_api(voter_device_id):  # voterRetrieve
                 if positive_value_exists(voter.we_vote_hosted_profile_image_url_large)
                 else voter.voter_photo_url(),
             'voter_photo_url_medium':           voter.we_vote_hosted_profile_image_url_medium,
-            'voter_photo_url_tiny':             voter.we_vote_hosted_profile_image_url_tiny
+            'voter_photo_url_tiny':             voter.we_vote_hosted_profile_image_url_tiny,
+            'voter_donation_history_list':      donation_list
         }
         return json_data
 


### PR DESCRIPTION
In apis_v1/documentation_source/voter_retrieve_doc.py, fixed the order of the fields in the
api display, to match current return.  Added section at the bottom to show new voter_donation_history_list that shows each payment that was made.

In donate/controllers.py the donation_with_stripe_for_api now returns the donation with a call
to donation_manager.create_donation_history_entry — this is a new table that is specifically
for donations, and can retrieve a list of donations with a single query of a single table.
There is also a new method donation_history_for_a_voter that retrieves the list for a single voter.

In donate/models.py added some fields to the existing DonationSubscription table that allows the
data to be associated with the data in stripe, and to be displayed in a new subscriptions tab in the 
webapp.  Created new table DonationHistory to contain all the voters donation records, all the key 
stripe ids are stored, so we could debug using their data in some unusual case.  New function
create_donation_history_entry that stores a donation history record, and retrieve_donation_history_list to get the list from the db.

In voter/controllers.py added a call to donation_history_for_a_voter(voter.we_vote_id) in 
voter_retrieve_for_api(voter_device_id) to send the donation history to the WebApp