### PR TITLE
#263 Added Delete Cached image option for Candidate, Organization and Voter

### DIFF
--- a/candidate/models.py
+++ b/candidate/models.py
@@ -1163,6 +1163,36 @@ class CandidateCampaignManager(models.Model):
         }
         return results
 
+    def reset_candidate_image_details(self, candidate, twitter_profile_image_url_https,
+                                      twitter_profile_background_image_url_https,
+                                      twitter_profile_banner_url_https):
+        """
+        Reset an candidate entry with original image details from we vote image.
+        """
+        success = False
+        status = "ENTERING_RESET_CANDIDATE_IMAGE_DETAILS"
+
+        if candidate:
+            if positive_value_exists(twitter_profile_image_url_https):
+                candidate.twitter_profile_image_url_https = twitter_profile_image_url_https
+            if positive_value_exists(twitter_profile_background_image_url_https):
+                candidate.twitter_profile_background_image_url_https = twitter_profile_background_image_url_https
+            if positive_value_exists(twitter_profile_banner_url_https):
+                candidate.twitter_profile_banner_url_https = twitter_profile_banner_url_https
+            candidate.we_vote_hosted_profile_image_url_large = ''
+            candidate.we_vote_hosted_profile_image_url_medium = ''
+            candidate.we_vote_hosted_profile_image_url_tiny = ''
+            candidate.save()
+            success = True
+            status = "RESET_CANDIDATE_IMAGE_DETAILS"
+
+        results = {
+            'success':      success,
+            'status':       status,
+            'candidate':    candidate,
+        }
+        return results
+
     def clear_candidate_twitter_details(self, candidate):
         """
         Update an candidate entry with details retrieved from the Twitter API.

--- a/image/controllers.py
+++ b/image/controllers.py
@@ -13,7 +13,11 @@ from django.db.models import Q
 from import_export_facebook.models import FacebookManager
 from import_export_twitter.functions import retrieve_twitter_user_info
 from organization.models import OrganizationManager
+from politician.models import PoliticianManager
+from position.controllers import reset_all_position_image_details_from_candidate, \
+    reset_position_for_friends_image_details_from_voter, reset_position_entered_image_details_from_organization
 from twitter.models import TwitterUserManager
+from voter_guide.models import VoterGuideManager
 from voter.models import VoterManager, VoterDeviceLinkManager, VoterAddressManager, VoterAddress, Voter
 from wevote_functions.functions import positive_value_exists, convert_to_int
 import requests
@@ -1146,6 +1150,257 @@ def create_resized_images_for_all_voters():
         create_resized_images_results = create_resized_image(we_vote_image)
         create_all_resized_images_results.append(create_resized_images_results)
     return create_all_resized_images_results
+
+
+def delete_cached_images_for_candidate(candidate):
+    original_twitter_profile_image_url_https = None
+    original_twitter_profile_background_image_url_https = None
+    original_twitter_profile_banner_url_https = None
+    delete_image_count = 0
+    not_deleted_image_count = 0
+
+    we_vote_image_list = retrieve_all_images_for_one_candidate(candidate.we_vote_id)
+    if len(we_vote_image_list) > 0:
+        we_vote_image_manager = WeVoteImageManager()
+        for we_vote_image in we_vote_image_list:
+            if we_vote_image.kind_of_image_twitter_profile and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_twitter_profile_image_url_https = we_vote_image.twitter_profile_image_url_https
+            if we_vote_image.kind_of_image_twitter_background and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_twitter_profile_background_image_url_https = \
+                    we_vote_image.twitter_profile_background_image_url_https
+            if we_vote_image.kind_of_image_twitter_banner and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_twitter_profile_banner_url_https = we_vote_image.twitter_profile_banner_url_https
+
+        # Reset CandidateCampaign with original image details
+        candidate_campaign_manager = CandidateCampaignManager()
+        reset_candidate_image_results = candidate_campaign_manager.reset_candidate_image_details(
+            candidate, original_twitter_profile_image_url_https, original_twitter_profile_background_image_url_https,
+            original_twitter_profile_banner_url_https)
+
+        # Reset Twitter User Table with original image details
+        twitter_user_manager = TwitterUserManager()
+        reset_twitter_user_image_results = twitter_user_manager.reset_twitter_user_image_details(
+            candidate.twitter_user_id, original_twitter_profile_image_url_https,
+            original_twitter_profile_background_image_url_https, original_twitter_profile_banner_url_https)
+
+        # Reset Position Table with original image details
+        reset_position_image_results = reset_all_position_image_details_from_candidate(
+            candidate, original_twitter_profile_image_url_https)
+
+        # Reset Politician Table with original image details
+        politician_manager = PoliticianManager()
+        reset_politician_image_results = politician_manager.reset_politician_image_details_from_candidate(
+            candidate, original_twitter_profile_image_url_https, original_twitter_profile_background_image_url_https,
+            original_twitter_profile_banner_url_https)
+
+        if reset_candidate_image_results['success']:
+            for we_vote_image in we_vote_image_list:
+                # Delete image from AWS
+                image_deleted_from_aws = we_vote_image_manager.delete_image_from_aws(
+                    we_vote_image.we_vote_image_file_location)
+
+                delete_result = we_vote_image_manager.delete_we_vote_image(we_vote_image)
+                if delete_result['success']:
+                    delete_image_count += 1
+                else:
+                    not_deleted_image_count += 1
+
+        success = True
+        status = "DELETED_CACHED_IMAGES_FOR_CANDIDATE"
+    else:
+        success = False
+        status = "NO_IMAGE_FOUND_FOR_CANDIDATE"
+
+    results = {
+        'success':              success,
+        'status':               status,
+        'delete_image_count':   delete_image_count,
+        'not_deleted_image_count':  not_deleted_image_count,
+    }
+    return results
+
+
+def delete_cached_images_for_organization(organization):
+    original_twitter_profile_image_url_https = None
+    original_twitter_profile_background_image_url_https = None
+    original_twitter_profile_banner_url_https = None
+    original_facebook_profile_image_url_https = None
+    original_facebook_background_image_url_https = None
+    delete_image_count = 0
+    not_deleted_image_count = 0
+
+    we_vote_image_list = retrieve_all_images_for_one_organization(organization.we_vote_id)
+    if len(we_vote_image_list) > 0:
+        we_vote_image_manager = WeVoteImageManager()
+        for we_vote_image in we_vote_image_list:
+            if we_vote_image.kind_of_image_twitter_profile and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_twitter_profile_image_url_https = we_vote_image.twitter_profile_image_url_https
+            if we_vote_image.kind_of_image_twitter_background and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_twitter_profile_background_image_url_https = \
+                    we_vote_image.twitter_profile_background_image_url_https
+            if we_vote_image.kind_of_image_twitter_banner and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_twitter_profile_banner_url_https = we_vote_image.twitter_profile_banner_url_https
+            if we_vote_image.kind_of_image_facebook_profile and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_facebook_profile_image_url_https = we_vote_image.facebook_profile_image_url_https
+            if we_vote_image.kind_of_image_facebook_background and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_facebook_background_image_url_https = we_vote_image.facebook_background_image_url_https
+
+        # Reset Organization with original image details
+        organization_manager = OrganizationManager()
+        reset_organization_image_results = organization_manager.reset_organization_image_details(
+            organization, original_twitter_profile_image_url_https, original_twitter_profile_background_image_url_https,
+            original_twitter_profile_banner_url_https, original_facebook_profile_image_url_https)
+
+        # Reset Twitter User Table with original image details
+        twitter_user_manager = TwitterUserManager()
+        reset_twitter_user_image_results = twitter_user_manager.reset_twitter_user_image_details(
+            organization.twitter_user_id, original_twitter_profile_image_url_https,
+            original_twitter_profile_background_image_url_https, original_twitter_profile_banner_url_https)
+
+        # Reset Position Table with original image details
+        reset_position_image_results = reset_position_entered_image_details_from_organization(
+            organization, original_twitter_profile_image_url_https, original_facebook_profile_image_url_https)
+
+        # Reset Voter Guide table with original image details
+        voter_guide_manager = VoterGuideManager()
+        reset_voter_guide_image_results = voter_guide_manager.reset_voter_guide_image_details(
+            organization, original_twitter_profile_image_url_https, original_facebook_profile_image_url_https)
+
+        # Reset Voter with original image details
+        voter_manager = VoterManager()
+        voter_results = voter_manager.retrieve_voter_by_organization_we_vote_id(organization.we_vote_id)
+        voter = voter_results['voter']
+        if voter_results['voter_found']:
+            reset_voter_image_results = voter_manager.reset_voter_image_details(
+                voter, original_twitter_profile_image_url_https, original_facebook_profile_image_url_https)
+
+        # Reset Facebook User Table with original image details
+        facebook_manager = FacebookManager()
+        reset_facebook_user_image_results = facebook_manager.reset_facebook_user_image_details(
+            organization.facebook_id, original_facebook_profile_image_url_https,
+            original_facebook_background_image_url_https)
+
+        if reset_organization_image_results['success']:
+            for we_vote_image in we_vote_image_list:
+                # Delete image from AWS
+                image_deleted_from_aws = we_vote_image_manager.delete_image_from_aws(
+                    we_vote_image.we_vote_image_file_location)
+
+                delete_result = we_vote_image_manager.delete_we_vote_image(we_vote_image)
+                if delete_result['success']:
+                    delete_image_count += 1
+                else:
+                    not_deleted_image_count += 1
+
+        success = True
+        status = "DELETED_CACHED_IMAGES_FOR_CANDIDATE"
+    else:
+        success = False
+        status = "NO_IMAGE_FOUND_FOR_CANDIDATE"
+
+    results = {
+        'success':                  success,
+        'status':                   status,
+        'delete_image_count':       delete_image_count,
+        'not_deleted_image_count':  not_deleted_image_count,
+    }
+    return results
+
+
+def delete_cached_images_for_voter(voter):
+    original_twitter_profile_image_url_https = None
+    original_twitter_profile_background_image_url_https = None
+    original_twitter_profile_banner_url_https = None
+    original_facebook_profile_image_url_https = None
+    original_facebook_background_image_url_https = None
+
+    delete_image_count = 0
+    not_deleted_image_count = 0
+
+    we_vote_image_list = retrieve_all_images_for_one_voter(voter.id)
+    if len(we_vote_image_list) > 0:
+        we_vote_image_manager = WeVoteImageManager()
+        for we_vote_image in we_vote_image_list:
+            if we_vote_image.kind_of_image_twitter_profile and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_twitter_profile_image_url_https = we_vote_image.twitter_profile_image_url_https
+            if we_vote_image.kind_of_image_twitter_background and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_twitter_profile_background_image_url_https = \
+                    we_vote_image.twitter_profile_background_image_url_https
+            if we_vote_image.kind_of_image_twitter_banner and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_twitter_profile_banner_url_https = we_vote_image.twitter_profile_banner_url_https
+            if we_vote_image.kind_of_image_facebook_profile and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_facebook_profile_image_url_https = we_vote_image.facebook_profile_image_url_https
+            if we_vote_image.kind_of_image_facebook_background and we_vote_image.kind_of_image_original and \
+                    we_vote_image.is_active_version:
+                original_facebook_background_image_url_https = we_vote_image.facebook_background_image_url_https
+
+        # Reset Voter with original image details
+        voter_manager = VoterManager()
+        reset_voter_image_results = voter_manager.reset_voter_image_details(
+            voter, original_twitter_profile_image_url_https, original_facebook_profile_image_url_https)
+
+        # Reset Twitter User Table with original image details
+        twitter_user_manager = TwitterUserManager()
+        reset_twitter_user_image_results = twitter_user_manager.reset_twitter_user_image_details(
+            voter.twitter_id, original_twitter_profile_image_url_https,
+            original_twitter_profile_background_image_url_https, original_twitter_profile_banner_url_https)
+
+        # Reset Organization with original image details
+        organization_manager = OrganizationManager()
+        organization_results = organization_manager.retrieve_organization(0, '', '', voter.twitter_id)
+        organization = organization_results['organization']
+        if organization_results['organization_found']:
+            reset_organization_image_results = organization_manager.reset_organization_image_details(
+                organization, original_twitter_profile_image_url_https,
+                original_twitter_profile_background_image_url_https, original_twitter_profile_banner_url_https,
+                original_facebook_profile_image_url_https)
+
+        # Reset Position Table with original image details
+        reset_position_image_results = reset_position_for_friends_image_details_from_voter(
+            voter, original_twitter_profile_image_url_https, original_facebook_profile_image_url_https)
+
+        # Reset Facebook User Table with original image details
+        facebook_manager = FacebookManager()
+        reset_facebook_user_image_results = facebook_manager.reset_facebook_user_image_details(
+            voter.facebook_id, original_facebook_profile_image_url_https, original_facebook_background_image_url_https)
+
+        if reset_voter_image_results['success']:
+            for we_vote_image in we_vote_image_list:
+                # Delete image from AWS
+                image_deleted_from_aws = we_vote_image_manager.delete_image_from_aws(
+                    we_vote_image.we_vote_image_file_location)
+
+                delete_result = we_vote_image_manager.delete_we_vote_image(we_vote_image)
+                if delete_result['success']:
+                    delete_image_count += 1
+                else:
+                    not_deleted_image_count += 1
+
+        success = True
+        status = "DELETED_CACHED_IMAGES_FOR_VOTER"
+    else:
+        success = False
+        status = "NO_IMAGE_FOUND_FOR_VOTER"
+
+    results = {
+        'success':                  success,
+        'status':                   status,
+        'delete_image_count':       delete_image_count,
+        'not_deleted_image_count':  not_deleted_image_count,
+    }
+    return results
 
 
 def retrieve_all_images_for_one_candidate(candidate_we_vote_id):

--- a/image/models.py
+++ b/image/models.py
@@ -202,6 +202,26 @@ class WeVoteImageManager(models.Model):
         }
         return results
 
+    def delete_image_from_aws(self, we_vote_image_file_location):
+        """
+        Delete image from aws
+        :param we_vote_image_file_location:
+        :return:
+        """
+        try:
+
+            client = boto3.client(AWS_STORAGE_SERVICE, region_name=AWS_REGION_NAME,
+                                  aws_access_key_id=AWS_ACCESS_KEY_ID,
+                                  aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+            client.delete_object(AWS_STORAGE_BUCKET_NAME, we_vote_image_file_location)
+            image_deleted_from_aws = True
+        except Exception as e:
+            image_deleted_from_aws = False
+            exception_message = "delete_image_from_aws failed"
+            handle_exception(e, logger=logger, exception_message=exception_message)
+
+        return image_deleted_from_aws
+
     def save_we_vote_image_facebook_info(self, we_vote_image, facebook_user_id, image_width, image_height,
                                          facebook_image_url_https, same_day_image_version,
                                          kind_of_image_facebook_profile,

--- a/import_export_facebook/models.py
+++ b/import_export_facebook/models.py
@@ -356,6 +356,47 @@ class FacebookManager(models.Model):
             }
         return results
 
+    def reset_facebook_user_image_details(self, facebook_user_id, facebook_profile_image_url_https,
+                                          facebook_background_image_url_https):
+        """
+         Reset an facebook user entry with original image details from we vote image.
+        :param facebook_user_id:
+        :param facebook_profile_image_url_https:
+        :param facebook_background_image_url_https:
+        :return:
+        """
+        success = False
+        status = "ENTERING_RESET_FACEBOOK_USER_IMAGE_DETAILS"
+        values_changed = False
+        facebook_user_results = self.retrieve_facebook_user_by_facebook_user_id(facebook_user_id)
+        facebook_user = facebook_user_results['facebook_user']
+        if facebook_user_results['facebook_user_found']:
+            if positive_value_exists(facebook_profile_image_url_https):
+                facebook_user.facebook_profile_image_url_https = facebook_profile_image_url_https
+                values_changed = True
+            if positive_value_exists(facebook_background_image_url_https):
+                facebook_user.facebook_background_image_url_https = facebook_background_image_url_https
+                values_changed = True
+
+            facebook_user.we_vote_hosted_profile_image_url_large = ''
+            facebook_user.we_vote_hosted_profile_image_url_medium = ''
+            facebook_user.we_vote_hosted_profile_image_url_tiny = ''
+
+            if values_changed:
+                facebook_user.save()
+                success = True
+                status = "RESET_FACEBOOK_USER_IMAGE_DETAILS"
+            else:
+                success = True
+                status = "NO_CHANGES_RESET_TO_FACEBOOK_USER_IMAGE_DETAILS"
+
+        results = {
+            'success':                  success,
+            'status':                   status,
+            'facebook_user':            facebook_user,
+        }
+        return results
+
     def update_facebook_user_details(self, facebook_user,
                                      cached_facebook_profile_image_url_https=False,
                                      cached_facebook_background_image_url_https=False,

--- a/import_export_twitter/urls.py
+++ b/import_export_twitter/urls.py
@@ -13,6 +13,8 @@ urlpatterns = [
     # views_admin
     url(r'^(?P<candidate_id>[0-9]+)/refresh_twitter_candidate_details/$',
         views_admin.refresh_twitter_candidate_details_view, name='refresh_twitter_candidate_details',),
+    url(r'^delete_images_view/$',
+        views_admin.delete_images_view, name='delete_images_view',),
     url(r'^(?P<election_id>[0-9]+)/refresh_twitter_candidate_details_for_election/$',
         views_admin.refresh_twitter_candidate_details_for_election_view,
         name='refresh_twitter_candidate_details_for_election',),

--- a/organization/models.py
+++ b/organization/models.py
@@ -1169,6 +1169,40 @@ class OrganizationManager(models.Manager):
 
         return True
 
+    def reset_organization_image_details(self, organization, twitter_profile_image_url_https=None,
+                                         twitter_profile_background_image_url_https=None,
+                                         twitter_profile_banner_url_https=None, facebook_profile_image_url_https=None):
+        """
+        Reset an organization entry with original image details from we vote image.
+        """
+        success = False
+        status = "ENTERING_RESET_ORGANIZATION_IMAGE_DETAILS"
+
+        if organization:
+            if positive_value_exists(twitter_profile_image_url_https):
+                organization.twitter_profile_image_url_https = twitter_profile_image_url_https
+            if positive_value_exists(twitter_profile_background_image_url_https):
+                organization.twitter_profile_background_image_url_https = twitter_profile_background_image_url_https
+            if positive_value_exists(twitter_profile_banner_url_https):
+                organization.twitter_profile_banner_url_https = twitter_profile_banner_url_https
+
+            if positive_value_exists(facebook_profile_image_url_https):
+                organization.facebook_profile_image_url_https = facebook_profile_image_url_https
+
+            organization.we_vote_hosted_profile_image_url_large = ''
+            organization.we_vote_hosted_profile_image_url_medium = ''
+            organization.we_vote_hosted_profile_image_url_tiny = ''
+            organization.save()
+            success = True
+            status = "RESET_ORGANIZATION_IMAGE_DETAILS"
+
+        results = {
+            'success':      success,
+            'status':       status,
+            'organization': organization,
+        }
+        return results
+
     def clear_organization_twitter_details(self, organization):
         """
         Update an organization entry with details retrieved from the Twitter API.

