### PR TITLE
oAuth support for react-native app

### DIFF
--- a/apis_v1/urls.py
+++ b/apis_v1/urls.py
@@ -114,6 +114,7 @@ urlpatterns = [
     url(r'^saveAnalyticsAction/', views_analytics.save_analytics_action_view, name='saveAnalyticsActionView'),
     url(r'^searchAll/', views_misc.search_all_view, name='searchAllView'),
     url(r'^twitterIdentityRetrieve/', views_twitter.twitter_identity_retrieve_view, name='twitterIdentityRetrieveView'),
+    url(r'^twitterNativeSignInSave/', views_twitter.twitter_native_sign_in_save_view, name='twitterNativeSignInSave'),
     url(r'^twitterSignInRequestAccessToken/',
         views_twitter.twitter_sign_in_request_access_token_view, name='twitterSignInRequestAccessTokenView'),
     url(r'^twitterSignInRequestVoterInfo/',

--- a/apis_v1/views/views_twitter.py
+++ b/apis_v1/views/views_twitter.py
@@ -5,7 +5,7 @@ from config.base import get_environment_variable
 from django.http import HttpResponse, HttpResponseRedirect
 from import_export_twitter.controllers import twitter_sign_in_start_for_api, \
     twitter_sign_in_request_access_token_for_api, twitter_sign_in_request_voter_info_for_api, \
-    twitter_sign_in_retrieve_for_api, twitter_retrieve_ids_i_follow_for_api
+    twitter_sign_in_retrieve_for_api, twitter_retrieve_ids_i_follow_for_api, twitter_native_sign_in_save_for_api
 import json
 from twitter.controllers import twitter_identity_retrieve_for_api
 from urllib.parse import quote
@@ -67,6 +67,7 @@ def twitter_identity_retrieve_view(request):  # twitterIdentityRetrieve
 
 def twitter_sign_in_start_view(request):  # twitterSignInStart
     """
+    Step 1 of the Twitter Sign In Process for the WebApp
     Start off the process of signing in with Twitter (twitterSignInStart)
     :param request:
     :return:
@@ -96,7 +97,7 @@ def twitter_sign_in_start_view(request):  # twitterSignInStart
 
 def twitter_sign_in_request_access_token_view(request):  # twitterSignInRequestAccessToken
     """
-    Step 2 of the Twitter Sign In Process (twitterSignInRequestAccessToken)
+    Step 2 of the Twitter Sign In Process (twitterSignInRequestAccessToken) for the WebApp
     :param request:
     :return:
     """
@@ -121,6 +122,27 @@ def twitter_sign_in_request_access_token_view(request):  # twitterSignInRequestA
         'success': results['success'],
         'voter_device_id': voter_device_id,
         'access_token_and_secret_returned': results['access_token_and_secret_returned'],
+    }
+    return HttpResponse(json.dumps(json_data), content_type='application/json')
+
+
+def twitter_native_sign_in_save_view(request):  # twitterNativeSignInSave
+    """
+    For the native "app" react-native-oauth, replaces Steps 1 & 2 of the WebApp Twitter Sign In Process.
+    Receives twitter_access_token and twitter_access_token_secret from the native app's authenticate() call
+    :param request:
+    :return:
+    """
+
+    voter_device_id = get_voter_device_id(request)  # We standardize how we take in the voter_device_id
+    twitter_access_token = request.GET.get('twitter_access_token', '')
+    twitter_access_token_secret = request.GET.get('twitter_access_token_secret', '')
+    results = twitter_native_sign_in_save_for_api(voter_device_id, twitter_access_token, twitter_access_token_secret)
+
+    json_data = {
+        'status': results['status'],
+        'success': results['success'],
+        'voter_device_id': voter_device_id,
     }
     return HttpResponse(json.dumps(json_data), content_type='application/json')
 

--- a/import_export_twitter/controllers.py
+++ b/import_export_twitter/controllers.py
@@ -769,6 +769,105 @@ def twitter_sign_in_start_for_api(voter_device_id, return_url):  # twitterSignIn
         }
     return results
 
+def twitter_native_sign_in_save_for_api(voter_device_id, twitter_access_token, twitter_access_secret):
+    """
+    For react-native-oauth, we receive the tokens from a single authenticate() call, and save them to the
+    TwitterAuthManager().  This is equivalent to Steps 1 & 2 in the WebApp oAuth processing
+
+    :param voter_device_id:
+    :param twitter_access_token:  react-native-oauth refers to this as the "access_token"
+    :param twitter_access_secret: react-native-oauth refers to this as the "access_token_secret"
+    :return:
+    """
+    # Get voter_id from the voter_device_id
+    results = is_voter_device_id_valid(voter_device_id)
+    if not results['success']:
+        results = {
+            'success':                      False,
+            'status':                       "VALID_VOTER_DEVICE_ID_MISSING",
+            'voter_device_id':              voter_device_id,
+        }
+        return results
+
+    voter_manager = VoterManager()
+    results = voter_manager.retrieve_voter_from_voter_device_id(voter_device_id)
+    if not positive_value_exists(results['voter_found']):
+        results = {
+            'status':                       "VALID_VOTER_MISSING",
+            'success':                      False,
+            'voter_device_id':              voter_device_id,
+        }
+        return results
+
+    voter = results['voter']
+
+    twitter_user_manager = TwitterUserManager()
+    twitter_user_results = twitter_user_manager.retrieve_twitter_link_to_voter(voter.we_vote_id)
+    if twitter_user_results['twitter_link_to_voter_found']:
+        error_results = {
+            'status':                       "TWITTER_OWNER_VOTER_FOUND_WHEN_NOT_EXPECTED",
+            'success':                      False,
+            'voter_device_id':              voter_device_id,
+         }
+        return error_results
+
+    twitter_auth_manager = TwitterAuthManager()
+    auth_response_results = twitter_auth_manager.retrieve_twitter_auth_response(voter_device_id)
+    if auth_response_results['twitter_auth_response_found']:
+        twitter_auth_response = auth_response_results['twitter_auth_response']
+    else:
+        # Create a new twitter_auth_response entry with only the voter_device_id
+        auth_create_results = twitter_auth_manager.update_or_create_twitter_auth_response(voter_device_id)
+
+        if not auth_create_results['twitter_auth_response_created']:
+            error_results = {
+                'status':                       auth_create_results['status'],
+                'success':                      False,
+                'voter_device_id':              voter_device_id,
+            }
+            return error_results
+
+        twitter_auth_response = auth_create_results['twitter_auth_response']
+
+
+    try:
+        if positive_value_exists(twitter_access_token) and positive_value_exists(twitter_access_secret):
+            twitter_auth_response.twitter_access_token = twitter_access_token
+            twitter_auth_response.twitter_access_secret = twitter_access_secret
+            twitter_auth_response.save()
+
+            success = True
+            status = 'TWITTER_TOKENS_STORED'
+        else:
+            success = False
+            status = 'TWITTER_TOKENS_NOT_STORED_DUE_TO_BAD_PASSED_IN_TOKENS'
+            logger.error('twitter_native_sign_in_save_for_api -- TWITTER_TOKENS_NOT_STORED_BAD_PASSED_IN_TOKENS')
+
+    except Exception as e:
+        success = False
+        status = 'TWITTER_TOKEN_EXCEPTION_ON_FAILED_SAVE'
+        logger.error('twitter_native_sign_in_save_for_api -- save threw exception: ' + str(e))
+
+    if success:
+        results = {
+            'status':                       status,
+            'success':                      True,
+            'voter_device_id':              voter_device_id,
+            'voter_info_retrieved':         False,
+            'switch_accounts':              False,
+            'jump_to_request_voter_info':   False,
+        }
+    else:
+        results = {
+            'status':                       status,
+            'success':                      False,
+            'voter_device_id':              voter_device_id,
+            'voter_info_retrieved':         False,
+            'switch_accounts':              False,
+            'jump_to_request_voter_info':   False,
+        }
+    return results
+
 
 def twitter_sign_in_request_access_token_for_api(voter_device_id,
                                                  incoming_request_token, incoming_oauth_verifier,

--- a/voter/models.py
+++ b/voter/models.py
@@ -114,7 +114,7 @@ class VoterManager(BaseUserManager):
             voter_id = voter.id
         except IntegrityError as e:
             handle_record_not_saved_exception(e, logger=logger)
-            logger.debug("create_voter IntegrityError exception 1 " + str(e))
+            logger.debug("create_voter IntegrityError exception (#1) " + str(e))
             try:
                 # Trying to save again will increment the 'we_vote_id_last_voter_integer'
                 # by calling 'fetch_next_we_vote_id_last_voter_integer'
@@ -124,15 +124,15 @@ class VoterManager(BaseUserManager):
                 voter_id = voter.id
             except IntegrityError as e:
                 handle_record_not_saved_exception(e, logger=logger)
-                logger.debug("create_voter IntegrityError exception 2 " + str(e))
+                logger.debug("create_voter IntegrityError exception (#2): " + str(e))
             except Exception as e:
                 handle_record_not_saved_exception(e, logger=logger)
-                logger.debug("create_voter first general exception " + str(e))
+                logger.debug("create_voter general exception (#1): " + str(e))
 
 
         except Exception as e:
             handle_record_not_saved_exception(e, logger=logger)
-            logger.error("create_voter second exception" + str(e))
+            logger.error("create_voter general exception (#2): " + str(e))
 
         results = {
             'email_not_valid':      email_not_valid,


### PR DESCRIPTION
In urls.py, views_twitter, and import_export_twitter/controllers.py add
a new API for twitter_native_sign_in_save_for_api for react-native to
bypass the Webapp oAuth flow that is done server side with tweepy.
In native, steps 1 & 2are replaced with a react-native-oauth
authenticate() call.
In voter/models.py fixed an unhandled exception for IntegrityErrors