### PR TITLE
Fixed python logging

### DIFF
--- a/candidate/controllers.py
+++ b/candidate/controllers.py
@@ -29,7 +29,7 @@ def candidates_import_from_sample_file():
     :return:
     """
     # Load saved json from local file
-    logger.info("Loading CandidateCampaigns from local file", {}, {})
+    logger.info("Loading CandidateCampaigns from local file")
 
     with open("candidate/import_data/candidate_campaigns_sample.json") as json_data:
         structured_json = json.load(json_data)

--- a/donate/controllers.py
+++ b/donate/controllers.py
@@ -348,7 +348,7 @@ def donation_process_stripe_webhook_event(event):
     :return:
     """
     print("donation_process_stripe_webhook_event received: " + event.type)
-    logger.debug("donation_process_stripe_webhook_event received: " + event.type, {}, {})
+    logger.debug("donation_process_stripe_webhook_event received: " + event.type)
 
     if event['type'] == 'charge.succeeded':
         return donation_process_charge(event)
@@ -362,7 +362,7 @@ def donation_process_stripe_webhook_event(event):
         return donation_process_refund_payment(event)
     else:
         print("donation_process_stripe_webhook_event Stripe event ignored: " + event.type)
-        logger.info("donation_process_stripe_webhook_event Stripe event ignored: " + event.type, {}, {})
+        logger.info("donation_process_stripe_webhook_event Stripe event ignored: " + event.type)
         return
 
 
