### PR TITLE
Bugfixes for the facebook "cover" for issue #378

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -189,9 +189,13 @@ USE_TZ = True
 AUTH_USER_MODEL = 'voter.Voter'
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.8/howto/static-files/
+# https://docs.djangoproject.com/en/1.11/howto/static-files/ calls loading static files from the project
+# "grossly inefficient and probably insecure, so it is unsuitable for production", but we only use it (August 2017) to
+# serve apis_v1.css for the admin console.
+# If we ever care, there is a better way: https://docs.djangoproject.com/en/1.11/howto/static-files/deployment/
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(PROJECT_PATH, "static", "static")  # Django Cookbook
+STATIC_ROOT = os.path.join(PROJECT_PATH, "static", "static") if DEBUG else \
+    os.path.join(PROJECT_PATH, "apis_v1", "static") # Django Cookbook
 MEDIA_URL = '/media/'  # Django Cookbook
 MEDIA_ROOT = os.path.join(PROJECT_PATH, "static", "media")  # Django Cookbook
 

--- a/config/environment_variables-template.json
+++ b/config/environment_variables-template.json
@@ -109,5 +109,8 @@
   "PROFILE_IMAGE_LARGE_WIDTH":      "200",
   "PROFILE_IMAGE_LARGE_HEIGHT":     "200",
 
+  "_comment":                       "When SERVER_IN_DEBUG_MODE=false, STATIC_URL must be defined to serve static files.",
+  "STATIC_URL":                     "/static/",
+
   "_comment":                       "End of json_environment_variables.json"
 }

--- a/config/environment_variables-template.json
+++ b/config/environment_variables-template.json
@@ -109,8 +109,5 @@
   "PROFILE_IMAGE_LARGE_WIDTH":      "200",
   "PROFILE_IMAGE_LARGE_HEIGHT":     "200",
 
-  "_comment":                       "When SERVER_IN_DEBUG_MODE=false, STATIC_URL must be defined to serve static files.",
-  "STATIC_URL":                     "/static/",
-
   "_comment":                       "End of json_environment_variables.json"
 }

--- a/import_export_facebook/controllers.py
+++ b/import_export_facebook/controllers.py
@@ -56,7 +56,7 @@ def voter_facebook_save_to_current_account_for_api(voter_device_id):  # voterFac
     voter = results['voter']
 
     facebook_manager = FacebookManager()
