### PR TITLE
Changes for the facebook "cover" for issue #378

### DIFF
--- a/apis_v1/views/views_organization.py
+++ b/apis_v1/views/views_organization.py
@@ -62,10 +62,13 @@ def organization_retrieve_view(request):
     organization_id = request.GET.get('organization_id', 0)
     organization_we_vote_id = request.GET.get('organization_we_vote_id', '')
     voter_device_id = request.GET.get('voter_device_id', "")
+    display_facebook_banner = request.GET.get('display_facebook_banner', 0)
     return organization_retrieve_for_api(
         organization_id=organization_id,
         organization_we_vote_id=organization_we_vote_id,
-        voter_device_id=voter_device_id)
+        voter_device_id=voter_device_id,
+        display_facebook_banner=display_facebook_banner,
+    )
 
 
 def organization_save_view(request):  # organizationSave

--- a/apis_v1/views/views_voter.py
+++ b/apis_v1/views/views_voter.py
@@ -755,7 +755,7 @@ def voter_guides_followed_by_organization_retrieve_view(request):
         maximum_number_to_retrieve=maximum_number_to_retrieve)
 
 
-def voter_guide_followers_retrieve_view(request):
+def voter_guide_followers_retrieve_view(request):  # voterGuideFollowersRetrieve
     organization_we_vote_id = request.GET.get('organization_we_vote_id', '')
     voter_device_id = get_voter_device_id(request)  # We standardize how we take in the voter_device_id
     maximum_number_to_retrieve = get_maximum_number_to_retrieve_from_request(request)

--- a/import_export_twitter/controllers.py
+++ b/import_export_twitter/controllers.py
@@ -1170,8 +1170,10 @@ def twitter_sign_in_retrieve_for_api(voter_device_id):  # twitterSignInRetrieve
         voter_we_vote_id=voter_we_vote_id_for_cache,
         twitter_id=twitter_id, twitter_screen_name=twitter_auth_response.twitter_screen_name,
         twitter_profile_image_url_https=twitter_auth_response.twitter_profile_image_url_https,
+        twitter_profile_banner_url_https=twitter_auth_response.twitter_profile_banner_url_https,
         image_source=TWITTER)
     cached_twitter_profile_image_url_https = cache_results['cached_twitter_profile_image_url_https']
+    cached_twitter_profile_banner_url_https = cache_results['cached_twitter_profile_banner_url_https']
     we_vote_hosted_profile_image_url_large = cache_results['we_vote_hosted_profile_image_url_large']
     we_vote_hosted_profile_image_url_medium = cache_results['we_vote_hosted_profile_image_url_medium']
     we_vote_hosted_profile_image_url_tiny = cache_results['we_vote_hosted_profile_image_url_tiny']
@@ -1184,9 +1186,11 @@ def twitter_sign_in_retrieve_for_api(voter_device_id):  # twitterSignInRetrieve
     twitter_user_results = twitter_user_manager.update_or_create_twitter_user(
         twitter_user_details_dict, twitter_id,
         cached_twitter_profile_image_url_https=cached_twitter_profile_image_url_https,
+        cached_twitter_profile_banner_url_https=cached_twitter_profile_banner_url_https,
         we_vote_hosted_profile_image_url_large=we_vote_hosted_profile_image_url_large,
         we_vote_hosted_profile_image_url_medium=we_vote_hosted_profile_image_url_medium,
         we_vote_hosted_profile_image_url_tiny=we_vote_hosted_profile_image_url_tiny)
+
     status += twitter_user_results['status']
     if positive_value_exists(cached_twitter_profile_image_url_https):
         twitter_profile_image_url_https = cached_twitter_profile_image_url_https
@@ -1201,11 +1205,17 @@ def twitter_sign_in_retrieve_for_api(voter_device_id):  # twitterSignInRetrieve
         except Exception:
             pass
 
-        OrganizationManager.update_organization_single_voter_data(twitter_id,
-                                                                  we_vote_hosted_profile_image_url_large,
-                                                                  we_vote_hosted_profile_image_url_medium,
-                                                                  we_vote_hosted_profile_image_url_tiny,
-                                                                  twitter_profile_banner_url_https)
+        try:
+            OrganizationManager.update_organization_single_voter_data(twitter_id,
+                                                                      we_vote_hosted_profile_image_url_large,
+                                                                      we_vote_hosted_profile_image_url_medium,
+                                                                      we_vote_hosted_profile_image_url_tiny,
+                                                                      twitter_profile_banner_url_https)
+        except Exception as e:
+            logger.error('twitter_sign_in_retrieve_for_api caught exception calling '
+                         'update_organization_single_voter_data: '
+                         '{error} [type: {error_type}]'.format(error=e, error_type=type(e)))
+
     json_data = {
         'success':                                  success,
         'status':                                   status,

--- a/import_export_twitter/models.py
+++ b/import_export_twitter/models.py
@@ -40,7 +40,7 @@ class TwitterAuthResponse(models.Model):
                                            max_length=255, null=True, unique=False)
     twitter_name = models.CharField(verbose_name="display name from twitter", max_length=255, null=True, blank=True)
     twitter_profile_image_url_https = models.URLField(verbose_name='url of logo from twitter', blank=True, null=True)
-
+    twitter_profile_banner_url_https = models.URLField(verbose_name='url of banner from twitter', blank=True, null=True)
     twitter_request_token = models.TextField(verbose_name='twitter request token', null=True, blank=True)
     twitter_request_secret = models.TextField(verbose_name='twitter request secret', null=True, blank=True)
     twitter_access_token = models.TextField(verbose_name='twitter access token', null=True, blank=True)
