### PR TITLE
Python 3.6 logging library requires args and kwargs when just sending a string.

### DIFF
--- a/candidate/controllers.py
+++ b/candidate/controllers.py
@@ -29,7 +29,7 @@ def candidates_import_from_sample_file():
     :return:
     """
     # Load saved json from local file
-    logger.info("Loading CandidateCampaigns from local file")
+    logger.info("Loading CandidateCampaigns from local file", {}, {})
 
     with open("candidate/import_data/candidate_campaigns_sample.json") as json_data:
         structured_json = json.load(json_data)
@@ -43,7 +43,7 @@ def candidates_import_from_master_server(request, google_civic_election_id='', s
     :return:
     """
     messages.add_message(request, messages.INFO, "Loading Candidates from We Vote Master servers")
-    logger.info("Loading Candidates from We Vote Master servers")
+    logger.info("Loading Candidates from We Vote Master servers", {}, {})
     # Request json file from We Vote servers
     request = requests.get(CANDIDATES_SYNC_URL, params={
         "key": WE_VOTE_API_KEY,  # This comes from an environment variable

--- a/follow/models.py
+++ b/follow/models.py
@@ -161,7 +161,7 @@ class FollowIssueManager(models.Model):
                 status = 'FAILED_TO_UPDATE ' + following_status
                 handle_record_not_saved_exception(e, logger=logger, exception_message_optional=status)
         elif results['MultipleObjectsReturned']:
-            logger.warn("follow_issue: delete all but one and take it over?")
+            logger.warn("follow_issue: delete all but one and take it over?", {}, {})
             status = 'TOGGLE_FOLLOWING MultipleObjectsReturned ' + following_status
         elif results['DoesNotExist']:
             try:
@@ -584,7 +584,7 @@ class FollowOrganizationManager(models.Model):
                 status = 'FAILED_TO_UPDATE ' + following_status
                 handle_record_not_saved_exception(e, logger=logger, exception_message_optional=status)
         elif results['MultipleObjectsReturned']:
-            logger.warn("follow_organization: delete all but one and take it over?")
+            logger.warn("follow_organization: delete all but one and take it over?", {}, {})
             status = 'TOGGLE_FOLLOWING MultipleObjectsReturned ' + following_status
         elif results['DoesNotExist']:
             try:

--- a/import_export_google_civic/controllers.py
+++ b/import_export_google_civic/controllers.py
@@ -154,7 +154,7 @@ def process_candidates_from_structured_json(
 def process_contest_office_from_structured_json(
         one_contest_office_structured_json, google_civic_election_id, ocd_division_id, local_ballot_order, state_code,
         voter_id, polling_location_we_vote_id):
-    logger.debug("General contest_type")
+    logger.debug("General contest_type", {}, {})
 
     # Protect against the case where this is NOT an office
     if 'candidates' not in one_contest_office_structured_json:
@@ -686,7 +686,7 @@ def store_one_ballot_from_google_civic_api(one_ballot_json, voter_id=0, polling_
 # See import_data/election_query_sample.json
 def retrieve_from_google_civic_api_election_query():
     # Request json file from Google servers
-    logger.info("Loading json data from Google servers, API call electionQuery")
+    logger.info("Loading json data from Google servers, API call electionQuery", {}, {})
     if not positive_value_exists(ELECTION_QUERY_URL):
         results = {
             'success':  False,

--- a/polling_location/controllers.py
+++ b/polling_location/controllers.py
@@ -25,7 +25,7 @@ def polling_locations_import_from_master_server(request, state_code):
     """
     # Request json file from We Vote servers
     messages.add_message(request, messages.INFO, "Loading Polling Locations from We Vote Master servers")
-    logger.info("Loading Polling Locations from We Vote Master servers")
+    logger.info("Loading Polling Locations from We Vote Master servers", {}, {})
     request = requests.get(POLLING_LOCATIONS_SYNC_URL, params={
         "key": WE_VOTE_API_KEY,  # This comes from an environment variable
         "format":   'json',

--- a/position/models.py
+++ b/position/models.py
@@ -345,7 +345,7 @@ class PositionEntered(models.Model):
         try:
             candidate_campaign = CandidateCampaign.objects.get(id=self.candidate_campaign_id)
         except CandidateCampaign.MultipleObjectsReturned as e:
-            logger.error("position.candidate_campaign Found multiple")
+            logger.error("position.candidate_campaign Found multiple", {}, {})
             return
         except CandidateCampaign.DoesNotExist:
             return
@@ -357,7 +357,7 @@ class PositionEntered(models.Model):
         try:
             contest_measure = ContestMeasure.objects.get(id=self.contest_measure_id)
         except ContestMeasure.MultipleObjectsReturned as e:
-            logger.error("position.contest_measure Found multiple")
+            logger.error("position.contest_measure Found multiple", {}, {})
             return
         except ContestMeasure.DoesNotExist:
             return
@@ -370,7 +370,7 @@ class PositionEntered(models.Model):
             election = Election.objects.get(google_civic_election_id=self.google_civic_election_id)
         except Election.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.election Found multiple")
+            logger.error("position.election Found multiple", {}, {})
             return
         except Election.DoesNotExist:
             return
@@ -383,7 +383,7 @@ class PositionEntered(models.Model):
             organization = Organization.objects.get(id=self.organization_id)
         except Organization.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.organization Found multiple")
+            logger.error("position.organization Found multiple", {}, {})
             return
         except Organization.DoesNotExist:
             return
@@ -685,7 +685,7 @@ class PositionForFriends(models.Model):
             candidate_campaign = CandidateCampaign.objects.get(id=self.candidate_campaign_id)
         except CandidateCampaign.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.candidate_campaign Found multiple")
+            logger.error("position.candidate_campaign Found multiple", {}, {})
             return
         except CandidateCampaign.DoesNotExist:
             return
@@ -698,7 +698,7 @@ class PositionForFriends(models.Model):
             contest_measure = ContestMeasure.objects.get(id=self.contest_measure_id)
         except ContestMeasure.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.candidate_campaign Found multiple")
+            logger.error("position.candidate_campaign Found multiple", {}, {})
             return
         except ContestMeasure.DoesNotExist:
             return
@@ -711,7 +711,7 @@ class PositionForFriends(models.Model):
             election = Election.objects.get(google_civic_election_id=self.google_civic_election_id)
         except Election.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.election Found multiple")
+            logger.error("position.election Found multiple", {}, {})
             return
         except Election.DoesNotExist:
             return
@@ -724,7 +724,7 @@ class PositionForFriends(models.Model):
             organization = Organization.objects.get(id=self.organization_id)
         except Organization.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.organization Found multiple")
+            logger.error("position.organization Found multiple", {}, {})
             return
         except Organization.DoesNotExist:
             return

--- a/voter_guide/models.py
+++ b/voter_guide/models.py
@@ -676,10 +676,10 @@ class VoterGuide(models.Model):
             organization = Organization.objects.get(we_vote_id=self.organization_we_vote_id)
         except Organization.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("voter_guide.organization Found multiple")
+            logger.error("voter_guide.organization Found multiple", {}, {})
             return
         except Organization.DoesNotExist:
-            logger.error("voter_guide.organization did not find")
+            logger.error("voter_guide.organization did not find", {}, {})
             return
         return organization
 
@@ -1425,9 +1425,9 @@ class VoterGuidePossibility(models.Model):
             organization = Organization.objects.get(we_vote_id=self.organization_we_vote_id)
         except Organization.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("voter_guide.organization Found multiple")
+            logger.error("voter_guide.organization Found multiple", {}, {})
             return
         except Organization.DoesNotExist:
-            logger.error("voter_guide.organization did not find")
+            logger.error("voter_guide.organization did not find", {}, {})
             return
         return organization

--- a/wevote_settings/models.py
+++ b/wevote_settings/models.py
@@ -70,7 +70,7 @@ class WeVoteSettingsManager(models.Model):
             elif type(setting_value).__name__ == 'str':
                 value_type = WeVoteSetting.STRING
             elif type(setting_value).__name__ == 'list':
-                logger.info("setting is a list. To be developed")
+                logger.info("setting is a list. To be developed", {}, {})
                 value_type = WeVoteSetting.STRING
             else:
                 value_type = WeVoteSetting.STRING

--- a/wevote_social/facebook.py
+++ b/wevote_social/facebook.py
@@ -29,7 +29,7 @@ class FacebookAPI(object):
         try:
             friends = json.loads(urlopen(request).read()).get('data')
         except Exception as err:
-            logger.error(err)
+            logger.error(err, {}, {})
 
         return friends
 


### PR DESCRIPTION
In lib/python3.6/logging/__init__.py
    def error(self, msg: object, args: object, kwargs: object) -> object:

If you are only sending in a string, you need to send {} for both *args
and **kwargs, or else you get a

[2017-06-12 22:24:33,988] [ERROR] Steve-Podells-MacBook-Pro.local:donate.controllers: donation_process_charge, general: error() missing 2 required positional arguments: 'args' and 'kwargs'

and if the logger.error call is in an exception code block, it throws nested exceptions.