### PR TITLE
Server side #427, Update server to optionally use a read-only database.

### DIFF
--- a/config/environment_variables-template.json
+++ b/config/environment_variables-template.json
@@ -4,13 +4,21 @@
   "WEB_APP_ROOT_URL":               "https://WeVote.US",
   "SERVER_IN_DEBUG_MODE":           true,
 
-  "_comment":                       "local.py settings, including database",
+  "_comment":                       "read/write database settings for local.py",
   "DATABASE_ENGINE":                "django.db.backends.postgresql_psycopg2",
   "DATABASE_NAME":                  "WeVoteServerDB",
   "DATABASE_USER":                  "postgres",
   "DATABASE_PASSWORD":              "",
   "DATABASE_HOST":                  "",
   "DATABASE_PORT":                  "",
+
+  "_comment":                       "read-only database settings for local.py",
+  "DATABASE_ENGINE_READONLY":       "django.db.backends.postgresql_psycopg2",
+  "DATABASE_NAME_READONLY":         "WeVoteServerDB",
+  "DATABASE_USER_READONLY":         "postgres",
+  "DATABASE_PASSWORD_READONLY":     "",
+  "DATABASE_HOST_READONLY":         "",
+  "DATABASE_PORT_READONLY":         "",
 
   "_comment":                       "The connection string for Elastic Search database",
   "ELASTIC_SEARCH_CONNECTION_STRING": "",

--- a/config/local.py
+++ b/config/local.py
@@ -15,10 +15,10 @@ DEBUG = get_environment_variable('SERVER_IN_DEBUG_MODE')
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 
 # Multiple Databases
-# DATABASE_NAME
+# See https://docs.djangoproject.com/en/1.10/topics/db/multi-db/#defining-your-databases
+# August 2017: Not setting DATABASE_ROUTERS at this time, instead going with ".using('readonly')" on individual queries
 
 DATABASES = {
-    # social graph & voter specific info
     'default': {
         'ENGINE':   get_environment_variable('DATABASE_ENGINE'),
         'NAME':     get_environment_variable('DATABASE_NAME'),
@@ -26,9 +26,15 @@ DATABASES = {
         'PASSWORD': get_environment_variable('DATABASE_PASSWORD'),
         'HOST':     get_environment_variable('DATABASE_HOST'),  # localhost
         'PORT':     get_environment_variable('DATABASE_PORT'),  # 5432
+    },
+    'readonly': {
+        'ENGINE': get_environment_variable('DATABASE_ENGINE_READONLY'),
+        'NAME': get_environment_variable('DATABASE_NAME_READONLY'),
+        'USER': get_environment_variable('DATABASE_USER_READONLY'),
+        'PASSWORD': get_environment_variable('DATABASE_PASSWORD_READONLY'),
+        'HOST': get_environment_variable('DATABASE_HOST_READONLY'),
+        'PORT': get_environment_variable('DATABASE_PORT_READONLY'),
     }
-    # ballot, organizations & opinions
-    # search
 }
 
 ALLOWED_HOSTS = ['*']

--- a/election/controllers.py
+++ b/election/controllers.py
@@ -144,7 +144,8 @@ def elections_sync_out_list_for_api(voter_device_id):
     #     return results
     #
 
-    election_list = Election.objects.all()
+    # Get the election list using the readonly DB server
+    election_list = Election.objects.using('readonly').all()
 
     if len(election_list):
         results = {


### PR DESCRIPTION
For queries to election/views_admin.py elections_sync_out_view, use the replicated (identical) WeVoteServerDB on a slave designated as a readonly db.

In environment_variables-template.json add the block of settings for the
read only slave replicated postgres server.
In config/local.py add the DATABASES section for the read only server.
In controllers.py change the "Election.objects.all()" to
"Election.objects.using('readonly').all()" so that it uses the readonly
db server.

Each engineer on the project will need to make the changes to their
local environment_variables.json -- Add the block of 7 lines with the
_READONLY vars.  It is easiest to just copy all the settings from the
non readonly settings to the readonly.  In that way if you try to make
a request to your local on port 8000, you will get the read/write
database through the read/only settings.

This has been tested with two postgres servers running on two macs.