@@ -88,6 +88,8 @@ class TwitterAuthManager(models.Model):
             success = False
             created = False
             status = "TWITTER_AUTH_RESPONSE_NOT_UPDATED_OR_CREATED"
+            logger.error("update_or_create_twitter_auth_response threw " + str(e))
+
 
         results = {
             'success': success,
@@ -173,7 +175,7 @@ class TwitterAuthManager(models.Model):
             # 'time_zone': 'Seoul',
             if hasattr(twitter_user_object, "profile_banner_url") and \
                     positive_value_exists(twitter_user_object.profile_banner_url):
-                twitter_auth_response.profile_banner_url = twitter_user_object.profile_banner_url
+                twitter_auth_response.twitter_profile_banner_url_https = twitter_user_object.profile_banner_url
                 twitter_auth_value_to_save = True
             if twitter_auth_value_to_save:
                 twitter_auth_response.save()

--- a/organization/controllers.py
+++ b/organization/controllers.py
@@ -719,12 +719,14 @@ def organizations_import_from_structured_json(structured_json):
     return organizations_results
 
 
-def organization_retrieve_for_api(organization_id, organization_we_vote_id, voter_device_id):  #
+def organization_retrieve_for_api(organization_id, organization_we_vote_id, voter_device_id,
+                                  display_facebook_banner):  #
     """
     Called from organizationRetrieve api
     :param organization_id:
     :param organization_we_vote_id:
     :param voter_device_id:
+    :param display_facebook_banner:
     :return:
     """
     organization_id = convert_to_int(organization_id)
@@ -763,34 +765,15 @@ def organization_retrieve_for_api(organization_id, organization_we_vote_id, vote
             position_list_manager = PositionListManager()
             position_list_manager.refresh_cached_position_info_for_organization(organization_we_vote_id)
 
-        we_vote_hosted_profile_image_url_large = organization.we_vote_hosted_profile_image_url_large if \
-            positive_value_exists(organization.we_vote_hosted_profile_image_url_large) else \
-            organization.organization_photo_url()
-        organization_banner_url = organization.twitter_profile_banner_url_https if \
-            positive_value_exists(organization.twitter_profile_banner_url_https) else '',
-
-        # NOTE FROM DALE: We don't want to add these database calls here -- we want to only rely on
-        #  values cached in the organization table.
-        # # If signed in with Facebook credentials AND this organization's we_vote_id is the same as this voter's
-        # # we_vote_id, then display the voter's Facebook "cover" (banner) instead of their Twitter banner image
-        # auth_response_results = FacebookManager().retrieve_facebook_auth_response(voter_device_id)
-        # if auth_response_results['facebook_auth_response_found']:
-        #     facebook_auth_response = auth_response_results['facebook_auth_response']
-        #     facebook_user_results = FacebookManager().retrieve_facebook_user_by_facebook_user_id(
-        #         facebook_auth_response.facebook_user_id)
-        #     if facebook_user_results['facebook_user_found']:
-        #         facebook_user = facebook_user_results['facebook_user']
-        #         try:
-        #             voter_manager = VoterManager()
-        #             voter_results = voter_manager.retrieve_voter_from_voter_device_id(voter_device_id)
-        #             voter = voter_results['voter']
-        #             we_vote_id = voter.we_vote_id
-        #             if facebook_user and voter.signed_in_facebook() and voter.linked_organization_we_vote_id== organization.we_vote_id:
-        #                 we_vote_hosted_profile_image_url_large = facebook_user.facebook_profile_image_url_https
-        #                 organization_banner_url = facebook_user.facebook_background_image_url_https
-        #         except Exception as e:
-        #             logger.error('FAILED to load voter in organization_retrieve_for_api. ' \
-        #                          '{error} [type: {error_type}]'.format(error=e, error_type=type(e)))
+        if positive_value_exists(display_facebook_banner):
+            we_vote_hosted_profile_image_url_large = organization.facebook_profile_image_url_https
+            organization_banner_url = organization.facebook_background_image_url_https
+        else:
+            we_vote_hosted_profile_image_url_large = organization.we_vote_hosted_profile_image_url_large if \
+                positive_value_exists(organization.we_vote_hosted_profile_image_url_large) else \
+                organization.organization_photo_url()
+            organization_banner_url = organization.twitter_profile_banner_url_https if \
+                                          positive_value_exists(organization.twitter_profile_banner_url_https) else '',
 
         json_data = {
             'success': True,

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -735,6 +735,8 @@ class TwitterUserManager(models.Model):
         except Exception as e:
             success = False
             twitter_user_found = False
+            logger.error("save_new_twitter_user_from_twitter_json caught: ", e.message)
+
             status = 'FAILED_TO_CREATE_NEW_TWITTER_USER'
             twitter_user_on_stage = TwitterUser()
 


### PR DESCRIPTION
This change set requires a database migration.
In apis_v1/views_organization we now receive a boolean from the client:
display_facebook_banner.
In import_export_twitter/controllers we now cache in aws, the twitter
banner and save link to the cached image in twitteruser.
In import_export_twitter/models the twitter auth response now contains
a value for the raw twitter banner.  In save_twitter_auth_values save
that raw banner, previously we were trying to save the value in a column
that did not exist.
In organization/controllers we now receive and act on that new boolean
from the client "display_facebook_banner", which allows us to avoid some
database calls that Dale did not like.