### PR TITLE
logger.error() call fixes.

### DIFF
--- a/apis_v1/views/views_donation.py
+++ b/apis_v1/views/views_donation.py
@@ -143,22 +143,15 @@ def donation_stripe_webhook_view(request):
         event = stripe.Webhook.construct_event(payload, sig_header, endpoint_secret)
 
     except ValueError as e:
-        logger.error("donation_stripe_webhook_view, Stripe returned 'Invalid payload'", {}, {})
+        logger.error("donation_stripe_webhook_view, Stripe returned 'Invalid payload'")
         return HttpResponse(status=400)
 
     except stripe.error.SignatureVerificationError as err:
-        logger.error("donation_stripe_webhook_view, Stripe returned SignatureVerificationError: " + str(err),
-                     {}, {})
-        # Temporary test logging for master server 6/27/17
-        logger.debug("Temporary test logging for master server 6/27/17 - debug")
-        logger.info("Temporary test logging for master server 6/27/17 - info")
-        logger.warn("Temporary test logging for master server 6/27/17 - warn")
-        # End Temporary test logging for master server 6/27/17
-
+        logger.error("donation_stripe_webhook_view, Stripe returned SignatureVerificationError: " + str(err))
         return HttpResponse(status=400)
 
     except Exception as err:
-        logger.error("donation_stripe_webhook_view: " + str(err), {}, {})
+        logger.error("donation_stripe_webhook_view: " + str(err))
         return HttpResponse(status=400)
 
     donation_process_stripe_webhook_event(event)

--- a/ballot/controllers.py
+++ b/ballot/controllers.py
@@ -342,7 +342,7 @@ def ballot_returned_import_from_structured_json(structured_json):
                 if 'text_for_map_search' in one_ballot_returned else False
             if latitude == False or latitude == None or longitude == False or longitude == None:
                 if text_for_map_search == False:
-                    logger.warn("Bad data received in ballot_returned_import_from_structured_json:" + str(one_ballot_returned))
+                    logger.warning("Bad data received in ballot_returned_import_from_structured_json:" + str(one_ballot_returned))
                 else:
                     latitude, longitude = heal_geo_coordinates(text_for_map_search)
 

--- a/bookmark/models.py
+++ b/bookmark/models.py
@@ -165,7 +165,7 @@ class BookmarkItemManager(models.Model):
                 status = 'FAILED_TO_UPDATE ' + bookmark_status
                 handle_record_not_saved_exception(e, logger=logger, exception_message_optional=status)
         elif results['MultipleObjectsReturned']:
-            logger.warn("bookmark_item: delete all but one and take it over?")
+            logger.warning("bookmark_item: delete all but one and take it over?")
             status = 'TOGGLE_ITEM_BOOKMARKED MultipleObjectsReturned ' + bookmark_status
         elif results['DoesNotExist']:
             try:

--- a/candidate/models.py
+++ b/candidate/models.py
@@ -476,10 +476,10 @@ class CandidateCampaign(models.Model):
             election = Election.objects.get(google_civic_election_id=self.google_civic_election_id)
         except Election.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("candidate.election Found multiple", {}, {})
+            logger.error("candidate.election Found multiple")
             return
         except Election.DoesNotExist:
-            logger.error("candidate.election did not find", {}, {})
+            logger.error("candidate.election did not find")
             return
         return election
 
@@ -488,10 +488,10 @@ class CandidateCampaign(models.Model):
             office = ContestOffice.objects.get(id=self.contest_office_id)
         except ContestOffice.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("candidate.election Found multiple", {}, {})
+            logger.error("candidate.election Found multiple")
             return
         except ContestOffice.DoesNotExist:
-            logger.error("candidate.election did not find", {}, {})
+            logger.error("candidate.election did not find")
             return
         return office
 

