### PR TITLE
Started off with this issue:

### DIFF
--- a/candidate/models.py
+++ b/candidate/models.py
@@ -476,10 +476,10 @@ class CandidateCampaign(models.Model):
             election = Election.objects.get(google_civic_election_id=self.google_civic_election_id)
         except Election.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("candidate.election Found multiple")
+            logger.error("candidate.election Found multiple", {}, {})
             return
         except Election.DoesNotExist:
-            logger.error("candidate.election did not find")
+            logger.error("candidate.election did not find", {}, {})
             return
         return election
 
@@ -488,10 +488,10 @@ class CandidateCampaign(models.Model):
             office = ContestOffice.objects.get(id=self.contest_office_id)
         except ContestOffice.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("candidate.election Found multiple")
+            logger.error("candidate.election Found multiple", {}, {})
             return
         except ContestOffice.DoesNotExist:
-            logger.error("candidate.election did not find")
+            logger.error("candidate.election did not find", {}, {})
             return
         return office
 

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -113,7 +113,7 @@ def candidates_import_from_master_server_view(request):
     else:
         messages.add_message(request, messages.INFO, 'Candidates import completed. '
                                                      'Saved: {saved}, Updated: {updated}, '
-                                                     'Master data not imported (local duplicates found): '
+                                                     'Duplicates skipped: '
                                                      '{duplicates_removed}, '
                                                      'Not processed: {not_processed}'
                                                      ''.format(saved=results['saved'],
@@ -658,7 +658,8 @@ def candidate_edit_process_view(request):
 
     if remove_duplicate_process:
         return HttpResponseRedirect(reverse('candidate:find_and_remove_duplicate_candidates', args=()) +
-                                    "?google_civic_election_id=" + str(google_civic_election_id))
+                                    "?google_civic_election_id=" + str(google_civic_election_id) +
+                                    "&state_code=" + str(state_code))
     else:
         return HttpResponseRedirect(reverse('candidate:candidate_edit', args=(candidate_id,)))
 

--- a/config/startup.py
+++ b/config/startup.py
@@ -7,6 +7,8 @@ import wevote_functions.admin
 from config import settings
 
 
+# TODO: This gets called after all the individual "logger = wevote_functions.admin.get_logger(__name__)" are called
+# It appears to have no effect on the LOG_FILE_LEVEL, so only ERROR logging works
 def run():
     wevote_functions.admin.setup_logging(
         stream=settings.LOG_STREAM,

--- a/donate/models.py
+++ b/donate/models.py
@@ -242,7 +242,7 @@ class DonationManager(models.Model):
         except DonationManager.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
             success = False
-            status += 'MULTIPLE_MATCHING_SUBSCRIPTION_PLANS_FOUND'
+            status += 'MULTIPLE_MATCHING_SUBSCRIPTION_PLANS_FOUND '
             exception_multiple_object_returned = True
 
         except stripe.error.StripeError:
@@ -681,9 +681,9 @@ class DonationManager(models.Model):
     def update_journal_entry_for_refund(charge, voter_we_vote_id, refund):
         if refund and refund['amount'] > 0 and refund['status'] == "succeeded":
             row = DonationJournal.objects.get(charge_id__iexact=charge, voter_we_vote_id__iexact=voter_we_vote_id)
-            row.status = textwrap.shorten(" CHARGE_REFUND_REQUESTED" + "_" + str(refund['created']) + "_" + \
+            row.status = textwrap.shorten(row.status + " CHARGE_REFUND_REQUESTED" + "_" + str(refund['created']) + "_" + \
                          refund['currency'] + "_" + str(refund['amount']) + "_REFUND_ID" + \
-                         refund['id'] + " " + row.status, width=255, placeholder="...")
+                         refund['id'] + " ", width=255, placeholder="...")
             row.amount_refunded = refund['amount']
             row.stripe_status = "refund pending"
             row.save()
@@ -699,7 +699,7 @@ class DonationManager(models.Model):
     @staticmethod
     def update_journal_entry_for_already_refunded(charge, voter_we_vote_id):
         row = DonationJournal.objects.get(charge_id__iexact=charge, voter_we_vote_id__iexact=voter_we_vote_id)
-        row.status = textwrap.shorten("CHARGE_WAS_ALREADY_REFUNDED_" + str(datetime.utcnow()) + " " + row.status,
+        row.status = textwrap.shorten(row.status + "CHARGE_WAS_ALREADY_REFUNDED_" + str(datetime.utcnow()) + " ",
                                       width=255, placeholder="...")
         row.amount_refunded = row.amount
         row.stripe_status = "refunded"
@@ -714,7 +714,7 @@ class DonationManager(models.Model):
         print("update_journal_entry_for_refund_completed: " + charge)
         try:
             row = DonationJournal.objects.get(charge_id=charge)
-            row.status = textwrap.shorten("CHARGE_REFUNDED_" + str(datetime.utcnow()) + " " + row.status, width=255,
+            row.status = textwrap.shorten(row.status + "CHARGE_REFUNDED_" + str(datetime.utcnow()) + " ", width=255,
                                           placeholder="...")
             row.stripe_status = "refunded"
             row.save()

--- a/election/views_admin.py
+++ b/election/views_admin.py
@@ -107,6 +107,8 @@ def election_all_ballots_retrieve_view(request, election_local_id=0):
     # number_of_polling_locations_to_retrieve = int(.1 * polling_location_count)
     ballot_returned_manager = BallotReturnedManager()
     rate_limit_count = 0
+    # Step though our set of polling locations, until we find one that contains a ballot.  Some won't contain ballots
+    # due to data quality issues.
     for polling_location in polling_location_list:
         success = False
         # Get the address for this polling place, and then retrieve the ballot from Google Civic API

--- a/exception/models.py
+++ b/exception/models.py
@@ -18,7 +18,7 @@ def _log_exception(exception_message, logger, e):
     frame = caller_frame_record[0]
     info = inspect.getframeinfo(frame)
 
-    logger.error(e)
+    logger.error(e, {}, {})
     logger.error("{message}, function: {function}, file: {filename}, line: {line}".format(
         message=exception_message,
         filename=info.filename,

--- a/import_export_batches/controllers.py
+++ b/import_export_batches/controllers.py
@@ -1377,11 +1377,11 @@ def import_contest_office_entry(batch_header_id, batch_row_id, create_entry_flag
                 positive_value_exists(google_civic_election_id):
             contest_office_manager = ContestOfficeManager()
             if create_entry_flag:
-                results = contest_office_manager.create_contest_office_row_entry(contest_office_name, state_code,
+                results = contest_office_manager.create_contest_office_row_entry(contest_office_name,
                                                                                  contest_office_votes_allowed,
                                                                                  ctcl_uuid,
                                                                                  contest_office_number_elected,
-                                                                                 google_civic_election_id)
+                                                                                 google_civic_election_id, state_code)
                 if results['new_contest_office_created']:
                     number_of_contest_offices_created += 1
                     success = True
@@ -1398,12 +1398,12 @@ def import_contest_office_entry(batch_header_id, batch_row_id, create_entry_flag
             elif update_entry_flag:
                 contest_office_we_vote_id = one_batch_action_row.contest_office_we_vote_id
                 results = contest_office_manager.update_contest_office_row_entry(contest_office_name,
-                                                                                 state_code,
                                                                                  contest_office_votes_allowed,
                                                                                  ctcl_uuid,
                                                                                  contest_office_number_elected,
+                                                                                 contest_office_we_vote_id,
                                                                                  google_civic_election_id,
-                                                                                 contest_office_we_vote_id)
+                                                                                 state_code)
                 if results['contest_office_updated']:
                     number_of_contest_offices_updated += 1
                     success = True

--- a/import_export_maplight/controllers.py
+++ b/import_export_maplight/controllers.py
@@ -20,7 +20,8 @@ def import_maplight_from_json(request):
     if load_from_url:
         # Request json file from Maplight servers
         logger.debug("TO BE IMPLEMENTED: Load Maplight JSON from url")
-        # request = requests.get(VOTER_INFO_URL, params={
+        # dry note: if we implement this, do it with process_request_from_master
+        # request = requests. get(VOTER_INFO_URL, params={
         #     "key": GOOGLE_CIVIC_API_KEY,  # This comes from an environment variable
         #     "address": "254 Hartford Street San Francisco CA",
         #     "electionId": "2000",

--- a/issue/controllers.py
+++ b/issue/controllers.py
@@ -10,7 +10,7 @@ from exception.models import handle_exception
 import json
 import requests
 import wevote_functions.admin
-from wevote_functions.functions import positive_value_exists
+from wevote_functions.functions import positive_value_exists, process_request_from_master
 
 logger = wevote_functions.admin.get_logger(__name__)
 
@@ -24,15 +24,15 @@ def issues_import_from_master_server(request):
     Get the json data, and either create new entries or update existing
     :return:
     """
-    messages.add_message(request, messages.INFO, "Loading Issues from We Vote Master servers")
-    logger.info("Loading Issues from We Vote Master servers")
-    # Request json file from We Vote servers
-    request = requests.get(ISSUES_SYNC_URL, params={
-        "key": WE_VOTE_API_KEY,  # This comes from an environment variable
-    })
-    structured_json = json.loads(request.text)
+    import_results, structured_json = process_request_from_master(
+        request, "Loading Issues from We Vote Master servers",
+        ISSUES_SYNC_URL, {
+            "key": WE_VOTE_API_KEY,
+        }
+    )
 
-    import_results = issues_import_from_structured_json(structured_json)
+    if import_results['success']:
+        import_results = issues_import_from_structured_json(structured_json)
 
     return import_results
 
@@ -239,15 +239,15 @@ def organization_link_to_issue_import_from_master_server(request):
     Get the json data, and either create new entries or update existing
     :return:
     """
-    messages.add_message(request, messages.INFO, "Loading organizationLinkToIssue data from We Vote Master servers")
-    logger.info("Loading organizationLinkToIssue from We Vote Master servers")
-    # Request json file from We Vote servers
-    link_request = requests.get(ORGANIZATION_LINK_TO_ISSUE_SYNC_URL, params={
-        "key": WE_VOTE_API_KEY,  # This comes from an environment variable
-    })
-    structured_json = json.loads(link_request.text)
+    import_results, structured_json = process_request_from_master(
+        request, "Loading Organization's Links To Issues data from We Vote Master servers",
+        ORGANIZATION_LINK_TO_ISSUE_SYNC_URL, {
+            "key": WE_VOTE_API_KEY,
+        }
+    )
 
-    import_results = organization_link_to_issue_import_from_structured_json(structured_json)
+    if import_results['success']:
+        import_results = organization_link_to_issue_import_from_structured_json(structured_json)
 
     return import_results
 

--- a/issue/views_admin.py
+++ b/issue/views_admin.py
@@ -87,7 +87,6 @@ def issues_import_from_master_server_view(request):
     else:
         messages.add_message(request, messages.INFO, 'Issues import completed. '
                                                      'Saved: {saved}, Updated: {updated}, '
-                                                     'Master data not imported (local duplicates found): '
                                                      'Not processed: {not_processed}'
                                                      ''.format(saved=results['issues_saved'],
                                                                updated=results['issues_updated'],
@@ -415,9 +414,8 @@ def organization_link_to_issue_import_from_master_server_view(request):
         messages.add_message(request, messages.ERROR, results['status'])
     else:
         messages.add_message(request, messages.INFO,
-                             'organizationLinkToIssue import completed. '
+                             'Organization Links import completed. '
                              'Saved: {saved}, Updated: {updated}, '
-                             'Master data not imported (local duplicates found): '
                              'Not processed: {not_processed}'
                              ''.format(saved=results['organization_link_to_issue_saved'],
                                        updated=results['organization_link_to_issue_updated'],

--- a/measure/views_admin.py
+++ b/measure/views_admin.py
@@ -65,9 +65,12 @@ def measures_sync_out_view(request):
 
 
 @login_required
-def measures_import_from_master_server_view(request):
+def measures_import_from_master_server_view(request):  # GET '/m/import/?google_civic_election_id=nnn&state_code=xx'
     google_civic_election_id = convert_to_int(request.GET.get('google_civic_election_id', 0))
     state_code = request.GET.get('state_code', '')
+
+    if not positive_value_exists(google_civic_election_id):
+        logger.error("measures_import_from_master_server_view did not receive a google_civic_election_id", {}, {})
 
     results = measures_import_from_master_server(request, google_civic_election_id, state_code)
 
@@ -76,7 +79,7 @@ def measures_import_from_master_server_view(request):
     else:
         messages.add_message(request, messages.INFO, 'Measures import completed. '
                                                      'Saved: {saved}, Updated: {updated}, '
-                                                     'Master data not imported (local duplicates found): '
+                                                     'Duplicates skipped: '
                                                      '{duplicates_removed}, '
                                                      'Not processed: {not_processed}'
                                                      ''.format(saved=results['saved'],
@@ -299,7 +302,8 @@ def measure_edit_process_view(request):
             messages.add_message(request, messages.ERROR, 'Could not save measure.')
 
     return HttpResponseRedirect(reverse('measure:measure_list', args=()) +
-                                "?google_civic_election_id=" + str(google_civic_election_id))
+                                "?google_civic_election_id=" + str(google_civic_election_id) +
+                                "&state_code=" + str(state_code))
 
 
 @login_required

--- a/office/views_admin.py
+++ b/office/views_admin.py
@@ -75,7 +75,7 @@ def offices_import_from_master_server_view(request):
     else:
         messages.add_message(request, messages.INFO, 'Offices import completed. '
                                                      'Saved: {saved}, Updated: {updated}, '
-                                                     'Master data not imported (local duplicates found): '
+                                                     'Duplicates skipped: '
                                                      '{duplicates_removed}, '
                                                      'Not processed: {not_processed}'
                                                      ''.format(saved=results['saved'],
@@ -249,7 +249,8 @@ def office_edit_process_view(request):
             google_civic_election_id = office_on_stage.google_civic_election_id
 
             return HttpResponseRedirect(reverse('office:office_summary', args=(office_on_stage_id,)) +
-                                        "?google_civic_election_id=" + str(google_civic_election_id))
+                                        "?google_civic_election_id=" + str(google_civic_election_id) +
+                                        "&state_code=" + str(state_code))
         else:
             # Create new
             office_on_stage = ContestOffice(
@@ -265,13 +266,15 @@ def office_edit_process_view(request):
 
             # Come back to the "Create New Office" page
             return HttpResponseRedirect(reverse('office:office_new', args=()) +
-                                        "?google_civic_election_id=" + str(google_civic_election_id))
+                                        "?google_civic_election_id=" + str(google_civic_election_id) +
+                                        "&state_code=" + str(state_code))
     except Exception as e:
         handle_record_not_saved_exception(e, logger=logger)
         messages.add_message(request, messages.ERROR, 'Could not save office.')
 
-    return HttpResponseRedirect(reverse('office:office_list', args=()) +
-                                "?google_civic_election_id=" + google_civic_election_id)
+    return HttpResponseRedirect(reverse("office:office_list", args=()) +
+                                "?google_civic_election_id=" + str(google_civic_election_id) +
+                                "&state_code=" + str(state_code))
 
 
 @login_required

--- a/organization/views_admin.py
+++ b/organization/views_admin.py
@@ -100,7 +100,7 @@ def organizations_import_from_master_server_view(request):
     else:
         messages.add_message(request, messages.INFO, 'Organizations import completed. '
                                                      'Saved: {saved}, Updated: {updated}, '
-                                                     'Master data not imported (local duplicates found): '
+                                                     'Duplicates skipped: '
                                                      '{duplicates_removed}, '
                                                      'Not processed: {not_processed}'
                                                      ''.format(saved=results['saved'],
@@ -342,6 +342,7 @@ def organization_edit_process_view(request):
     # A positive value in google_civic_election_id or add_organization_button means we want to create a voter guide
     # for this org for this election
     google_civic_election_id = request.POST.get('google_civic_election_id', 0)
+    state_code = request.POST.get('state_code', '')
     # add_organization_button = request.POST.get('add_organization_button', False)
 
     # Filter incoming data
@@ -485,7 +486,8 @@ def organization_edit_process_view(request):
                 link_issue_manager.unlink_organization_to_issue(organization_we_vote_id, issue_id, issue_we_vote_id)
 
     return HttpResponseRedirect(reverse('organization:organization_position_list', args=(organization_id,)) +
-                                "?google_civic_election_id=" + str(google_civic_election_id))
+                                "?google_civic_election_id=" + str(google_civic_election_id) + "&state_code=" +
+                                str(state_code))
 
 
 @login_required
@@ -918,6 +920,7 @@ def organization_position_edit_process_view(request):
                 return HttpResponseRedirect(
                     reverse('organization:organization_position_edit', args=([organization_id], [position_we_vote_id])) +
                     "?google_civic_election_id=" + str(google_civic_election_id) +
+                    "&state_code=" + str(state_code) +
                     "&stance=" + stance +
                     "&statement_text=" + statement_text +
                     "&more_info_url=" + more_info_url +
@@ -927,6 +930,7 @@ def organization_position_edit_process_view(request):
                 return HttpResponseRedirect(
                     reverse('organization:organization_position_new', args=([organization_id])) +
                     "?google_civic_election_id=" + str(google_civic_election_id) +
+                    "&state_code=" + str(state_code) +
                     "&stance=" + stance +
                     "&statement_text=" + statement_text +
                     "&more_info_url=" + more_info_url +
@@ -940,6 +944,7 @@ def organization_position_edit_process_view(request):
         return HttpResponseRedirect(
             reverse('organization:organization_position_new', args=([organization_id])) +
             "?google_civic_election_id=" + str(google_civic_election_id) +
+            "&state_code=" + str(state_code) +
             "&stance=" + stance +
             "&statement_text=" + statement_text +
             "&more_info_url=" + more_info_url +
@@ -1066,13 +1071,13 @@ def organization_position_edit_process_view(request):
     if success:
         voter_guide_manager = VoterGuideManager()
         results = voter_guide_manager.update_or_create_organization_voter_guide_by_election_id(
-            organization_on_stage.we_vote_id, google_civic_election_id)
+            organization_on_stage.we_vote_id, google_civic_election_id, state_code)
         # if results['success']:
 
     if go_back_to_add_new:
         return HttpResponseRedirect(
             reverse('organization:organization_position_new', args=(organization_on_stage.id,)) +
-            "?google_civic_election_id=" + str(google_civic_election_id))
+            "?google_civic_election_id=" + str(google_civic_election_id) + "&state_code=" + str(state_code))
     else:
         return HttpResponseRedirect(
             reverse('organization:organization_position_list', args=(organization_on_stage.id,)))

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -65,7 +65,7 @@ def candidates_import_from_master_server_view(request):  # TODO DALE Transition 
     else:
         messages.add_message(request, messages.INFO, 'Candidates import completed. '
                                                      'Saved: {saved}, Updated: {updated}, '
-                                                     'Master data not imported (local duplicates found): '
+                                                     'Duplicates skipped: '
                                                      '{duplicates_removed}, '
                                                      'Not processed: {not_processed}'
                                                      ''.format(saved=results['saved'],

--- a/polling_location/views_admin.py
+++ b/polling_location/views_admin.py
@@ -129,7 +129,7 @@ def polling_locations_import_from_master_server_view(request):
     else:
         messages.add_message(request, messages.INFO, 'Polling Locations import completed. '
                                                      'Saved: {saved}, Updated: {updated}, '
-                                                     'Master data not imported (local duplicates found): '
+                                                     'Duplicates skipped: '
                                                      '{duplicates_removed}, '
                                                      'Not processed: {not_processed}'
                                                      ''.format(saved=results['saved'],

--- a/position/views_admin.py
+++ b/position/views_admin.py
@@ -87,7 +87,7 @@ def positions_import_from_master_server_view(request):
     else:
         messages.add_message(request, messages.INFO, 'Positions import completed. '
                                                      'Saved: {saved}, Updated: {updated}, '
-                                                     'Master data not imported (local duplicates found): '
+                                                     'Duplicates skipped: '
                                                      '{duplicates_removed}, '
                                                      'Not processed: {not_processed}'
                                                      ''.format(saved=results['saved'],

--- a/search/models.py
+++ b/search/models.py
@@ -43,7 +43,7 @@ def save_candidate_campaign_signal(sender, instance, **kwargs):
             if res["_shards"]["successful"] <= 1:
                 logger.error("failed to index CandidateCampaign " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err)
+            logger.error(err, {}, {})
 
 
 @receiver(post_delete, sender=CandidateCampaign)
@@ -55,7 +55,7 @@ def delete_candidate_campaign_signal(sender, instance, **kwargs):
             if res["_shards"]["successful"] <= 1:
                 logger.error("failed to delete CandidateCampaign " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err)
+            logger.error(err, {}, {})
 
 
 # ContestMeasure
@@ -76,7 +76,7 @@ def save_contest_measure_signal(sender, instance, **kwargs):
             if res["_shards"]["successful"] <= 1:
                 logger.error("failed to index ContestMeasure " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err)
+            logger.error(err, {}, {})
 
 
 @receiver(post_delete, sender=ContestMeasure)
@@ -88,7 +88,7 @@ def delete_contest_measure_signal(sender, instance, **kwargs):
             if res["_shards"]["successful"] <= 1:
                 logger.error("failed to delete ContestMeasure " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err)
+            logger.error(err, {}, {})
 
 
 # ContestOffice
@@ -107,7 +107,7 @@ def save_contest_office_signal(sender, instance, **kwargs):
             if res["_shards"]["successful"] <= 1:
                 logger.error("failed to index ContestMeasure " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err)
+            logger.error(err, {}, {})
 
 
 @receiver(post_delete, sender=ContestOffice)
@@ -119,7 +119,7 @@ def delete_contest_office_signal(sender, instance, **kwargs):
             if res["_shards"]["successful"] <= 1:
                 logger.error("failed to delete ContestMeasure " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err)
+            logger.error(err, {}, {})
 
 
 # Organization
@@ -140,7 +140,7 @@ def save_organization_signal(sender, instance, **kwargs):
             if res["_shards"]["successful"] <= 1:
                 logger.error("failed to index Organization " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err)
+            logger.error(err, {}, {})
 
 
 @receiver(post_delete, sender=Organization)
@@ -152,7 +152,7 @@ def delete_organization_signal(sender, instance, **kwargs):
             if res["_shards"]["successful"] <= 1:
                 logger.error("failed to delete Organization " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err)
+            logger.error(err, {}, {})
 
 
 # @receiver(post_save)

--- a/templates/admin_tools/sync_data_with_master_dashboard.html
+++ b/templates/admin_tools/sync_data_with_master_dashboard.html
@@ -18,18 +18,20 @@
 <h4>Elections</h4>
 
 <p><a href="{% url 'election:elections_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve All Elections</a> (Meta information only)</p>
+    Retrieve All Elections</a> &nbsp;&nbsp;&nbsp;&nbsp; (Meta information only)</p>
 <br />
 
 {% if election_list %}
 
     <select id="google_civic_election_id" name="google_civic_election_id">
         <option value="0" {% if 0 == google_civic_election_id|convert_to_int %} selected="selected"{% endif %}>
-            -- Filter by Election --</option>
+            -- Filter by Election --
+        </option>
     {% for election in election_list %}
         <option value="{{ election.google_civic_election_id }}"
                 {% if election.google_civic_election_id|slugify == google_civic_election_id|slugify %} selected="selected"{% endif %}>
-            {{ election.election_name }} - {{ election.google_civic_election_id }} - {{ election.election_day_text }}</option>
+            {{ election.election_name }} - {{ election.google_civic_election_id }} - {{ election.election_day_text }}
+        </option>
     {% endfor %}
     </select>
     <br />
@@ -39,97 +41,130 @@
 {% if state_list %}
 
     <select id="state_code" name="state_code">
-        <option value="" {% if '' == state_code %} selected="selected"{% endif %}>
-            -- All States --</option>
+        <option value="" {% if state_code.length == 0 %} selected="selected"{% endif %}>
+            -- All States --
+        </option>
     {% for key, state in state_list %}
         <option value="{{ key }}"
                 {% if key|lower == state_code|lower %} selected="selected"{% endif %}>
-            {{ state }}</option>
+            {{ state }}
+        </option>
     {% endfor %}
     </select>
     <br />
 {% endif %}{# End of if state_list #}
 
+<table>
+    <tr><td><h4>Offices</h4></h4></td></tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;
+            <a href="{% url 'office:offices_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                Retrieve Offices</a>
+            {% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}
+        </td>
+        <td>The list of elected offices, like &#34;Governor State of Virginia&#34;, one entry for each polling location</td>
+    </tr>
+
+    <tr><td><h4>Candidates</h4></td></tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;
+            <a href="{% url 'candidate:candidates_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                Retrieve Candidates</a>
+            {% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}
+        </td>
+        <td>The list of candidates for office)</td>
+    </tr>
+
+    <tr><td><h4>Measures</h4></td></tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;
+            <a href="{% url 'measure:measures_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                Retrieve Measures</a>
+            {% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}
+        </td>
+        <td>The list of unique measures, like &#34;Measure BB - Berkeley&#34;)</td>
+    </tr>
+
+    <tr><td><h4>Issues</h4></td></tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;
+            <a href="{% url 'issue:issues_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                Retrieve Issues</a>
+        </td>
+        <td>Note: Issues are independent of elections and state_codes</td>
+    </tr>
+
+    <tr><td><h4>Organizations</h4></td></tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;
+            <a href="{% url 'organization:organizations_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+    Retrieve Organizations</a>{% if state_code %} for the state {{ state_code }}{% else %} for ALL states{% endif %}
+        </td>
+        <td>The list of organizations that make ballot recomendations</td>
+    </tr>
+
+    <tr><td><h4>Organization Links to Issues</h4></td></tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;
+            <a href="{% url 'issue:organization_link_to_issue_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                Retrieve Organization Links to Issues</a>
+        </td>
+        <td>Organization Links to Issues are independent of elections and state_codes</td>
+    </tr>
+
+    <tr><td><h4>Positions</h4></td></tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;
+            {% if google_civic_election_id|convert_to_int > 0 %}
+            <a href="{% url 'position:positions_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                Retrieve Positions</a>
+            for election {{ google_civic_election_id }}{% else %} (Cannot retrieve Positions without election id){% endif %}
+        </td>
+        <td>The list of positions on measures and candidates, that organizations have made</td>
+    </tr>
+
+    <tr><td><h4>Polling Locations</h4></td></tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;
+            <a href="{% url 'polling_location:polling_locations_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                Retrieve Polling Locations</a>
+            {% if state_code %} for the state {{ state_code }}{% else %} for ALL states{% endif %}
+        </td>
+        <td>The list of known polling locations.  &#34;All states&#34; can take more than 15 minutes to load.</td>
+    </tr>
 
 
-{# ################################### #}
-<h4>Offices</h4>
+    <tr><td><h4>Ballot Items</h4></td></tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;
+            <a href="{% url 'ballot:ballot_items_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                Retrieve Saved Ballot Items</a>
+            {% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}
+            &nbsp;&nbsp;
+        </td>
+        <td>The list unique elected offices, like &#34;Governor State of Virginia&#34;  <br/>Some of our older data has no state_codes, so if you get no results try with &#34;All states&#34;</td>
+    </tr>
 
-<p>&nbsp;&nbsp;&nbsp;<a href="{% url 'office:offices_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve Offices</a>{% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}</p>
+    <tr><td><h4>Ballot Returned</h4></td></tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;
+            <a href="{% url 'ballot:ballot_returned_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                Retrieve Saved Ballots</a>
+            {% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}
+        </td>
+        <td>Polling locations for a specific election and date</td>
+    </tr>
 
-
-{# ################################### #}
-<h4>Candidates</h4>
-
-<p>&nbsp;&nbsp;&nbsp;<a href="{% url 'candidate:candidates_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve Candidates</a>{% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}</p>
-
-
-{# ################################### #}
-<h4>Measures</h4>
-
-<p>&nbsp;&nbsp;&nbsp;<a href="{% url 'measure:measures_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve Measures</a>{% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}</p>
-
-
-{# ################################### #}
-<h4>Issues</h4>
-
-<p>&nbsp;&nbsp;&nbsp;<a href="{% url 'issue:issues_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve Issues</a> (Note: Issues are independent of elections and state_codes)</p>
-
-
-{# ################################### #}
-<h4>Organizations</h4>
-
-<p>&nbsp;&nbsp;&nbsp;<a href="{% url 'organization:organizations_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve Organizations</a>{% if state_code %} for the state {{ state_code }}{% else %} for ALL states{% endif %}</p>
-
-
-{# ################################### #}
-<h4>Organization Links to Issues</h4>
-
-<p>&nbsp;&nbsp;&nbsp;<a href="{% url 'issue:organization_link_to_issue_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve Organization Links to Issues</a> (Note: Organization Links to Issues are independent of elections and state_codes)</p>
-
-
-{# ################################### #}
-<h4>Positions</h4>
-
-<p>&nbsp;&nbsp;&nbsp;{% if google_civic_election_id|convert_to_int > 0 %}
-    <a href="{% url 'position:positions_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve Positions</a> for election {{ google_civic_election_id }}{% else %} (Cannot retrieve Positions without election id){% endif %}</p>
-
-
-{# ################################### #}
-<h4>Polling Locations</h4>
-
-<p>&nbsp;&nbsp;&nbsp;<a href="{% url 'polling_location:polling_locations_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve Polling Locations</a>{% if state_code %} for the state {{ state_code }}{% else %} for ALL states{% endif %}</p>
-
-
-{# ################################### #}
-<h4>Ballot Items</h4>
-
-<p>&nbsp;&nbsp;&nbsp;<a href="{% url 'ballot:ballot_items_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve Saved Ballot Items</a>{% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}</p>
-
-
-{# ################################### #}
-<h4>Ballot Returned</h4>
-
-<p>&nbsp;&nbsp;&nbsp;<a href="{% url 'ballot:ballot_returned_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve Saved Ballots</a>{% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}</p>
-
-
-{# ################################### #}
-<h4>Voter Guides</h4>
-
-<p>&nbsp;&nbsp;&nbsp;<a href="{% url 'voter_guide:voter_guides_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-    Retrieve Voter Guides</a>{% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}</p>
-<br />
-
+    <tr><td><h4>Voter Guides</h4></td></tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;
+            <a href="{% url 'voter_guide:voter_guides_import_from_master_server' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                Retrieve Voter Guides</a>
+            {% if google_civic_election_id|convert_to_int > 0 %} for election {{ google_civic_election_id }}{% else %} for ALL elections{% endif %}
+        </td>
+        <td>The guides published by organizations</td>
+    </tr>
+</table>
 </form>
 
 {# ################################### #}

--- a/voter/models.py
+++ b/voter/models.py
@@ -1483,6 +1483,7 @@ class VoterDeviceLink(models.Model):
     # The unique ID of the election (provided by Google Civic) that the voter is looking at on this device
     google_civic_election_id = models.PositiveIntegerField(
         verbose_name="google civic election id", default=0, null=False)
+    state_code = models.CharField(verbose_name="state the ballot item is related to", max_length=2, null=True)
 
     def generate_voter_device_id(self):
         # A simple mapping to this function

--- a/voter/models.py
+++ b/voter/models.py
@@ -1483,7 +1483,7 @@ class VoterDeviceLink(models.Model):
     # The unique ID of the election (provided by Google Civic) that the voter is looking at on this device
     google_civic_election_id = models.PositiveIntegerField(
         verbose_name="google civic election id", default=0, null=False)
-    state_code = models.CharField(verbose_name="state the ballot item is related to", max_length=2, null=True)
+    state_code = models.CharField(verbose_name="us state the device is most recently active in", max_length=2, null=True)
 
     def generate_voter_device_id(self):
         # A simple mapping to this function

--- a/voter_guide/models.py
+++ b/voter_guide/models.py
@@ -32,7 +32,7 @@ class VoterGuideManager(models.Manager):
     A class for working with the VoterGuide model
     """
     def update_or_create_organization_voter_guide_by_election_id(self, organization_we_vote_id,
-                                                                 google_civic_election_id):
+                                                                 google_civic_election_id, state_code):
         """
         This creates voter_guides, and also refreshes voter guides with updated organization data
         """
@@ -69,6 +69,7 @@ class VoterGuideManager(models.Manager):
                         'twitter_description':      organization.twitter_description,
                         'twitter_followers_count':  organization.twitter_followers_count,
                         'display_name':             organization.organization_name,
+                        'state_code':               state_code,
                     }
                     voter_guide_on_stage, new_voter_guide_created = VoterGuide.objects.update_or_create(
                         google_civic_election_id__exact=google_civic_election_id,
@@ -592,6 +593,7 @@ class VoterGuide(models.Model):
     # The unique ID of this election. (Provided by Google Civic)
     google_civic_election_id = models.PositiveIntegerField(
         verbose_name="google civic election id", null=True)
+    state_code = models.CharField(verbose_name="state the ballot item is related to", max_length=2, null=True)
 
     # Usually in one of these two formats 2015, 2014-2015
     vote_smart_time_span = models.CharField(

--- a/voter_guide/views_admin.py
+++ b/voter_guide/views_admin.py
@@ -69,7 +69,7 @@ def voter_guides_import_from_master_server_view(request):
     else:
         messages.add_message(request, messages.INFO, 'Voter Guides import completed. '
                                                      'Saved: {saved}, Updated: {updated}, '
-                                                     'Master data not imported (local duplicates found): '
+                                                     'Duplicates skipped: '
                                                      '{duplicates_removed}, '
                                                      'Not processed: {not_processed}'
                                                      ''.format(saved=results['saved'],
@@ -273,6 +273,7 @@ def voter_guide_list_view(request):
         return redirect_to_sign_in_page(request, authority_required)
 
     google_civic_election_id = convert_to_int(request.GET.get('google_civic_election_id', 0))
+    state_code = request.GET.get('state_code', '')
 
     voter_guide_list = []
     voter_guide_list_object = VoterGuideListManager()
@@ -296,12 +297,12 @@ def voter_guide_list_view(request):
         # How many Publicly visible positions are there in this election on this voter guide?
         retrieve_public_positions = True
         one_voter_guide.number_of_public_positions = position_list_manager.fetch_positions_count_for_voter_guide(
-            one_voter_guide.organization_we_vote_id, one_voter_guide.google_civic_election_id,
+            one_voter_guide.organization_we_vote_id, one_voter_guide.google_civic_election_id, state_code,
             retrieve_public_positions)
         # How many Friends-only visible positions are there in this election on this voter guide?
         retrieve_public_positions = False
         one_voter_guide.number_of_friends_only_positions = position_list_manager.fetch_positions_count_for_voter_guide(
-            one_voter_guide.organization_we_vote_id, one_voter_guide.google_civic_election_id,
+            one_voter_guide.organization_we_vote_id, one_voter_guide.google_civic_election_id, state_code,
             retrieve_public_positions)
         modified_voter_guide_list.append(one_voter_guide)
 
@@ -309,10 +310,11 @@ def voter_guide_list_view(request):
 
     messages_on_stage = get_messages(request)
     template_values = {
-        'election_list': election_list,
+        'election_list':            election_list,
         'google_civic_election_id': google_civic_election_id,
-        'messages_on_stage': messages_on_stage,
-        'voter_guide_list': modified_voter_guide_list,
+        'state_code':               state_code,
+        'messages_on_stage':        messages_on_stage,
+        'voter_guide_list':         modified_voter_guide_list,
     }
     return render(request, 'voter_guide/voter_guide_list.html', template_values)
 

--- a/wevote_functions/functions.py
+++ b/wevote_functions/functions.py
@@ -10,6 +10,9 @@ import string
 import sys
 import types
 import wevote_functions.admin
+import json
+import requests
+from django.contrib import messages
 
 
 logger = wevote_functions.admin.get_logger(__name__)
@@ -607,3 +610,34 @@ def convert_state_code_to_state_text(incoming_state_code):
             return state_name
     else:
         return ""
+
+
+def process_request_from_master(request, message_text, get_url, get_params):
+    """
+
+    :param request:
+    :param message_text:
+    :param get_url:
+    :param get_params:
+    :return: structured_json and import_results
+    """
+
+    messages.add_message(request, messages.INFO, message_text)
+    logger.info(message_text)
+    print(message_text)
+
+    response = requests.get(get_url, get_params)
+
+    structured_json = json.loads(response.text)
+    if 'success' in structured_json and not structured_json['success']:
+        import_results = {
+            'success': False,
+            'status': "Error: " + structured_json['status'],
+        }
+    else:
+        import_results = {
+            'success': True,
+            'status': "",
+        }
+
+    return import_results, structured_json


### PR DESCRIPTION
Google civic returns the same google_civic_election_id for primaries
that occur in multiple states on the same day, so we need to persist
the state_code most places where we store google_civic_election_id.
Added (working) error handling when receiving un-successful API queries.
Error response in these error conditions provides text that describes
the problem, instead of silently failing.

There was so much inconsistently "repeated" code, that resulted in
silently ignored errors, so I added process_request_from_master().

Reworked sync_data_with_master_dashboard.html so that it was more
understandable by newbies, and so that errors bubbled up to the
web page (instead of failing silently).

If I knew at the beginning how big this was going to become, I would 
have broken it up into multiple PRs.

I carefully inspected (many times) the code that runs on the master server 
and loads the original master copy, but could not fully test it on my local.

This change requires a DB migration.