--- a/politician/models.py
+++ b/politician/models.py
@@ -306,6 +306,38 @@ class PoliticianManager(models.Model):
         }
         return results
 
+    def reset_politician_image_details_from_candidate(self, candidate, twitter_profile_image_url_https,
+                                                      twitter_profile_background_image_url_https,
+                                                      twitter_profile_banner_url_https):
+        """
+        Reset an Politician entry with original image details from we vote image.
+        :param candidate:
+        :param twitter_profile_image_url_https:
+        :param twitter_profile_background_image_url_https:
+        :param twitter_profile_banner_url_https:
+        :return:
+        """
+        politician_details = self.retrieve_politician(0, candidate.politician_we_vote_id)
+        politician = politician_details['politician']
+        if politician_details['success']:
+            politician.we_vote_hosted_profile_image_url_medium = ''
+            politician.we_vote_hosted_profile_image_url_large = ''
+            politician.we_vote_hosted_profile_image_url_tiny = ''
+
+            politician.save()
+            success = True
+            status = "RESET_POLITICIAN_IMAGE_DETAILS"
+        else:
+            success = False
+            status = "POLITICIAN_NOT_FOUND_IN_RESET_IMAGE_DETAILS"
+
+        results = {
+            'success':      success,
+            'status':       status,
+            'politician':   politician
+        }
+        return results
+
     def update_politician_details_from_candidate(self, candidate):
         """
         Update a politician entry with details retrieved from candidate

--- a/position/controllers.py
+++ b/position/controllers.py
@@ -2993,6 +2993,41 @@ def retrieve_ballot_item_we_vote_ids_for_organizations_to_follow(voter_id,
     return results
 
 
+def reset_all_position_image_details_from_candidate(candidate_campaign, twitter_profile_image_url_https):
+    """
+    Reset all position image urls PositionEntered and PositionForFriends from candidate details
+    :param candidate_campaign:
+    :param twitter_profile_image_url_https
+    :return:
+    """
+    position_list_manager = PositionListManager()
+    position_manager = PositionManager()
+    reset_all_position_image_urls_results = []
+
+    retrieve_public_positions = True
+    public_position_list = position_list_manager.retrieve_all_positions_for_candidate_campaign(
+        retrieve_public_positions, candidate_campaign.id, candidate_campaign.we_vote_id)
+    for position_object in public_position_list:
+        reset_position_image_urls_results = position_manager.reset_position_image_details(
+            position_object, twitter_profile_image_url_https)
+        reset_all_position_image_urls_results.append(reset_position_image_urls_results)
+
+    retrieve_public_positions = False
+    friends_position_list = position_list_manager.retrieve_all_positions_for_candidate_campaign(
+        retrieve_public_positions, candidate_campaign.id, candidate_campaign.we_vote_id,
+        retrieve_all_admin_override=True)
+    for position_object in friends_position_list:
+        reset_position_image_urls_results = position_manager.reset_position_image_details(
+            position_object, twitter_profile_image_url_https)
+        reset_all_position_image_urls_results.append(reset_position_image_urls_results)
+
+    results = {
+        'success':                     True,
+        'reset_all_position_results':  reset_all_position_image_urls_results
+    }
+    return results
+
+
 def update_all_position_details_from_candidate(candidate_campaign):
     """
     Update all position image urls PositionEntered and PositionForFriends from candidate details
