### PR TITLE
Server side #431, Persist and use facebook background offsets.

### DIFF
--- a/apis_v1/views/views_voter.py
+++ b/apis_v1/views/views_voter.py
@@ -681,6 +681,8 @@ def voter_facebook_sign_in_save_view(request):  # voterFacebookSignInSave
     facebook_last_name = request.GET.get('facebook_last_name', '')
     facebook_profile_image_url_https = request.GET.get('facebook_profile_image_url_https', '')
     facebook_background_image_url_https = request.GET.get('facebook_background_image_url_https', '')
+    facebook_background_image_offset_x = request.GET.get('facebook_background_image_offset_x', '')
+    facebook_background_image_offset_y = request.GET.get('facebook_background_image_offset_y', '')
 
     results = voter_facebook_sign_in_save_for_api(
         voter_device_id=voter_device_id,
@@ -697,6 +699,8 @@ def voter_facebook_sign_in_save_view(request):  # voterFacebookSignInSave
         save_photo_data=save_photo_data,
         facebook_profile_image_url_https=facebook_profile_image_url_https,
         facebook_background_image_url_https=facebook_background_image_url_https,
+        facebook_background_image_offset_x=facebook_background_image_offset_x,
+        facebook_background_image_offset_y=facebook_background_image_offset_y,
         )
 
     json_data = {

--- a/config/environment_variables-template.json
+++ b/config/environment_variables-template.json
@@ -128,6 +128,8 @@
   "PROFILE_IMAGE_MEDIUM_HEIGHT":    "48",
   "PROFILE_IMAGE_LARGE_WIDTH":      "200",
   "PROFILE_IMAGE_LARGE_HEIGHT":     "200",
+  "SOCIAL_BACKGROUND_IMAGE_HEIGHT": "200",
+  "SOCIAL_BACKGROUND_IMAGE_WIDTH":  "900",
 
   "_comment":                       "End of json_environment_variables.json"
 }

--- a/import_export_facebook/models.py
+++ b/import_export_facebook/models.py
@@ -49,6 +49,10 @@ class FacebookAuthResponse(models.Model):
     facebook_background_image_url_https = models.URLField(
         verbose_name='url of voter&apos;s background &apos;cover&apos; image from facebook \
         (like the twitter banner photo)', blank=True, null=True)
+    facebook_background_image_offset_x = models.IntegerField(verbose_name="x offset of facebook cover image", default=0,
+                                                             null=True, blank=True)
+    facebook_background_image_offset_y = models.IntegerField(verbose_name="y offset of facebook cover image", default=0,
+                                                             null=True, blank=True)
 
     def get_full_name(self):
         full_name = self.facebook_first_name if positive_value_exists(self.facebook_first_name) else ''
@@ -119,6 +123,10 @@ class FacebookUser(models.Model):
                                                        blank=True, null=True)
     facebook_background_image_url_https = models.URLField(verbose_name='url of cover image from facebook',
                                                           blank=True, null=True)
+    facebook_background_image_offset_x = models.IntegerField(verbose_name="x offset of facebook cover image", default=0,
+                                                             null=True, blank=True)
+    facebook_background_image_offset_y = models.IntegerField(verbose_name="y offset of facebook cover image", default=0,
+                                                             null=True, blank=True)
     we_vote_hosted_profile_image_url_large = models.URLField(verbose_name='we vote hosted large image url',
                                                              blank=True, null=True)
     we_vote_hosted_profile_image_url_medium = models.URLField(verbose_name='we vote hosted medium image url',
@@ -179,7 +187,8 @@ class FacebookManager(models.Model):
             self, voter_device_id, facebook_access_token, facebook_user_id, facebook_expires_in,
             facebook_signed_request,
             facebook_email, facebook_first_name, facebook_middle_name, facebook_last_name,
-            facebook_profile_image_url_https, facebook_background_image_url_https):
+            facebook_profile_image_url_https, facebook_background_image_url_https,
+            facebook_background_image_offset_x, facebook_background_image_offset_y):
         """
 
         :param voter_device_id:
@@ -193,6 +202,8 @@ class FacebookManager(models.Model):
         :param facebook_last_name:
         :param facebook_profile_image_url_https:
         :param facebook_background_image_url_https:
+        :param facebook_background_image_offset_x:
+        :param facebook_background_image_offset_y:
         :return:
         """
 