--- a/donate/controllers.py
+++ b/donate/controllers.py
@@ -197,7 +197,7 @@ def donation_with_stripe_for_api(request, token, email, donation_amount, monthly
                                     error_message=error_from_json['message'])
         status = textwrap.shorten(donation_status + " " + status, width=255, placeholder="...")
         error_message = translate_stripe_error_to_voter_explanation_text(e.http_status, error_from_json['type'])
-        logger.error("donation_with_stripe_for_api, CardError: " + error_message, {}, {})
+        logger.error("donation_with_stripe_for_api, CardError: " + error_message)
         # error_text_description = donation_status
     except stripe.error.StripeError as e:
         body = e.json_body
@@ -208,11 +208,11 @@ def donation_with_stripe_for_api(request, token, email, donation_amount, monthly
                                     error_message=error_from_json['message'])
         status = textwrap.shorten(donation_status + " " + status, width=255, placeholder="...")
         error_message = translate_stripe_error_to_voter_explanation_text(e.http_status, error_from_json['type'])
-        logger.error("donation_with_stripe_for_api, StripeError : " + donation_status, {}, {})
+        logger.error("donation_with_stripe_for_api, StripeError : " + donation_status)
     except Exception as err:
         # Something else happened, completely unrelated to Stripe
         donation_status = "A_NON_STRIPE_ERROR_OCCURRED "
-        logger.error("donation_with_stripe_for_api threw " + str(err), {}, {})
+        logger.error("donation_with_stripe_for_api threw " + str(err))
         status = textwrap.shorten(donation_status + " " + status, width=255, placeholder="...")
         error_message = 'Your payment was unsuccessful. Please try again later.'
     if "already has the maximum 25 current subscriptions" in status:
@@ -286,7 +286,7 @@ def is_voter_logged_in(request):
     voter_results = voter_manager.retrieve_voter_from_voter_device_id(voter_device_id)
     voter_id = voter_results['voter_id']
     if not positive_value_exists(voter_id):
-        logger.error("invalid voter_device_id passed to is_voter_logged_in" + voter_device_id, {}, {})
+        logger.error("invalid voter_device_id passed to is_voter_logged_in" + voter_device_id)
         return False
     voter = voter_results['voter']
     return voter.is_signed_in()
@@ -415,10 +415,10 @@ def donation_process_charge(event):           # 'charge.succeeded'
     except stripe.error.StripeError as e:
         body = e.json_body
         error_from_json = body['error']
-        logger.error("donation_process_charge, Stripe: " + error_from_json, {}, {})
+        logger.error("donation_process_charge, Stripe: " + error_from_json)
 
     except Exception as err:
-        logger.error("donation_process_charge, general: " + str(err), {}, {})
+        logger.error("donation_process_charge, general: " + str(err))
 
     return None
 
@@ -522,7 +522,7 @@ def donation_process_subscription_payment(event):
         DonationManager.update_subscription_in_db(row_id, amount, currency, id_card, address_zip, brand, country,
                                                   exp_month, exp_year, funding)
     except Exception as err:
-        logger.error("donation_process_subscription_payment: " + str(err), {}, {})
+        logger.error("donation_process_subscription_payment: " + str(err))
 
     return None
 
@@ -550,16 +550,16 @@ def donation_refund_for_api(request, charge, voter_we_vote_id):
     except stripe.error.InvalidRequestError as err:
         body = err.json_body
         error_string = body['error']['message']
-        logger.error("donation_refund_for_api: " + error_string, {}, {})
+        logger.error("donation_refund_for_api: " + error_string)
         success = DonationManager.update_journal_entry_for_already_refunded(charge, voter_we_vote_id)
         return success
 
     except DonationManager.DoesNotExist as err:
-        logger.error("donation_refund_for_api returned DoesNotExist for : " + charge, {}, {})
+        logger.error("donation_refund_for_api returned DoesNotExist for : " + charge)
         return False
 
     except Exception as err:
-        logger.error("donation_refund_for_api: " + str(err), {}, {})
+        logger.error("donation_refund_for_api: " + str(err))
         return False
 
     success = DonationManager.update_journal_entry_for_refund(charge, voter_we_vote_id, refund)