@@ -3144,6 +3179,40 @@ def update_all_position_details_from_contest_measure(contest_measure):
     return results
 
 
+def reset_position_entered_image_details_from_organization(organization, twitter_profile_image_url_https,
+                                                           facebook_profile_image_url_https):
+    """
+    Reset all position image urls in PositionEntered from organization details
+    :param organization:
+    :param twitter_profile_image_url_https:
+    :param facebook_profile_image_url_https:
+    :return:
+    """
+    position_list_manager = PositionListManager()
+    position_manager = PositionManager()
+    reset_all_position_org_data_results = []
+    stance_we_are_looking_for = ANY_STANCE
+    friends_vs_public = PUBLIC_ONLY
+    speaker_image_url_https = None
+    if positive_value_exists(twitter_profile_image_url_https):
+        speaker_image_url_https = twitter_profile_image_url_https
+    elif positive_value_exists(facebook_profile_image_url_https):
+        speaker_image_url_https = facebook_profile_image_url_https
+
+    public_position_list = position_list_manager.retrieve_all_positions_for_organization(
+        organization.id, organization.we_vote_id, stance_we_are_looking_for, friends_vs_public)
+    for position_object in public_position_list:
+        reset_position_image_urls_results = position_manager.reset_position_image_details(
+            position_object, speaker_image_url_https=speaker_image_url_https)
+        reset_all_position_org_data_results.append(reset_position_image_urls_results)
+
+    results = {
+        'success':                      True,
+        'reset_all_position_results':  reset_all_position_org_data_results
+    }
+    return results
+
+
 def update_position_entered_details_from_organization(organization):
     """
     Update all position image urls PositionEntered from organization details
@@ -3179,6 +3248,42 @@ def update_position_entered_details_from_organization(organization):
         'positions_updated_count':      positions_updated_count,
         'positions_not_updated_count':  positions_not_updated_count,
         'update_all_position_results':  update_all_position_results
+    }
+    return results
+
+
+def reset_position_for_friends_image_details_from_voter(voter, twitter_profile_image_url_https,
+                                                        facebook_profile_image_url_https):
+    """
+    Reset all position image urls in PositionForFriends from we vote image details
+    :param voter:
+    :param twitter_profile_image_url_https:
+    :param facebook_profile_image_url_https:
+    :return:
+    """
+    position_list_manager = PositionListManager()
+    position_manager = PositionManager()
+    stance_we_are_looking_for = ANY_STANCE
+    friends_vs_public = FRIENDS_ONLY
+    speaker_image_url_https = None
+    reset_all_position_image_urls_results = []
+    if positive_value_exists(twitter_profile_image_url_https):
+        speaker_image_url_https = twitter_profile_image_url_https
+    elif positive_value_exists(facebook_profile_image_url_https):
+        speaker_image_url_https = facebook_profile_image_url_https
+
+    positions_for_voter_results = position_list_manager.retrieve_all_positions_for_voter(
+        voter.id, voter.we_vote_id, stance_we_are_looking_for, friends_vs_public)
+    if positions_for_voter_results['position_list_found']:
+        friends_position_list = positions_for_voter_results['position_list']
+        for position_object in friends_position_list:
+
+            reset_position_image_urls_results = position_manager.reset_position_image_details(
+                position_object, speaker_image_url_https=speaker_image_url_https)
+            reset_all_position_image_urls_results.append(reset_position_image_urls_results)
+    results = {
+        'success':                      True,
+        'reset_all_position_results':   reset_all_position_image_urls_results
     }
     return results
 

--- a/position/models.py
+++ b/position/models.py
@@ -4593,6 +4593,43 @@ class PositionManager(models.Model):
         }
         return results
 
+    def reset_position_image_details(self, position_object, ballot_item_image_url_https=None,
+                                     speaker_image_url_https=None):
+        """
+        Reset Position image details as per we vote image details
+        :param position_object:
+        :param ballot_item_image_url_https:
+        :param speaker_image_url_https:
+        :return:
+        """
+        position_change = False
+        if positive_value_exists(ballot_item_image_url_https):
+            position_object.ballot_item_image_url_https = ballot_item_image_url_https
+            position_object.ballot_item_image_url_https_large = ''
+            position_object.ballot_item_image_url_https_medium = ''
+            position_object.ballot_item_image_url_https_tiny = ''
+            position_change = True
+        if positive_value_exists(speaker_image_url_https):
+            position_object.speaker_image_url_https = speaker_image_url_https
+            position_object.speaker_image_url_https_large = ''
+            position_object.speaker_image_url_https_medium = ''
+            position_object.speaker_image_url_https_tiny = ''
+            position_change = True
+
+        if position_change:
+            position_object.save()
+            success = True
+            status = "RESET_POSITION_IMAGE_DETAILS"
+        else:
+            success = False
+            status = "NO_CHANGES_RESET_TO_POSITION_IMAGE_DETAILS"
+        results = {
+            'success':  success,
+            'status':   status,
+            'position': position_object
+        }
+        return results
+
     def update_position_ballot_data_from_candidate(self, position_object, candidate_campaign):
         """
         Update position_object with candidate data.

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -118,7 +118,8 @@
         <input type="text" name="candidate_twitter_handle" id="candidate_twitter_handle_id" class="form-control"
                value="{% if candidate %}{{ candidate.candidate_twitter_handle|default_if_none:"" }}{% else %}{{ candidate_twitter_handle|default_if_none:"" }}{% endif %}" />
     {% if candidate.candidate_twitter_handle %}
