### PR TITLE
Implemented bulk retrieval of possible Twitter handles

### DIFF
--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -219,6 +219,16 @@ def candidate_list_view(request):
 
     election_list = Election.objects.order_by('-election_day_text')
 
+    # Attach the best guess Twitter account, if any, to each candidate in list
+    for candidate in candidate_list:
+        try:
+            twitter_possibility_query = TwitterLinkPossibility.objects.order_by('-likelihood_percentage')
+            twitter_possibility_query = twitter_possibility_query.filter(
+                candidate_campaign_we_vote_id=candidate.we_vote_id)
+            candidate.candidate_merge_possibility = twitter_possibility_query[0]
+        except Exception as e:
+            candidate.candidate_merge_possibility = None
+
     template_values = {
         'messages_on_stage':        messages_on_stage,
         'candidate_list':           candidate_list,

--- a/templates/candidate/candidate_list.html
+++ b/templates/candidate/candidate_list.html
@@ -58,40 +58,40 @@
 
 {% if candidate_list %}
     {% if google_civic_election_id %}
+    <ul>
+        <li>Prepare: <a href="{% url 'candidate:find_and_remove_duplicate_candidates' %}?google_civic_election_id={{ google_civic_election_id }}" >
+        Find and Remove Duplicate Candidates for this Election</a> (about 1 minute)</li>
+        <li>Prepare: <a href="{% url 'candidate:find_and_remove_duplicate_candidates' %}?google_civic_election_id={{ google_civic_election_id }}" >
+        Generate One Sample Ballot</a> (about 1 minute)</li>
+        <li>Prepare: <a href="{% url 'candidate:candidate_politician_match_for_this_election' %}?google_civic_election_id={{ google_civic_election_id }}" >
+        Match Candidates to Politicians (and Create Politicians)</a> (about 1 minute)</li>
+    </ul>
 
-    <p>
-        Prepare: <a href="{% url 'candidate:find_and_remove_duplicate_candidates' %}?google_civic_election_id={{ google_civic_election_id }}" >
-            Find and Remove Duplicate Candidates for this Election</a> (about 1 minute)<br />
-        Prepare: <a href="{% url 'candidate:find_and_remove_duplicate_candidates' %}?google_civic_election_id={{ google_civic_election_id }}" >
-            Generate One Sample Ballot</a> (about 1 minute)<br />
-        Prepare: <a href="{% url 'candidate:candidate_politician_match_for_this_election' %}?google_civic_election_id={{ google_civic_election_id }}" >
-            Match Candidates to Politicians (and Create Politicians)</a> (about 1 minute)<br />
+    <ol>
+        <li><a href="{% url 'candidate:photos_for_election' google_civic_election_id %}" target="_blank" >
+            Retrieve Candidate Photos from Vote Smart for this Election</a> (3-10 minutes - Open in New Window)</li>
 
-        1. <a href="{% url 'candidate:photos_for_election' google_civic_election_id %}" target="_blank" >
-            Retrieve Candidate Photos from Vote Smart for this Election</a> (3-10 minutes - Open in New Window)<br />
+        <li><a href="{% url 'import_export_twitter:transfer_candidate_twitter_handles_from_google_civic' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" >
+        Transfer Twitter handles from Google Civic Data</a> (30 seconds)</li>
 
-        2. <a href="{% url 'import_export_twitter:transfer_candidate_twitter_handles_from_google_civic' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" >
-            Transfer Twitter handles from Google Civic Data</a> (30 seconds)<br />
+        <li><a href="{% url 'import_export_twitter:scrape_social_media_for_candidates_in_one_election' %}?google_civic_election_id={{ google_civic_election_id }}" >
+        Go to Candidate Sites and get Twitter Handles for this Election</a> (1-2 minutes)</li>
 
-        3. <a href="{% url 'import_export_twitter:scrape_social_media_for_candidates_in_one_election' %}?google_civic_election_id={{ google_civic_election_id }}" >
-            Go to Candidate Sites and get Twitter Handles for this Election</a> (1-2 minutes)<br />
+        <li><a href="{% url 'twitter2:bulk_retrieve_possible_twitter_handles' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" >
+        Retrieve Possible Twitter Handles</a> (10 at a time - about 30 seconds)</li>
 
-        4. <a href="{% url 'twitter2:bulk_retrieve_possible_twitter_handles' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" >
-            Retrieve Possible Twitter Handles</a> (10 at a time - about 30 seconds)<br />
+        <li><a href="{% url 'import_export_twitter:refresh_twitter_candidate_details_for_election' google_civic_election_id %}?state_code={{ state_code }}" >
+        Retrieve/Refresh Candidate Twitter Info for this Election</a> (1-2 minutes)</li>
 
-        5. <a href="{% url 'import_export_twitter:refresh_twitter_candidate_details_for_election' google_civic_election_id %}?state_code={{ state_code }}" >
-            Retrieve/Refresh Candidate Twitter Info for this Election</a> (1-2 minutes)<br />
+        <li><a href="{% url 'import_export_vote_smart:retrieve_positions_from_vote_smart_for_election' %}?google_civic_election_id={{ google_civic_election_id }}" target="_blank" >
+        Retrieve Positions from Vote Smart for this Election</a> (5-15 minutes - Open in New Window)</li>
 
-        6. <a href="{% url 'import_export_vote_smart:retrieve_positions_from_vote_smart_for_election' %}?google_civic_election_id={{ google_civic_election_id }}" target="_blank" >
-            Retrieve Positions from Vote Smart for this Election</a> (5-15 minutes - Open in New Window)<br />
+        <li><a href="{% url 'voter_guide:generate_voter_guides_one_election' %}?google_civic_election_id={{ google_civic_election_id }}" >
+        Generate Voter Guides for this Election</a> (about 1 minute)</li>
 
-        7. <a href="{% url 'voter_guide:generate_voter_guides_one_election' %}?google_civic_election_id={{ google_civic_election_id }}" >
-            Generate Voter Guides for this Election</a> (about 1 minute)<br />
-
-        8. <a href="{% url 'position:refresh_positions_with_candidate_details_for_election' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" >
-            Refresh Positions from Candidate Info for this Election</a> (1-2 minutes)<br />
-
-    </p>
+        <li><a href="{% url 'position:refresh_positions_with_candidate_details_for_election' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" >
+        Refresh Positions from Candidate Info for this Election</a> (1-2 minutes)</li>
+    </ol>
     {% endif %}
 {% endif %}
     <a href="{% url 'candidate:candidate_new' %}?google_civic_election_id={{ google_civic_election_id }}">Add New Candidate</a><br />

--- a/templates/candidate/candidate_list.html
+++ b/templates/candidate/candidate_list.html
@@ -76,16 +76,19 @@
         3. <a href="{% url 'import_export_twitter:scrape_social_media_for_candidates_in_one_election' %}?google_civic_election_id={{ google_civic_election_id }}" >
             Go to Candidate Sites and get Twitter Handles for this Election</a> (1-2 minutes)<br />
 
-        4. <a href="{% url 'import_export_twitter:refresh_twitter_candidate_details_for_election' google_civic_election_id %}?state_code={{ state_code }}" >
+        4. <a href="{% url 'twitter2:bulk_retrieve_possible_twitter_handles' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" >
+            Retrieve Possible Twitter Handles</a> (10 at a time - about 30 seconds)<br />
+
+        5. <a href="{% url 'import_export_twitter:refresh_twitter_candidate_details_for_election' google_civic_election_id %}?state_code={{ state_code }}" >
             Retrieve/Refresh Candidate Twitter Info for this Election</a> (1-2 minutes)<br />
 
-        5. <a href="{% url 'import_export_vote_smart:retrieve_positions_from_vote_smart_for_election' %}?google_civic_election_id={{ google_civic_election_id }}" target="_blank" >
+        6. <a href="{% url 'import_export_vote_smart:retrieve_positions_from_vote_smart_for_election' %}?google_civic_election_id={{ google_civic_election_id }}" target="_blank" >
             Retrieve Positions from Vote Smart for this Election</a> (5-15 minutes - Open in New Window)<br />
 
-        6. <a href="{% url 'voter_guide:generate_voter_guides_one_election' %}?google_civic_election_id={{ google_civic_election_id }}" >
+        7. <a href="{% url 'voter_guide:generate_voter_guides_one_election' %}?google_civic_election_id={{ google_civic_election_id }}" >
             Generate Voter Guides for this Election</a> (about 1 minute)<br />
 
-        7. <a href="{% url 'position:refresh_positions_with_candidate_details_for_election' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" >
+        8. <a href="{% url 'position:refresh_positions_with_candidate_details_for_election' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" >
             Refresh Positions from Candidate Info for this Election</a> (1-2 minutes)<br />
 
     </p>

--- a/templates/candidate/candidate_list.html
+++ b/templates/candidate/candidate_list.html
@@ -144,9 +144,23 @@
             (office missing)
         {% endif %}
             </td>
-            <td>{% if candidate.candidate_twitter_handle %}<a href="https://twitter.com/{{ candidate.candidate_twitter_handle }}"
-                    target="_blank">{{ candidate.candidate_twitter_handle }}</a><br />
-                ({{ candidate.twitter_followers_count }} followers){% endif %}</td>
+            <td>{% if candidate.candidate_twitter_handle %}
+                    <a href="https://twitter.com/{{ candidate.candidate_twitter_handle }}"
+                        target="_blank">{{ candidate.candidate_twitter_handle }}</a><br />
+                    ({{ candidate.twitter_followers_count }} followers)
+                {% else %}
+                    {% if candidate.candidate_merge_possibility %}
+                        <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                            <img src='{{ candidate.candidate_merge_possibility.twitter_profile_image_url_https }}' height="25px" /></a>&nbsp;
+                        <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                            {{ candidate.candidate_merge_possibility.twitter_handle }}</a>
+                        (Best Guess:
+                        <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+                            {{ candidate.candidate_merge_possibility.likelihood_percentage }}</a>)<br />
+                        {{ candidate.candidate_merge_possibility.twitter_description }}
+                    {% endif %}
+                {% endif %}
+            </td>
             <td>{% if candidate.candidate_url %}<a href="{{ candidate.candidate_url }}" target="_blank">{{ candidate.candidate_url }}</a>{% endif %}</td>
             <td>{{ candidate.id }}</td>
             <td>{{ candidate.we_vote_id }}

--- a/twitter/urls.py
+++ b/twitter/urls.py
@@ -15,4 +15,6 @@ urlpatterns = [
         views_admin.delete_possible_twitter_handles_view, name='delete_possible_twitter_handles',),
     url(r'^retrieve_possible_twitter_handles/(?P<candidate_campaign_we_vote_id>wv[\w]{2}cand[\w]+)/$',
         views_admin.retrieve_possible_twitter_handles_view, name='retrieve_possible_twitter_handles',),
+    url(r'^bulk_retrieve_possible_twitter_handles/$',
+        views_admin.bulk_retrieve_possible_twitter_handles_view, name='bulk_retrieve_possible_twitter_handles',),
 ]

