### PR TITLE
Twitter photos and banner are available immediately after first sign in for issue #377

### DIFF
--- a/import_export_twitter/controllers.py
+++ b/import_export_twitter/controllers.py
@@ -1211,6 +1211,20 @@ def twitter_sign_in_retrieve_for_api(voter_device_id):  # twitterSignInRetrieve
         'we_vote_hosted_profile_image_url_medium':  we_vote_hosted_profile_image_url_medium,
         'we_vote_hosted_profile_image_url_tiny':    we_vote_hosted_profile_image_url_tiny,
     }
+
+
+    if success:
+        twitter_profile_banner_url_https = ""
+        try:
+            twitter_profile_banner_url_https = twitter_user_results['twitter_user'].twitter_profile_banner_url_https
+        except Exception:
+            pass
+
+        OrganizationManager.update_organization_single_voter_data(twitter_auth_response.twitter_id,
+                                                                  we_vote_hosted_profile_image_url_large,
+                                                                  we_vote_hosted_profile_image_url_medium,
+                                                                  we_vote_hosted_profile_image_url_tiny,
+                                                                  twitter_profile_banner_url_https)
     return json_data
 
 

--- a/organization/models.py
+++ b/organization/models.py
@@ -1029,6 +1029,38 @@ class OrganizationManager(models.Manager):
         }
         return results
 
+    @staticmethod
+    def update_organization_single_voter_data(twitter_user_id,
+                                              we_vote_hosted_profile_image_url_large,
+                                              we_vote_hosted_profile_image_url_medium,
+                                              we_vote_hosted_profile_image_url_tiny,
+                                              twitter_profile_banner_url_https):
+        """
+        Make a best effort to update the organization for a single voter with twitter images
+        :param twitter_user_id:
+        :param we_vote_hosted_profile_image_url_large:
+        :param we_vote_hosted_profile_image_url_medium:
+        :param we_vote_hosted_profile_image_url_tiny:
+        :param twitter_profile_banner_url_https:
+        :return: True/False
+        """
+
+        organization_manager = OrganizationManager()
+        results = organization_manager.retrieve_organization(0, '', '', twitter_user_id)
+
+        if not results['organization_found']:
+            logger.info("update_organization_single_voter_data was not able to find " + twitter_user_id)
+            return False
+
+        organization = results['organization']
+
+        organization.twitter_profile_banner_url_https = twitter_profile_banner_url_https
+        organization.we_vote_hosted_profile_image_url_large = we_vote_hosted_profile_image_url_large
+        organization.we_vote_hosted_profile_image_url_medium = we_vote_hosted_profile_image_url_medium
+        organization.we_vote_hosted_profile_image_url_tiny = we_vote_hosted_profile_image_url_tiny
+        organization.save()
+        return True
+
     def clear_organization_twitter_details(self, organization):
         """
         Update an organization entry with details retrieved from the Twitter API.


### PR DESCRIPTION
In import_export_twitter/controller, store the photos and banner in the
organization that is for a single user.
In import_export_twitter/models store the banner at auth time.
In organization/models added update_organization_single_voter_data()