-        (<a href="{% url 'import_export_twitter:refresh_twitter_candidate_details' candidate.id %}">refresh Twitter details</a>)<br />
+        (<a href="{% url 'import_export_twitter:refresh_twitter_candidate_details' candidate.id %}">refresh Twitter details</a>)
+        (<a href="{% url 'import_export_twitter:delete_images_view'%}?candidate_id={{ candidate.id }}">Delete Cached Images</a>)<br />
         Twitter Name: {{ candidate.twitter_name }}<br />
         Twitter Description: {{ candidate.twitter_description }}<br />
         Twitter Location: {{ candidate.twitter_location }}<br />

--- a/templates/organization/organization_position_list.html
+++ b/templates/organization/organization_position_list.html
@@ -25,7 +25,8 @@
     Twitter: {% if organization.generate_twitter_link %}
         <a href="{{ organization.generate_twitter_link }}" target="_blank">{{ organization.organization_twitter_handle }}</a>
         ({{ organization.twitter_followers_count }} Followers)
-        {% endif %} (<a href="{% url 'import_export_twitter:refresh_twitter_organization_details' organization.id %}?google_civic_election_id={{ google_civic_election_id }}">refresh Twitter details</a>)<br />
+        {% endif %} (<a href="{% url 'import_export_twitter:refresh_twitter_organization_details' organization.id %}?google_civic_election_id={{ google_civic_election_id }}">refresh Twitter details</a>)
+        (<a href="{% url 'import_export_twitter:delete_images_view'%}?organization_id={{ organization.id }}&google_civic_election_id={{ google_civic_election_id }}">Delete Cached Images</a>)<br />
     Twitter Name: {{ organization.twitter_name }}<br />
     Twitter Description: {{ organization.twitter_description }}<br />
     Twitter Location: {{ organization.twitter_location }}<br />

