### PR TITLE
Removed state_code from BallotReturned since we already have normalized_state. Fixed bug where old ballot items were not being deleted when you switched to a new address in the same election. Removed code that locks us to google_civic_election_id 5000.

### DIFF
--- a/templates/election/election_summary.html
+++ b/templates/election/election_summary.html
@@ -88,6 +88,7 @@
             <td>Text for Map Search</td>
             <td>Voter Id</td>
             <td>Lat/Long?</td>
+            <td>normalized_state</td>
             <td><a href="{% url 'election:election_summary' election.id %}?google_civic_election_id={{ election.google_civic_election_id }}&state_code={{ state_code }}&show_offices_and_candidates=1">
                 Offices & Candidates</a></td>
             <td>&nbsp;</td>
@@ -96,10 +97,11 @@
         <tr>
             <td>{{ forloop.counter }}</td>
             <td><a href="{% url 'ballot:ballot_item_list_edit' ballot_returned.id %}">{{ ballot_returned.id }}</a></td>
-            <td>{{ ballot_returned.polling_location_we_vote_id }}</td>
+            <td>{{ ballot_returned.polling_location_we_vote_id|default_if_none:"" }}</td>
             <td>{{ ballot_returned.text_for_map_search }}</td>
             <td>{% if ballot_returned.voter_id != 0 %}{{ ballot_returned.voter_id }}{% endif %}</td>
             <td>{% if ballot_returned.latitude %}yes{% endif %}</td>
+            <td>{{ ballot_returned.normalized_state|default_if_none:"" }}</td>
             <td>{% if ballot_returned.office_and_candidate_text %}{{ ballot_returned.office_and_candidate_text }}{% endif %}</td>
             <td><a href="{% url 'ballot:ballot_item_list_edit' ballot_returned.id %}">(edit)</a></td>
         </tr>


### PR DESCRIPTION
Removed state_code from BallotReturned since we already have normalized_state. Fixed bug where old ballot items were not being deleted when you switched to a new address in the same election. Removed code that locks us to google_civic_election_id 5000.