-    facebook_results = facebook_manager.retrieve_facebook_link_to_voter(voter.we_vote_id)
+    facebook_results = facebook_manager.retrieve_facebook_link_to_voter(voter_we_vote_id=voter.we_vote_id)
     if facebook_results['facebook_link_to_voter_found']:
         error_results = {
             'status':                   "FACEBOOK_OWNER_VOTER_FOUND_WHEN_NOT_EXPECTED",

--- a/import_export_facebook/models.py
+++ b/import_export_facebook/models.py
@@ -685,7 +685,8 @@ class FacebookManager(models.Model):
                         if facebook_friends_friend_dict not in facebook_suggested_friends_list:
                             facebook_suggested_friends_list.append(facebook_friends_friend_dict)
 
-
+            if facebook_friends_api_details.get('data', []).__len__() == 0:
+                logger.debug("retrieve_facebook_friends_from_facebook  received zero friends from the API")
             success = True
             status += " " + "FACEBOOK_FRIENDS_LIST_FOUND"
             facebook_friends_list_found = True

--- a/organization/models.py
+++ b/organization/models.py
@@ -73,7 +73,8 @@ class OrganizationManager(models.Manager):
                 twitter_user_id = twitter_user.twitter_id
                 twitter_name = twitter_user.twitter_name
                 twitter_location = twitter_user.twitter_location
-                twitter_followers_count = twitter_user.twitter_followers_count
+                twitter_followers_count = twitter_user.twitter_followers_count if \
+                    positive_value_exists(twitter_user.twitter_followers_count) else 0
                 twitter_profile_image_url_https = twitter_user.twitter_profile_background_image_url_https
                 twitter_profile_background_image_url_https = twitter_user.twitter_profile_background_image_url_https
                 twitter_profile_banner_url_https = twitter_user.twitter_profile_banner_url_https
@@ -81,7 +82,6 @@ class OrganizationManager(models.Manager):
                 we_vote_hosted_profile_image_url_large = twitter_user.we_vote_hosted_profile_image_url_large
                 we_vote_hosted_profile_image_url_medium = twitter_user.we_vote_hosted_profile_image_url_medium
                 we_vote_hosted_profile_image_url_tiny = twitter_user.we_vote_hosted_profile_image_url_tiny
-                count = twitter_followers_count if twitter_followers_count else None
                 organization = Organization.create(
                     organization_name=organization_name,
                     organization_website=organization_website,
@@ -92,7 +92,7 @@ class OrganizationManager(models.Manager):
                     twitter_user_id=twitter_user_id,
                     twitter_name=twitter_name,
                     twitter_location=twitter_location,
-                    twitter_followers_count=count,
+                    twitter_followers_count=twitter_followers_count,
                     twitter_profile_image_url_https=twitter_profile_image_url_https,
                     twitter_profile_background_image_url_https=twitter_profile_background_image_url_https,
                     twitter_profile_banner_url_https=twitter_profile_banner_url_https,
@@ -510,7 +510,8 @@ class OrganizationManager(models.Manager):
                 try:
                     organization.organization_name = twitter_user.twitter_name
                     organization.twitter_description = twitter_user.twitter_description
-                    organization.twitter_followers_count = twitter_user.twitter_followers_count
+                    organization.twitter_followers_count = twitter_user.twitter_followers_count if \
+                        positive_value_exists(twitter_user.twitter_followers_count) else 0
                     organization.twitter_profile_image_url_https = twitter_user.twitter_profile_image_url_https
                     organization.organization_website = twitter_user.twitter_url
                     organization.twitter_name = twitter_user.twitter_name
@@ -1818,7 +1819,7 @@ class Organization(models.Model):
     @classmethod
     def create(cls, organization_name, organization_website, organization_twitter_handle, organization_email,
                organization_facebook, organization_image, twitter_user_id=None, twitter_name=None,
-               twitter_location=None, twitter_followers_count=None, twitter_profile_image_url_https=None,
+               twitter_location=None, twitter_followers_count=0, twitter_profile_image_url_https=None,
                twitter_profile_background_image_url_https=None, twitter_profile_banner_url_https=None,
                twitter_description=None, we_vote_hosted_profile_image_url_large=None,
                we_vote_hosted_profile_image_url_medium=None, we_vote_hosted_profile_image_url_tiny=None):

--- a/voter/controllers.py
+++ b/voter/controllers.py
@@ -1451,7 +1451,7 @@ def voter_retrieve_for_api(voter_device_id):  # voterRetrieve
                     organization = organization_dict['organization']
                     if not positive_value_exists(organization.facebook_id) or \
                             not positive_value_exists(organization.facebook_background_image_url_https):
-                        organization_manager.update_or_create_organization(
+                        OrganizationManager().update_or_create_organization(
                             organization.id,
                             we_vote_id=organization.we_vote_id,
                             organization_website_search=None,


### PR DESCRIPTION
In import_export_facebook/controllers.py in
voter_facebook_save_to_current_account_for_api, pass a dictionary to
retrieve_facebook_link_to_voter, which was previously failing with a
parameter mismatch.
In import_export_facebook/models, log at the debug level if no facebook
friends came back from the facebook api.  Change to come up with a safe
value for twitter_followers_count on Organization.create().  In
Organization.create() default to 0 for twitter_followers_count instead
of None, which would fail every time due to model column contraints.
Previously this was failing silently for logging to disk.
In voter/controllers fixed call to update_or_create_organization which
could on some conditions rely on an uninitialized organization_manager.
In Base.py STATIC_ROOT needed different settings when SERVER_IN_DEBUG_MODE=false
to build the correct path to serve apis_v1.css for the admin console.