--- a/templates/voter/voter_list.html
+++ b/templates/voter/voter_list.html
@@ -108,6 +108,8 @@
             <!-- See images //-->
             <td>
                 <a href="{% url 'image:images_for_one_voter' voter.id %}" target="_blank">See images</a>
+                <br \>
+                <a href="{% url 'import_export_twitter:delete_images_view' %}?voter_id={{voter.id}}">Delete images</a>
             </td>
         </tr>
     {% endfor %}

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -667,6 +667,46 @@ class TwitterUserManager(models.Model):
         }
         return results
 
+    def reset_twitter_user_image_details(self, twitter_id, twitter_profile_image_url_https,
+                                         twitter_profile_background_image_url_https,
+                                         twitter_profile_banner_url_https):
+        """
+        Reset an twitter user entry with original image details from we vote image.
+        """
+        if positive_value_exists(twitter_id):
+            twitter_results = self.retrieve_twitter_user(twitter_id)
+            twitter_user_found = twitter_results['twitter_user_found']
+            twitter_user = twitter_results['twitter_user']
+            if twitter_user_found:
+                if positive_value_exists(twitter_profile_image_url_https):
+                    twitter_user.twitter_profile_image_url_https = twitter_profile_image_url_https
+                if positive_value_exists(twitter_profile_background_image_url_https):
+                    twitter_user.twitter_profile_background_image_url_https = twitter_profile_background_image_url_https
+                if positive_value_exists(twitter_profile_banner_url_https):
+                    twitter_user.twitter_profile_banner_url_https = twitter_profile_banner_url_https
+
+                twitter_user.we_vote_hosted_profile_image_url_large = ''
+                twitter_user.we_vote_hosted_profile_image_url_medium = ''
+                twitter_user.we_vote_hosted_profile_image_url_tiny = ''
+                twitter_user.save()
+
+                success = True
+                status = 'RESET_TWITTER_USER_IMAGE_DETAILS'
+            else:
+                success = False
+                status = 'TWITTER_USER_NOT_FOUND'
+        else:
+            success = False
+            status = 'TWITTER_ID_MISSING'
+            twitter_user = ''
+
+        results = {
+            'success':      success,
+            'status':       status,
+            'twitter_user': twitter_user,
+        }
+        return results
+
     def save_new_twitter_user_from_twitter_json(self, twitter_json, cached_twitter_profile_image_url_https=None,
                                                 cached_twitter_profile_background_image_url_https=None,
                                                 cached_twitter_profile_banner_url_https=None,

--- a/voter/models.py
+++ b/voter/models.py
@@ -1213,6 +1213,47 @@ class VoterManager(BaseUserManager):
         }
         return results
 
