### PR TITLE
Implemented utc_offset check in Twitter search results analysis

### DIFF
--- a/twitter/controllers.py
+++ b/twitter/controllers.py
@@ -10,7 +10,8 @@ from candidate.models import CandidateCampaignListManager
 from config.base import get_environment_variable
 from office.models import ContestOfficeManager
 from organization.models import OrganizationListManager
-from wevote_functions.functions import convert_state_code_to_state_text, convert_to_int, positive_value_exists
+from wevote_functions.functions import convert_state_code_to_state_text, convert_state_code_to_utc_offset, \
+    convert_to_int, positive_value_exists
 from math import floor, log2
 from re import sub
 from time import time
@@ -99,6 +100,11 @@ def analyze_twitter_search_results(search_results, search_results_length, candid
         if one_result.description and positive_value_exists(state_code) and \
                 state_code in one_result.description:
             likelihood_score += 10
+
+        # Check if user time zone is close to election/state time zone
+        state_utc_offset = convert_state_code_to_utc_offset(state_code)
+        if one_result.utc_offset and state_utc_offset and abs(state_utc_offset - one_result.utc_offset) > 7200:
+            likelihood_score -= 30
 
         # Check if candidate's party is in description
         political_party = candidate_campaign.political_party_display()

--- a/twitter/controllers.py
+++ b/twitter/controllers.py
@@ -96,6 +96,9 @@ def analyze_twitter_search_results(search_results, search_results_length, candid
         if one_result.description and positive_value_exists(state_full_name) and \
                 state_full_name in one_result.description:
             likelihood_score += 20
+        if one_result.description and positive_value_exists(state_code) and \
+                state_code in one_result.description:
+            likelihood_score += 10
 
         # Check if candidate's party is in description
         political_party = candidate_campaign.political_party_display()
@@ -104,7 +107,6 @@ def analyze_twitter_search_results(search_results, search_results_length, candid
             likelihood_score += 20
 
         # Check (each word individually) if office name is in description
-        # This also checks if state code is in description
         office_name = candidate_campaign.contest_office_name
         if positive_value_exists(office_name) and one_result.description:
             office_name = office_name.split()

--- a/wevote_functions/functions.py
+++ b/wevote_functions/functions.py
@@ -75,7 +75,66 @@ STATE_CODE_MAP = {
     'WA': 'Washington',
     'WI': 'Wisconsin',
     'WV': 'West Virginia',
-    'WY': 'Wyoming'
+    'WY': 'Wyoming',
+}
+
+UTC_OFFSET_MAP = {
+    'AK': -32400,
+    'AL': -18000,
+    'AR': -21600,
+    'AS': -39600,
+    'AZ': -25200,
+    'CA': -28800,
+    'CO': -25200,
+    'CT': -18000,
+    'DC': -18000,
+    'DE': -18000,
+    'FL': -18000,
+    'GA': -18000,
+    'GU':  36000,
+    'HI': -36000,
+    'IA': -21600,
+    'ID': -25200,
+    'IL': -21600,
+    'IN': -18000,
+    'KS': -21600,
+    'KY': -18000,
+    'LA': -21600,
+    'MA': -18000,
+    'MD': -18000,
+    'ME': -18000,
+    'MI': -18000,
+    'MN': -21600,
+    'MO': -21600,
+    'MP':  36000,
+    'MS': -21600,
+    'MT': -25200,
+    'NC': -18000,
+    'ND': -21600,
+    'NE': -21600,
+    'NH': -18000,
+    'NJ': -18000,
+    'NM': -25200,
+    'NV': -25200,
+    'NY': -18000,
+    'OH': -18000,
+    'OK': -21600,
+    'OR': -25200,
+    'PA': -18000,
+    'PR': -14400,
+    'RI': -18000,
+    'SC': -18000,
+    'SD': -21600,
+    'TN': -18000,
+    'TX': -21600,
+    'UT': -25200,
+    'VA': -18000,
+    'VI': -14400,
+    'VT': -18000,
+    'WA': -28800,
+    'WI': -21600,
+    'WV': -18000,
+    'WY': -25200,
 }
 
 AMERICAN_INDEPENDENT = 'AMERICAN_INDEPENDENT'
@@ -690,6 +749,10 @@ def convert_state_code_to_state_text(incoming_state_code):
             return state_name
     else:
         return ""
+
+
+def convert_state_code_to_utc_offset(state_code):
+    return UTC_OFFSET_MAP.get(state_code, None)
 
 
 def process_request_from_master(request, message_text, get_url, get_params):


### PR DESCRIPTION
Implemented the ability to check if the utc_offset of a Twitter account is within two hours of the time zone of the current state. Added a helper function `convert_state_code_to_utc_offset` in wevote_functions.functions to handle the mapping from state_code to utc_offset. Re-added the ability to check if state_code is in the Twitter description since it is not already inside contest_office_name.