--- a/twitter/views_admin.py
+++ b/twitter/views_admin.py
@@ -3,14 +3,14 @@
 # -*- coding: UTF-8 -*-
 
 from .controllers import delete_possible_twitter_handles, retrieve_possible_twitter_handles
+from .models import TwitterLinkPossibility
 from admin_tools.views import redirect_to_sign_in_page
 from candidate.models import CandidateCampaign, CandidateCampaignManager
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
-from twitter.models import TwitterLinkPossibility
-from voter.models import voter_has_authority, VoterManager
+from voter.models import voter_has_authority
 from wevote_functions.functions import convert_to_int, positive_value_exists
 import wevote_functions.admin
 

--- a/twitter/views_admin.py
+++ b/twitter/views_admin.py
@@ -4,12 +4,14 @@
 
 from .controllers import delete_possible_twitter_handles, retrieve_possible_twitter_handles
 from admin_tools.views import redirect_to_sign_in_page
-from candidate.models import CandidateCampaignManager
+from candidate.models import CandidateCampaign, CandidateCampaignManager
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
+from twitter.models import TwitterLinkPossibility
 from voter.models import voter_has_authority, VoterManager
+from wevote_functions.functions import convert_to_int, positive_value_exists
 import wevote_functions.admin
 
 logger = wevote_functions.admin.get_logger(__name__)