+    def reset_voter_image_details(self, voter, twitter_profile_image_url_https=None,
+                                  facebook_profile_image_url_https=None):
+        """
+        Reset Voter image details from we voter image
+        :param voter:
+        :param twitter_profile_image_url_https:
+        :param facebook_profile_image_url_https:
+        :return:
+        """
+        value_changed = False
+        voter_results = self.retrieve_voter_by_we_vote_id(voter.we_vote_id)
+        voter = voter_results['voter']
+        if voter_results['voter_found']:
+            if positive_value_exists(twitter_profile_image_url_https):
+                voter.twitter_profile_image_url_https = twitter_profile_image_url_https
+                voter.we_vote_hosted_profile_image_url_large = ''
+                voter.we_vote_hosted_profile_image_url_medium = ''
+                voter.we_vote_hosted_profile_image_url_tiny = ''
+                value_changed = True
+            if positive_value_exists(facebook_profile_image_url_https):
+                voter.facebook_profile_image_url_https = facebook_profile_image_url_https
+                value_changed = True
+
+            if value_changed:
+                voter.save()
+                success = True
+                status = "RESET_VOTER_IMAGE_DETAILS"
+            else:
+                success = True
+                status = "NO_CHANGES_IN_VOTER_IMAGE_DETAILS"
+        else:
+            success = False
+            status = "VOTER_NOT_FOUND"
+
+        results = {
+            'success':  success,
+            'status':   status,
+            'voter':    voter
+        }
+        return results
+
     def update_voter_twitter_details(self, twitter_id, twitter_json,
                                      cached_twitter_profile_image_url_https,
                                      we_vote_hosted_profile_image_url_large,

--- a/voter_guide/models.py
+++ b/voter_guide/models.py
@@ -394,6 +394,51 @@ class VoterGuideManager(models.Manager):
         }
         return results
 
