### PR TITLE
donation_history_for_a_voter query now uses all() to retain keys in results set.

### DIFF
--- a/donate/controllers.py
+++ b/donate/controllers.py
@@ -249,20 +249,18 @@ def donation_history_for_a_voter(voter_we_vote_id):
 
     simple_donation_list = []
     for donation_row in donation_list['voters_donation_list']:
-        row = donation_row
         json_data = {
-            'created': str(row[0].isoformat()),
-            'amount': row[1],
-            'currency': row[2],
-            'one_time_donation': row[3],
-            'brand': row[4],
-            'exp_month': row[5],
-            'exp_year': row[6],
-            'last4': row[7],
-            'stripe_status': row[8],
-            'charge_id': row[9]
+            'created': str(donation_row.created),
+            'amount': donation_row.amount,
+            'currency': donation_row.currency,
+            'one_time_donation': donation_row.one_time_donation,
+            'brand': donation_row.brand,
+            'exp_month': donation_row.exp_month,
+            'exp_year': donation_row.exp_year,
+            'last4': donation_row.last4,
+            'stripe_status': donation_row.stripe_status,
+            'charge_id': donation_row.charge_id
         }
-
         simple_donation_list.append(json_data)
 
     return simple_donation_list

--- a/donate/models.py
+++ b/donate/models.py
@@ -557,9 +557,7 @@ class DonationManager(models.Model):
         status = ''
 
         try:
-            donation_queryset = DonationHistory.objects.values_list('created', 'amount', 'currency',
-                                                                    'one_time_donation', 'brand', 'exp_month',
-                                                                    'exp_year', 'last4', 'stripe_status', 'charge_id')
+            donation_queryset = DonationHistory.objects.all()
             donation_queryset = donation_queryset.filter(voter_we_vote_id=we_vote_id)
             voters_donation_list = donation_queryset
 


### PR DESCRIPTION
row references.
retrieve_donation_history_list now does a query all(), instead of
retrieving individual fields, so that the result set contains the keys.