@@ -603,7 +603,7 @@ def donation_subscription_cancellation_for_api(request, subscription_id, voter_w
             'success': True,
         }
     except Exception as err:
-        logger.error("donation_subscription_cancellation_for_api err " + str(err), {}, {})
+        logger.error("donation_subscription_cancellation_for_api err " + str(err))
         json_returned = {
             'status': "Error: " + str(err),
             'subscription_id': subscription_id,

--- a/donate/models.py
+++ b/donate/models.py
@@ -397,7 +397,7 @@ class DonationManager(models.Model):
                 body = e.json_body
                 err = body['error']
                 status = "STRIPE_ERROR_IS_" + err['message'] + "_END"
-                logger.error("create_recurring_donation StripeError: " + status, {}, {})
+                logger.error("create_recurring_donation StripeError: " + status)
 
                 results = {
                     'success': False,
@@ -551,8 +551,8 @@ class DonationManager(models.Model):
             subscription_row.save()
 
         except DonationJournal.DoesNotExist:
-            logger.error("mark_subscription_canceled_or_ended: Subscription " + subscription_id + " with customer_id " + customer_id + " does not exist",
-                         {}, {})
+            logger.error("mark_subscription_canceled_or_ended: Subscription " + subscription_id + " with customer_id " +
+                         customer_id + " does not exist")
             return False
 
         except Exception as e:
@@ -596,7 +596,7 @@ class DonationManager(models.Model):
 
         except Exception as e:
             status += " EXCEPTION-IN-move_donations_between_donors "
-            logger.error("move_donations_between_donors 2:" + status, {}, {})
+            logger.error("move_donations_between_donors 2:" + status)
             results = {
                 'status': status,
                 'success': False,
@@ -627,9 +627,9 @@ class DonationManager(models.Model):
                     row_id = row.id
         except DonationJournal.DoesNotExist:
             logger.error("check_for_subscription_in_db_without_card_info row does not exist for stripe customer" +
-                         customer, {}, {})
+                         customer)
         except Exception as e:
-            logger.error("check_for_subscription_in_db_without_card_info Exception " + str(e), {}, {})
+            logger.error("check_for_subscription_in_db_without_card_info Exception " + str(e))
 
         return row_id
 
@@ -651,7 +651,7 @@ class DonationManager(models.Model):
             logger.debug("update_subscription_in_db row=" + str(row_id) + ", plan_id=" + str(row.subscription_plan_id) +
                          ", amount=" + str(amount))
         except Exception as err:
-            logger.error("update_subscription_in_db: " + str(err), {}, {})
+            logger.error("update_subscription_in_db: " + str(err))
 
         return
 
@@ -670,9 +670,9 @@ class DonationManager(models.Model):
             return ""
 
         except DonationJournal.DoesNotExist:
-            logger.error("find_we_vote_voter_id_for_stripe_customer row does not exist", {}, {})
+            logger.error("find_we_vote_voter_id_for_stripe_customer row does not exist")
         except Exception as e:
-            logger.error("find_we_vote_voter_id_for_stripe_customer: " + str(e), {}, {})
+            logger.error("find_we_vote_voter_id_for_stripe_customer: " + str(e))
 
         return ""
 
@@ -691,7 +691,7 @@ class DonationManager(models.Model):
             return "True"
 
         logger.error("update_journal_entry_for_refund bad charge or refund for charge_id " + charge +
-                     " and voter_we_vote_id " + voter_we_vote_id, {}, {})
+                     " and voter_we_vote_id " + voter_we_vote_id)
         return "False"
 
     @staticmethod
@@ -720,5 +720,5 @@ class DonationManager(models.Model):
             return "True"
 
         except DonationJournal.DoesNotExist:
-            logger.error("update_journal_entry_for_refund_completed row does not exist for charge " + charge, {}, {})
+            logger.error("update_journal_entry_for_refund_completed row does not exist for charge " + charge)
         return "False"

--- a/election/controllers.py
+++ b/election/controllers.py
@@ -22,7 +22,7 @@ def election_remote_retrieve():
     error = structured_json.get('error', {})
     errors = error.get('errors', {})
     if not retrieve_results['success'] or len('errors'):  # Success refers to http success, not an error free response
-        logger.error("Loading Election from Google Civic failed: " + json.dumps(errors), {}, {})
+        logger.error("Loading Election from Google Civic failed: " + json.dumps(errors))
         results = {
             'success':  False,
             'status':   retrieve_results['status']

--- a/exception/models.py
+++ b/exception/models.py
@@ -18,12 +18,12 @@ def _log_exception(exception_message, logger, e):
     frame = caller_frame_record[0]
     info = inspect.getframeinfo(frame)
 
-    logger.error(e, {}, {})
+    logger.error(e)
     logger.error("{message}, function: {function}, file: {filename}, line: {line}".format(
         message=exception_message,
         filename=info.filename,
         function=info.function,
-        line=info.lineno), {}, {})
+        line=info.lineno))
 
 
 def handle_exception(e, logger=None, exception_message=""):