+    def reset_voter_guide_image_details(self, organization, twitter_profile_image_url_https=None,
+                                        facebook_profile_image_url_https=None):
+        """
+        Reset Voter guide entry with original we vote image details
+        :param organization:
+        :param twitter_profile_image_url_https:
+        :param facebook_profile_image_url_https:
+        :return:
+        """
+        image_url = None
+        success = False
+        status = ""
+        voter_guide = VoterGuide()
+
+        if positive_value_exists(twitter_profile_image_url_https):
+            image_url = twitter_profile_image_url_https
+        elif positive_value_exists(facebook_profile_image_url_https):
+            image_url = facebook_profile_image_url_https
+        if organization:
+            voter_guide_list_manager = VoterGuideListManager()
+            results = voter_guide_list_manager.retrieve_all_voter_guides_by_organization_we_vote_id(
+                organization.we_vote_id)
+            voter_guide_list = results['voter_guide_list']
+            if positive_value_exists(results['voter_guide_list_found']):
+                for voter_guide in voter_guide_list:
+                    voter_guide.image_url = image_url
+                    voter_guide.we_vote_hosted_profile_image_url_large = ''
+                    voter_guide.we_vote_hosted_profile_image_url_medium = ''
+                    voter_guide.we_vote_hosted_profile_image_url_tiny = ''
+
+                    voter_guide.save()
+                    success = True
+                    status += " RESET_ORG_IMAGE_DETAILS-EARLIER VERSION"
+            else:
+                success = True
+                status += "NO_VOTER_GUIDES_FOUND_FOR_RESET_IMAGE_DETAILS"
+
+        results = {
+            'success':                  success,
+            'status':                   status,
+            'organization':             organization,
+            'voter_guide':              voter_guide,
+        }
+        return results
+
     def update_voter_guide_social_media_statistics(self, organization):
         """
         Update voter_guide entry with details retrieved from Twitter, Facebook, or ???


### PR DESCRIPTION
- Restore original twitter/facebook image urls in respected tables
- Delete cached images from aws
- Delete cached image entries from WeVoteImage Table