@@ -219,6 +230,9 @@ class FacebookManager(models.Model):
             defaults["facebook_profile_image_url_https"] = facebook_profile_image_url_https
         if positive_value_exists(facebook_background_image_url_https):
             defaults["facebook_background_image_url_https"] = facebook_background_image_url_https
+            # A zero value for the offsets can be a valid value.  If we received an image, we also received the offsets.
+            defaults["facebook_background_image_offset_x"] = int(facebook_background_image_offset_x)
+            defaults["facebook_background_image_offset_y"] = int(facebook_background_image_offset_y)
 
         try:
             facebook_auth_response, created = FacebookAuthResponse.objects.update_or_create(

--- a/organization/controllers.py
+++ b/organization/controllers.py
@@ -771,16 +771,17 @@ def organization_retrieve_for_api(organization_id, organization_we_vote_id, vote
             position_list_manager = PositionListManager()
             position_list_manager.refresh_cached_position_info_for_organization(organization_we_vote_id)
 
+        # Favor the Twitter banner and profile image if they exist
+        # From Dale September 1, 2017:  Eventually we would like to let a person choose which they want to display,
+        # but for now Twitter always wins out.
         we_vote_hosted_profile_image_url_large = organization.we_vote_hosted_profile_image_url_large if \
             positive_value_exists(organization.we_vote_hosted_profile_image_url_large) else \
             organization.organization_photo_url()
-        # To discuss: we_vote_hosted_profile_image_url_large = organization.facebook_profile_image_url_https
 
-        # Favor the Twitter banner if we have that
         if positive_value_exists(organization.twitter_profile_banner_url_https):
             organization_banner_url = organization.twitter_profile_banner_url_https
         else:
-            organization_banner_url = organization.facebook_background_image_url_https,
+            organization_banner_url = organization.facebook_background_image_url_https
 
         if isinstance(organization_banner_url, list):
             # If a list, just return the first one
@@ -849,6 +850,7 @@ def organization_save_for_api(voter_device_id, organization_id, organization_we_
                               facebook_id, facebook_email, facebook_profile_image_url_https):
     """
     DALE NOTE: I believe we only use this to save an organization in order to link it to a voter
+    NOTE September 2017:  I think the note above is outdated, we now use this to store displayable organization data
     :param voter_device_id:
     :param organization_id:
     :param organization_we_vote_id:
@@ -951,12 +953,8 @@ def organization_save_for_api(voter_device_id, organization_id, organization_we_
             if not positive_value_exists(organization_name):
                 organization_name = facebook_auth_response.get_full_name()
 
-    # Piece all the data together, the authoritative source if not in a parameter is facebook_user
+    # Add in the facebook email if we have it
     if facebook_auth_response:
-        if not positive_value_exists(facebook_profile_image_url_https):
-            facebook_profile_image_url_https = facebook_auth_response.facebook_profile_image_url_https
-        if not positive_value_exists(facebook_background_image_url_https):
-            facebook_background_image_url_https = facebook_auth_response.facebook_background_image_url_https
         if not positive_value_exists(facebook_email):
             facebook_email = facebook_auth_response.facebook_email
 

--- a/organization/models.py
+++ b/organization/models.py
@@ -206,7 +206,17 @@ class OrganizationManager(models.Manager):
         """
         return self.retrieve_organization(0, '', '', twitter_user_id)
 
-    def retrieve_organization(self, organization_id, we_vote_id=None, vote_smart_id=None, twitter_user_id=None):
+    def retrieve_organization(self, organization_id, we_vote_id=None, vote_smart_id=None, twitter_user_id=None,
+                              facebook_user_id=None):
+        """
+        Get an organization, based the passed in parameters
+        :param organization_id:
+        :param we_vote_id:
+        :param vote_smart_id:
+        :param twitter_user_id:
+        :param facebook_user_id:
+        :return: the matching organization object
+        """
         error_result = False
         exception_does_not_exist = False
         exception_multiple_object_returned = False
@@ -234,6 +244,12 @@ class OrganizationManager(models.Manager):
                 organization_on_stage = Organization.objects.get(twitter_user_id=twitter_user_id)
                 organization_on_stage_id = organization_on_stage.id
                 status = "ORGANIZATION_FOUND_WITH_TWITTER_ID"
+            elif positive_value_exists(facebook_user_id):
+                status = "ERROR_RETRIEVING_ORGANIZATION_WITH_FACEBOOK_ID"
+                # Unfortunately "facebook_user_id" is "facebook_id" in the Organization table
+                organization_on_stage = Organization.objects.get(facebook_id=facebook_user_id)
+                organization_on_stage_id = organization_on_stage.id
+                status = "ORGANIZATION_FOUND_WITH_FACEBOOK_ID"
         except Organization.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger)
             error_result = True
@@ -1825,6 +1841,10 @@ class Organization(models.Model):
         return str(self.organization_name)
 
     def organization_photo_url(self):
+        """
+        For an organization, this heirarchy determines which image gets displayed
+        :return: URL to the image to be displayed
+        """
         if positive_value_exists(self.organization_image):
             return self.organization_image
         elif positive_value_exists(self.we_vote_hosted_profile_image_url_large):

--- a/templates/image/create_resized_images_for_organization.html
+++ b/templates/image/create_resized_images_for_organization.html
@@ -106,19 +106,8 @@
                 {% else %}{% endif %}
             </td>
             <td>
-                {% if resized_images_for_one_organization.cached_large_facebook_background_image %}
-                    {{ resized_images_for_one_organization.cached_large_facebook_background_image }}
-                {% else %}{% endif %}
-            </td>
-
-            <td>
-                {% if resized_images_for_one_organization.cached_medium_facebook_background_image %}
-                    {{ resized_images_for_one_organization.cached_medium_facebook_background_image }}
-                {% else %}{% endif %}
-            </td>
-            <td>
-                {% if resized_images_for_one_organization.cached_tiny_facebook_background_image %}
-                    {{ resized_images_for_one_organization.cached_tiny_facebook_background_image }}
+                {% if resized_images_for_one_organization.cached_facebook_background_image %}
+                    {{ resized_images_for_one_organization.cached_facebook_background_image }}
                 {% else %}{% endif %}
             </td>
 

--- a/templates/image/create_resized_images_for_voters.html
+++ b/templates/image/create_resized_images_for_voters.html
@@ -106,19 +106,8 @@
                 {% else %}{% endif %}
             </td>
             <td>
-                {% if create_resized_images_for_a_voter.cached_large_facebook_background_image %}
-                    {{ create_resized_images_for_a_voter.cached_large_facebook_background_image }}
-                {% else %}{% endif %}
-            </td>
-
-            <td>
-                {% if create_resized_images_for_a_voter.cached_medium_facebook_background_image %}
-                    {{ create_resized_images_for_a_voter.cached_medium_facebook_background_image }}
-                {% else %}{% endif %}
-            </td>
-            <td>
-                {% if create_resized_images_for_a_voter.cached_tiny_facebook_background_image %}
-                    {{ create_resized_images_for_a_voter.cached_tiny_facebook_background_image }}
+                {% if create_resized_images_for_a_voter.cached_facebook_background_image %}
+                    {{ create_resized_images_for_a_voter.cached_facebook_background_image }}
                 {% else %}{% endif %}
             </td>
 

--- a/wevote_social/middleware.py
+++ b/wevote_social/middleware.py
@@ -56,6 +56,6 @@ class WeVoteSocialAuthExceptionMiddleware(SocialAuthExceptionMiddleware):
             except Exception as e2:
                 pass
 
-            logger.error('WeVoteSocialAuthExceptionMiddleware threw {error} [type: {error_type}]'.format(
-                error=error_exception, error_type=type(exception)))
+            logger.error('From \'{path}\' caught \'{error}\', type: {error_type}'.format(
+                path=print_path, error=error_exception, error_type=type(exception)))
             raise exception


### PR DESCRIPTION
This is now an entirely server side implementation.
This change requires database migrations, and has two new environment
variables in the template:  "SOCIAL_BACKGROUND_IMAGE_HEIGHT" snf
"SOCIAL_BACKGROUND_IMAGE_WIDTH".
Receive Facebook background offsets from the client side call to
voter_facebook_sign_in_save_view() -- we were already sending the data,
but ignoring it serverside.
A big piece of the image caching chain now passes the two facebook
offsets all the way down to resize_we_vote_master_image() which uses
them to resize the facebook background image to the same size and aspect
ratio as the twitter background.
In image/controllers removed a bunch of useless code to make multiple
sizes for the facebook backgrounds.
In import_export_facebook/controllers, put the newly cached and sized
images into the organization object.  In display of the organization
banner and profile pictures, we unconditionally display the twitter
versions if they exist in the organization object.