@@ -58,3 +60,55 @@ def retrieve_possible_twitter_handles_view(request, candidate_campaign_we_vote_i
 
     return HttpResponseRedirect(reverse('candidate:candidate_edit_we_vote_id', args=(candidate_campaign_we_vote_id,)))
 
+
+@login_required
+def bulk_retrieve_possible_twitter_handles_view(request):
+    authority_required = {'verified_volunteer'}  # admin, verified_volunteer
+    if not voter_has_authority(request, authority_required):
+        return redirect_to_sign_in_page(request, authority_required)
+
+    google_civic_election_id = convert_to_int(request.GET.get('google_civic_election_id', 0))
+    state_code = request.GET.get('state_code', '')
+    show_all = request.GET.get('show_all', False)
+
+    try:
+        candidate_list = CandidateCampaign.objects.all()
+        if positive_value_exists(google_civic_election_id):
+            candidate_list = candidate_list.filter(google_civic_election_id=google_civic_election_id)
+        if positive_value_exists(state_code):
+            candidate_list = candidate_list.filter(state_code__iexact=state_code)
+        candidate_list = candidate_list.order_by('candidate_name')
+        if not positive_value_exists(show_all):
+            candidate_list = candidate_list[:200]
+        candidate_list_count = candidate_list.count()
+
+        # Run Twitter account search and analysis on candidates without a linked or possible Twitter account
+        number_of_candidates_to_search = 10
+        current_candidate_index = 0
+        while positive_value_exists(number_of_candidates_to_search) \
+                and (current_candidate_index < candidate_list_count):
+            one_candidate = candidate_list[current_candidate_index]
+            if not positive_value_exists(one_candidate.candidate_twitter_handle):
+                # Candidate does not have a Twitter account linked
+                twitter_link_possibility_list = []
+                try:
+                    twitter_possibility_query = TwitterLinkPossibility.objects.order_by('-likelihood_percentage')
+                    twitter_possibility_query = twitter_possibility_query.filter(
+                        candidate_campaign_we_vote_id=one_candidate.we_vote_id)
+                    twitter_link_possibility_list = list(twitter_possibility_query)
+                except Exception as e:
+                    pass
+
+                if not positive_value_exists(twitter_link_possibility_list):
+                    # Twitter account search and analysis has not been run on this candidate yet
+                    # (or no results have been found for this candidate, at least)
+                    results = retrieve_possible_twitter_handles(one_candidate)
+                    number_of_candidates_to_search -= 1
+            current_candidate_index += 1
+    except CandidateCampaign.DoesNotExist:
+        # This is fine, do nothing
+        pass
+
+    return HttpResponseRedirect(reverse('candidate:candidate_list', args=()) +
+                                '?google_civic_election_id=' + str(google_civic_election_id) +
+                                '&state_code=' + str(state_code))


### PR DESCRIPTION
Retrieved the top Twitter search result for each candidate without a linked Twitter account to display on the candidate list page. Implemented the ability to retrieve possible Twitter handles for multiple candidates at once. Refactored steps on candidate list page as unordered/ordered lists for ease of numbering.

To fix later: the bulk retrieval currently does not account for candidates with zero search results and so will no longer work if there are enough candidates with zero search results.

#538 