@@ -68,4 +68,4 @@ def _log_print(exception_message, logger):
         message=exception_message,
         filename=info.filename,
         function=info.function,
-        line=info.lineno), {}, {})
+        line=info.lineno))

--- a/follow/models.py
+++ b/follow/models.py
@@ -156,7 +156,7 @@ class FollowIssueManager(models.Model):
                 status = 'FAILED_TO_UPDATE ' + following_status
                 handle_record_not_saved_exception(e, logger=logger, exception_message_optional=status)
         elif results['MultipleObjectsReturned']:
-            logger.warn("follow_issue: delete all but one and take it over?")
+            logger.warning("follow_issue: delete all but one and take it over?")
             status = 'TOGGLE_FOLLOWING MultipleObjectsReturned ' + following_status
         elif results['DoesNotExist']:
             try:
@@ -575,7 +575,7 @@ class FollowOrganizationManager(models.Model):
                 status = 'FAILED_TO_UPDATE ' + following_status
                 handle_record_not_saved_exception(e, logger=logger, exception_message_optional=status)
         elif results['MultipleObjectsReturned']:
-            logger.warn("follow_organization: delete all but one and take it over?")
+            logger.warning("follow_organization: delete all but one and take it over?")
             status = 'TOGGLE_FOLLOWING MultipleObjectsReturned ' + following_status
         elif results['DoesNotExist']:
             try:

--- a/import_export_maplight/controllers.py
+++ b/import_export_maplight/controllers.py
@@ -128,7 +128,7 @@ def import_maplight_contest_office_candidates_from_array(politicians_running_for
             one_politician_array['candidate_id'])
 
         if maplight_candidate.id:
-            logger.warn(u"Candidate {display_name} previously saved".format(
+            logger.warning(u"Candidate {display_name} previously saved".format(
                 display_name=maplight_candidate.display_name
             ))
         else:

--- a/import_export_maplight/controllers.py
+++ b/import_export_maplight/controllers.py
@@ -56,7 +56,7 @@ def import_maplight_from_json(request):
                             politicians_running_for_one_contest_array = json.load(json_data)
                     except Exception as e:
                         logger.error("File {file_path} not found.".format(
-                            file_path=json_file_with_the_data_from_this_contest), {}, {})
+                            file_path=json_file_with_the_data_from_this_contest))
                         # Don't try to process the file if it doesn't exist, but go to the next entry
                         continue
 

--- a/import_export_maplight/views_admin.py
+++ b/import_export_maplight/views_admin.py
@@ -74,21 +74,21 @@ def transfer_maplight_data_to_we_vote_tables(request):
             one_candidate_from_maplight_table.candidate_id)
 
         if not results['success']:
-            logger.warn(u"Candidate NOT found by MapLight id: {name}".format(
+            logger.warning(u"Candidate NOT found by MapLight id: {name}".format(
                 name=one_candidate_from_maplight_table.candidate_id
             ))
             results = candidate_campaign_manager.retrieve_candidate_campaign_from_candidate_name(
                 one_candidate_from_maplight_table.display_name)
 
             if not results['success']:
-                logger.warn(u"Candidate NOT found by display_name: {name}".format(
+                logger.warning(u"Candidate NOT found by display_name: {name}".format(
                     name=one_candidate_from_maplight_table.display_name
                 ))
                 results = candidate_campaign_manager.retrieve_candidate_campaign_from_candidate_name(
                     one_candidate_from_maplight_table.original_name)
 
                 if not results['success']:
-                    logger.warn(u"Candidate NOT found by original_name: {name}".format(
+                    logger.warning(u"Candidate NOT found by original_name: {name}".format(
                         name=one_candidate_from_maplight_table.original_name
                     ))
 
@@ -103,7 +103,7 @@ def transfer_maplight_data_to_we_vote_tables(request):
                         results = candidate_campaign_manager.retrieve_candidate_campaign_from_candidate_name(
                             one_mapping_google_civic_name)
                     if not results['success'] or not positive_value_exists(one_mapping_google_civic_name):
-                        logger.warn(u"Candidate NOT found by mapping to google_civic name: {name}".format(
+                        logger.warning(u"Candidate NOT found by mapping to google_civic name: {name}".format(
                             name=one_mapping_google_civic_name
                         ))
 

--- a/issue/models.py
+++ b/issue/models.py
@@ -595,7 +595,7 @@ class OrganizationLinkToIssueManager(models.Model):
                 status = 'FAILED_TO_UPDATE ' + str(link_active)
                 handle_record_not_saved_exception(e, logger=logger, exception_message_optional=status)
         elif results['MultipleObjectsReturned']:
-            logger.warn("link_issue: delete all but one and take it over?")
+            logger.warning("link_issue: delete all but one and take it over?")
             status = 'TOGGLE_LINKING MultipleObjectsReturned ' + str(link_active)
         elif results['DoesNotExist']:
             try:

--- a/measure/views_admin.py
+++ b/measure/views_admin.py
@@ -70,7 +70,7 @@ def measures_import_from_master_server_view(request):  # GET '/m/import/?google_
     state_code = request.GET.get('state_code', '')
 
     if not positive_value_exists(google_civic_election_id):
-        logger.error("measures_import_from_master_server_view did not receive a google_civic_election_id", {}, {})
+        logger.error("measures_import_from_master_server_view did not receive a google_civic_election_id")
 
     results = measures_import_from_master_server(request, google_civic_election_id, state_code)
 

--- a/organization/models.py
+++ b/organization/models.py
@@ -183,12 +183,12 @@ class OrganizationManager(models.Manager):
             error_result = True
             exception_multiple_object_returned = True
             status = "ERROR_MORE_THAN_ONE_ORGANIZATION_FOUND"
-            # logger.warn("Organization.MultipleObjectsReturned")
+            # logger.warning("Organization.MultipleObjectsReturned")
         except Organization.DoesNotExist:
             error_result = True
             exception_does_not_exist = True
             status += ", ORGANIZATION_NOT_FOUND"
-            # logger.warn("Organization.DoesNotExist")
+            # logger.warning("Organization.DoesNotExist")
 
         organization_on_stage_found = True if organization_on_stage_id > 0 else False
         results = {
@@ -640,7 +640,7 @@ class OrganizationManager(models.Manager):
                                     found_with_status = "FOUND_WITH_FACEBOOK_LINK_TO_VOTER"
                                 except Organization.MultipleObjectsReturned as e:
                                     exception_multiple_object_returned = True
-                                    logger.warn("Organization.MultipleObjectsReturned FACEBOOK_LINK_TO_VOTER")
+                                    logger.warning("Organization.MultipleObjectsReturned FACEBOOK_LINK_TO_VOTER")
                                 except Organization.DoesNotExist as e:
                                     # Not a problem -- an organization matching this facebook_id wasn't found
                                     exception_does_not_exist = True
@@ -655,7 +655,7 @@ class OrganizationManager(models.Manager):
                     except Organization.MultipleObjectsReturned as e:
                         handle_record_found_more_than_one_exception(e, logger)
                         exception_multiple_object_returned = True
-                        logger.warn("Organization.MultipleObjectsReturned facebook_id")
+                        logger.warning("Organization.MultipleObjectsReturned facebook_id")
                     except Organization.DoesNotExist as e:
                         # Not a problem -- an organization matching this facebook_id wasn't found
                         exception_does_not_exist = True
@@ -670,7 +670,7 @@ class OrganizationManager(models.Manager):
                     except Organization.MultipleObjectsReturned as e:
                         handle_record_found_more_than_one_exception(e, logger)
                         exception_multiple_object_returned = True
-                        logger.warn("Organization.MultipleObjectsReturned organization_website")
+                        logger.warning("Organization.MultipleObjectsReturned organization_website")
                     except Organization.DoesNotExist as e:
                         # Not a problem -- an organization matching this organization_website wasn't found
                         exception_does_not_exist = True
@@ -685,7 +685,7 @@ class OrganizationManager(models.Manager):
                     except Organization.MultipleObjectsReturned as e:
                         handle_record_found_more_than_one_exception(e, logger)
                         exception_multiple_object_returned = True
-                        logger.warn("Organization.MultipleObjectsReturned organization_twitter_handle")
+                        logger.warning("Organization.MultipleObjectsReturned organization_twitter_handle")
                     except Organization.DoesNotExist as e:
                         # Not a problem -- an organization matching this twitter handle wasn't found
                         exception_does_not_exist = True

--- a/position/models.py
+++ b/position/models.py
@@ -344,7 +344,7 @@ class PositionEntered(models.Model):
         try:
             candidate_campaign = CandidateCampaign.objects.get(id=self.candidate_campaign_id)
         except CandidateCampaign.MultipleObjectsReturned as e:
-            logger.error("position.candidate_campaign Found multiple", {}, {})
+            logger.error("position.candidate_campaign Found multiple")
             return
         except CandidateCampaign.DoesNotExist:
             return
@@ -356,7 +356,7 @@ class PositionEntered(models.Model):
         try:
             contest_measure = ContestMeasure.objects.get(id=self.contest_measure_id)
         except ContestMeasure.MultipleObjectsReturned as e:
-            logger.error("position.contest_measure Found multiple", {}, {})
+            logger.error("position.contest_measure Found multiple")
             return
         except ContestMeasure.DoesNotExist:
             return
@@ -369,7 +369,7 @@ class PositionEntered(models.Model):
             election = Election.objects.get(google_civic_election_id=self.google_civic_election_id)
         except Election.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.election Found multiple", {}, {})
+            logger.error("position.election Found multiple")
             return
         except Election.DoesNotExist:
             return
@@ -382,7 +382,7 @@ class PositionEntered(models.Model):
             organization = Organization.objects.get(id=self.organization_id)
         except Organization.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.organization Found multiple", {}, {})
+            logger.error("position.organization Found multiple")
             return
         except Organization.DoesNotExist:
             return
@@ -683,7 +683,7 @@ class PositionForFriends(models.Model):
             candidate_campaign = CandidateCampaign.objects.get(id=self.candidate_campaign_id)
         except CandidateCampaign.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.candidate_campaign Found multiple", {}, {})
+            logger.error("position.candidate_campaign Found multiple")
             return
         except CandidateCampaign.DoesNotExist:
             return
@@ -696,7 +696,7 @@ class PositionForFriends(models.Model):
             contest_measure = ContestMeasure.objects.get(id=self.contest_measure_id)
         except ContestMeasure.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.candidate_campaign Found multiple", {}, {})
+            logger.error("position.candidate_campaign Found multiple")
             return
         except ContestMeasure.DoesNotExist:
             return
@@ -709,7 +709,7 @@ class PositionForFriends(models.Model):
             election = Election.objects.get(google_civic_election_id=self.google_civic_election_id)
         except Election.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.election Found multiple", {}, {})
+            logger.error("position.election Found multiple")
             return
         except Election.DoesNotExist:
             return
@@ -722,7 +722,7 @@ class PositionForFriends(models.Model):
             organization = Organization.objects.get(id=self.organization_id)
         except Organization.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("position.organization Found multiple", {}, {})
+            logger.error("position.organization Found multiple")
             return
         except Organization.DoesNotExist:
             return

--- a/search/models.py
+++ b/search/models.py
@@ -41,9 +41,9 @@ def save_candidate_campaign_signal(sender, instance, **kwargs):
         try:
             res = elastic_search_object.index(index="candidates", doc_type='candidate', id=instance.id, body=doc)
             if res["_shards"]["successful"] <= 1:
-                logger.error("failed to index CandidateCampaign " + instance.we_vote_id, {}, {})
+                logger.error("failed to index CandidateCampaign " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err, {}, {})
+            logger.error(err)
 
 
 @receiver(post_delete, sender=CandidateCampaign)
@@ -53,9 +53,9 @@ def delete_candidate_campaign_signal(sender, instance, **kwargs):
         try:
             res = elastic_search_object.delete(index="candidates", doc_type='candidate', id=instance.id)
             if res["_shards"]["successful"] <= 1:
-                logger.error("failed to delete CandidateCampaign " + instance.we_vote_id, {}, {})
+                logger.error("failed to delete CandidateCampaign " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err, {}, {})
+            logger.error(err)
 
 
 # ContestMeasure
@@ -74,9 +74,9 @@ def save_contest_measure_signal(sender, instance, **kwargs):
         try:
             res = elastic_search_object.index(index="measures", doc_type='measure', id=instance.id, body=doc)
             if res["_shards"]["successful"] <= 1:
-                logger.error("failed to index ContestMeasure " + instance.we_vote_id, {}, {})
+                logger.error("failed to index ContestMeasure " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err, {}, {})
+            logger.error(err)
 
 
 @receiver(post_delete, sender=ContestMeasure)
@@ -86,9 +86,9 @@ def delete_contest_measure_signal(sender, instance, **kwargs):
         try:
             res = elastic_search_object.delete(index="measures", doc_type='measure', id=instance.id)
             if res["_shards"]["successful"] <= 1:
-                logger.error("failed to delete ContestMeasure " + instance.we_vote_id, {}, {})
+                logger.error("failed to delete ContestMeasure " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err, {}, {})
+            logger.error(err)
 
 
 # ContestOffice
@@ -105,9 +105,9 @@ def save_contest_office_signal(sender, instance, **kwargs):
         try:
             res = elastic_search_object.index(index="offices", doc_type='office', id=instance.id, body=doc)
             if res["_shards"]["successful"] <= 1:
-                logger.error("failed to index ContestMeasure " + instance.we_vote_id, {}, {})
+                logger.error("failed to index ContestMeasure " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err, {}, {})
+            logger.error(err)
 
 
 @receiver(post_delete, sender=ContestOffice)
@@ -117,9 +117,9 @@ def delete_contest_office_signal(sender, instance, **kwargs):
         try:
             res = elastic_search_object.delete(index="offices", doc_type='office', id=instance.id)
             if res["_shards"]["successful"] <= 1:
-                logger.error("failed to delete ContestMeasure " + instance.we_vote_id, {}, {})
+                logger.error("failed to delete ContestMeasure " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err, {}, {})
+            logger.error(err)
 
 
 # Organization
@@ -138,9 +138,9 @@ def save_organization_signal(sender, instance, **kwargs):
         try:
             res = elastic_search_object.index(index="organizations", doc_type='organization', id=instance.id, body=doc)
             if res["_shards"]["successful"] <= 1:
-                logger.error("failed to index Organization " + instance.we_vote_id, {}, {})
+                logger.error("failed to index Organization " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err, {}, {})
+            logger.error(err)
 
 
 @receiver(post_delete, sender=Organization)
@@ -150,9 +150,9 @@ def delete_organization_signal(sender, instance, **kwargs):
         try:
             res = elastic_search_object.delete(index="organizations", doc_type='organization', id=instance.id)
             if res["_shards"]["successful"] <= 1:
-                logger.error("failed to delete Organization " + instance.we_vote_id, {}, {})
+                logger.error("failed to delete Organization " + instance.we_vote_id)
         except Exception as err:
-            logger.error(err, {}, {})
+            logger.error(err)
 
 
 # @receiver(post_save)

--- a/voter_guide/models.py
+++ b/voter_guide/models.py
@@ -683,10 +683,10 @@ class VoterGuide(models.Model):
             organization = Organization.objects.get(we_vote_id=self.organization_we_vote_id)
         except Organization.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("voter_guide.organization Found multiple", {}, {})
+            logger.error("voter_guide.organization Found multiple")
             return
         except Organization.DoesNotExist:
-            logger.error("voter_guide.organization did not find", {}, {})
+            logger.error("voter_guide.organization did not find")
             return
         return organization
 
@@ -1432,9 +1432,9 @@ class VoterGuidePossibility(models.Model):
             organization = Organization.objects.get(we_vote_id=self.organization_we_vote_id)
         except Organization.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
-            logger.error("voter_guide.organization Found multiple", {}, {})
+            logger.error("voter_guide.organization Found multiple")
             return
         except Organization.DoesNotExist:
-            logger.error("voter_guide.organization did not find", {}, {})
+            logger.error("voter_guide.organization did not find")
             return
         return organization

--- a/wevote_functions/admin.py
+++ b/wevote_functions/admin.py
@@ -51,10 +51,10 @@ def get_logger(name):
             if isinstance(level, int):
                 logger.level = level
             elif not _only_log_once:
-                logger.error("LOG_FILE_LEVEL is invalid", {}, {})  # setup_logging hasn't run yet so just to the console
+                logger.error("LOG_FILE_LEVEL is invalid")  # setup_logging hasn't run yet so just to the console
                 _only_log_once = True
         elif not _only_log_once:
-            logger.error("LOG_FILE_LEVEL is not set", {}, {})  # setup_logging() hasn't run yet, so just to the console
+            logger.error("LOG_FILE_LEVEL is not set")  # setup_logging() hasn't run yet, so just to the console
             _only_log_once = True
 
     return logger

--- a/wevote_social/facebook.py
+++ b/wevote_social/facebook.py
@@ -29,7 +29,7 @@ class FacebookAPI(object):
         try:
             friends = json.loads(urlopen(request).read()).get('data')
         except Exception as err:
-            logger.error(err, {}, {})
+            logger.error(err)
 
         return friends
 

--- a/wevote_social/utils.py
+++ b/wevote_social/utils.py
@@ -152,7 +152,7 @@ def social_user(backend, uid, details, user=None, *args, **kwargs):
 def switch_user(backend, switch_user=False, user=None, social=None, *args, **kwargs):
 
     if switch_user and social:
-        logger.warn('[authplus.social_pipeline.switch_user] switch to user %s' % user.email)
+        logger.warning('[authplus.social_pipeline.switch_user] switch to user %s' % user.email)
 
         # Do we have a voter who's twitter_id matches the incoming user_id?
         # Is social.user_id the Twitter id?


### PR DESCRIPTION
In Python 3.4 (what we are still using on the Master application servers) and in the latest Python 3.6.1, logger.error("some string") works fine.
In Python 3.6, that same logger.error would need to pass empty arrays
for args and kwargs... logger.error("some string", {}, {})
Upgraded my local to 3.6.1, and made code changes to remove all of those
empty arrays for logger.error() calls in the codebase.
Changed calls from deprecated logger.warn() to logger.warning()