@@ -580,7 +580,7 @@ def donation_subscription_cancellation_for_api(request, subscription_id, voter_w
     except stripe.error.InvalidRequestError as err:
         # 5/29/17, Does it throw this every time you cancel a valid subscription?
         if "No such subscription:" in str(err):
-            logger.info("Marking subscription as canceled due to: " + str(err), {}, {})
+            logger.info("Marking subscription as canceled due to: " + str(err))
 
         DonationManager().mark_subscription_canceled_or_ended(subscription['id'], subscription['customer'],
                                                               subscription['ended_at'], subscription['canceled_at'])

--- a/donate/models.py
+++ b/donate/models.py
@@ -586,7 +586,7 @@ class DonationManager(models.Model):
             # The not-loggedin-voter rarely has made a donation, so this is not a problem
             status += " NO-DONATIONS-TO-MOVE-FROM-" + \
                       voter_we_vote_id + "-TO-" + to_voter_we_vote_id + " "
-            logger.debug("move_donations_between_donors 1:" + status, {}, {})
+            logger.debug("move_donations_between_donors 1:" + status)
             results = {
                 'status': status,
                 'success': False,

--- a/follow/models.py
+++ b/follow/models.py
@@ -156,7 +156,7 @@ class FollowIssueManager(models.Model):
                 status = 'FAILED_TO_UPDATE ' + following_status
                 handle_record_not_saved_exception(e, logger=logger, exception_message_optional=status)
         elif results['MultipleObjectsReturned']:
-            logger.warn("follow_issue: delete all but one and take it over?", {}, {})
+            logger.warn("follow_issue: delete all but one and take it over?")
             status = 'TOGGLE_FOLLOWING MultipleObjectsReturned ' + following_status
         elif results['DoesNotExist']:
             try:
@@ -575,7 +575,7 @@ class FollowOrganizationManager(models.Model):
                 status = 'FAILED_TO_UPDATE ' + following_status
                 handle_record_not_saved_exception(e, logger=logger, exception_message_optional=status)
         elif results['MultipleObjectsReturned']:
-            logger.warn("follow_organization: delete all but one and take it over?", {}, {})
+            logger.warn("follow_organization: delete all but one and take it over?")
             status = 'TOGGLE_FOLLOWING MultipleObjectsReturned ' + following_status
         elif results['DoesNotExist']:
             try:

--- a/import_export_google_civic/controllers.py
+++ b/import_export_google_civic/controllers.py
@@ -154,7 +154,7 @@ def process_candidates_from_structured_json(
 def process_contest_office_from_structured_json(
         one_contest_office_structured_json, google_civic_election_id, state_code, ocd_division_id, local_ballot_order,
         voter_id, polling_location_we_vote_id):
-    logger.debug("General contest_type", {}, {})
+    logger.debug("General contest_type")
 
     # Protect against the case where this is NOT an office
     if 'candidates' not in one_contest_office_structured_json:

--- a/search/models.py
+++ b/search/models.py
@@ -27,7 +27,7 @@ if positive_value_exists(ELASTIC_SEARCH_CONNECTION_STRING):
 # CandidateCampaign
 @receiver(post_save, sender=CandidateCampaign)
 def save_candidate_campaign_signal(sender, instance, **kwargs):
-    logger.debug("search.save_candidate_campaign_signal")
+    # logger.debug("search.save_candidate_campaign_signal")
     if 'elastic_search_object' in globals():
         doc = {
             "candidate_name": instance.candidate_name,
@@ -48,7 +48,7 @@ def save_candidate_campaign_signal(sender, instance, **kwargs):
 
 @receiver(post_delete, sender=CandidateCampaign)
 def delete_candidate_campaign_signal(sender, instance, **kwargs):
-    logger.debug("search.delete_CandidateCampaign_signal")
+    # logger.debug("search.delete_CandidateCampaign_signal")
     if 'elastic_search_object' in globals():
         try:
             res = elastic_search_object.delete(index="candidates", doc_type='candidate', id=instance.id)
@@ -61,7 +61,7 @@ def delete_candidate_campaign_signal(sender, instance, **kwargs):
 # ContestMeasure
 @receiver(post_save, sender=ContestMeasure)
 def save_contest_measure_signal(sender, instance, **kwargs):
-    logger.debug("search.save_ContestMeasure_signal")
+    # logger.debug("search.save_ContestMeasure_signal")
     if 'elastic_search_object' in globals():
         doc = {
             "we_vote_id": instance.we_vote_id,
@@ -81,7 +81,7 @@ def save_contest_measure_signal(sender, instance, **kwargs):
 
 @receiver(post_delete, sender=ContestMeasure)
 def delete_contest_measure_signal(sender, instance, **kwargs):
-    logger.debug("search.delete_ContestMeasure_signal")
+    # logger.debug("search.delete_ContestMeasure_signal")
     if 'elastic_search_object' in globals():
         try:
             res = elastic_search_object.delete(index="measures", doc_type='measure', id=instance.id)
@@ -94,7 +94,7 @@ def delete_contest_measure_signal(sender, instance, **kwargs):
 # ContestOffice
 @receiver(post_save, sender=ContestOffice)
 def save_contest_office_signal(sender, instance, **kwargs):
-    logger.debug("search.save_ContestOffice_signal")
+    # logger.debug("search.save_ContestOffice_signal")
     if 'elastic_search_object' in globals():
         doc = {
             "we_vote_id": instance.we_vote_id,
@@ -112,7 +112,7 @@ def save_contest_office_signal(sender, instance, **kwargs):
 
 @receiver(post_delete, sender=ContestOffice)
 def delete_contest_office_signal(sender, instance, **kwargs):
-    logger.debug("search.delete_ContestOffice_signal")
+    # logger.debug("search.delete_ContestOffice_signal")
     if 'elastic_search_object' in globals():
         try:
             res = elastic_search_object.delete(index="offices", doc_type='office', id=instance.id)
@@ -125,7 +125,7 @@ def delete_contest_office_signal(sender, instance, **kwargs):
 # Organization
 @receiver(post_save, sender=Organization)
 def save_organization_signal(sender, instance, **kwargs):
-    logger.debug("search.save_Organization_signal")
+    # logger.debug("search.save_Organization_signal")
     if 'elastic_search_object' in globals():
         doc = {
             "we_vote_id": instance.we_vote_id,
@@ -145,7 +145,7 @@ def save_organization_signal(sender, instance, **kwargs):
 
 @receiver(post_delete, sender=Organization)
 def delete_organization_signal(sender, instance, **kwargs):
-    logger.debug("search.delete_Organization_signal")
+    # logger.debug("search.delete_Organization_signal")
     if 'elastic_search_object' in globals():
         try:
             res = elastic_search_object.delete(index="organizations", doc_type='organization', id=instance.id)

--- a/wevote_functions/admin.py
+++ b/wevote_functions/admin.py
@@ -15,7 +15,7 @@ from config.base import get_environment_variable, convert_logging_level
 
 _ch = None  # root stream handler.
 _fh = None  # root file handler.
-_only_log_once = None
+_only_log_once = None  # if LOG_FILE_LEVEL is misconfigured, only log that config error once per start-up of the server
 host = socket.gethostname()
 
 
@@ -50,11 +50,11 @@ def get_logger(name):
             level = convert_logging_level(environment_variable_log_level)
             if isinstance(level, int):
                 logger.level = level
-            elif (not _only_log_once):
-                logger.error("LOG_FILE_LEVEL is invalid", {}, {})  # startup.run hasn't run yet, so just to the console
+            elif not _only_log_once:
+                logger.error("LOG_FILE_LEVEL is invalid", {}, {})  # setup_logging hasn't run yet so just to the console
                 _only_log_once = True
-        elif not (not _only_log_once):
-            logger.error("LOG_FILE_LEVEL is not set", {}, {})  # startup.run() hasn't run yet, so just to the console
+        elif not _only_log_once:
+            logger.error("LOG_FILE_LEVEL is not set", {}, {})  # setup_logging() hasn't run yet, so just to the console
             _only_log_once = True
 
     return logger

--- a/wevote_functions/admin.py
+++ b/wevote_functions/admin.py
@@ -15,7 +15,7 @@ from config.base import get_environment_variable, convert_logging_level
 
 _ch = None  # root stream handler.
 _fh = None  # root file handler.
-_only_log_once = None
+_only_log_once = None  # if LOG_FILE_LEVEL is misconfigured, only log that config error once per start-up of the server
 host = socket.gethostname()
 
 

--- a/wevote_settings/models.py
+++ b/wevote_settings/models.py
@@ -70,7 +70,7 @@ class WeVoteSettingsManager(models.Model):
             elif type(setting_value).__name__ == 'str':
                 value_type = WeVoteSetting.STRING
             elif type(setting_value).__name__ == 'list':
-                logger.info("setting is a list. To be developed", {}, {})
+                logger.info("setting is a list. To be developed")
                 value_type = WeVoteSetting.STRING
             else:
                 value_type = WeVoteSetting.STRING


### PR DESCRIPTION
Logging controlled by LOG_FILE_LEVEL now works, so we can have other 
than ERROR level log lines (DEBUG, WARNING, INFO etc) if so configured with LOG_FILE_LEVEL.
Now that log lines other than ERROR work, it became clear that the non-ERROR lines don't need the two empty dictionaries passed with the call.