### PR TITLE
Fixed #567 #549

### DIFF
--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -236,7 +236,8 @@ def candidate_list_view(request):
     for candidate in candidate_list:
         try:
             google_search_possibility_query = GoogleSearchUser.objects.filter(
-                candidate_campaign_we_vote_id=candidate.we_vote_id)
+                candidate_campaign_we_vote_id=candidate.we_vote_id).\
+                exclude(item_image__isnull=True).exclude(item_image__exact='')
             google_search_possibility_query = google_search_possibility_query.order_by(
                 '-chosen_and_updated', 'not_a_match', '-likelihood_score')
             candidate.google_search_merge_possibility = google_search_possibility_query[0]

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -345,6 +345,7 @@ def candidate_edit_view(request, candidate_id=0, candidate_campaign_we_vote_id="
     vote_smart_id = request.GET.get('vote_smart_id', False)
     maplight_id = request.GET.get('maplight_id', False)
     state_code = request.GET.get('state_code', "")
+    show_all_google_search_users = request.GET.get('show_all_google_search_users', False)
 
     messages_on_stage = get_messages(request)
     candidate_id = convert_to_int(candidate_id)
@@ -419,8 +420,10 @@ def candidate_edit_view(request, candidate_id=0, candidate_campaign_we_vote_id="
                 candidate_campaign_we_vote_id=candidate_on_stage.we_vote_id)
             google_search_possibility_query = google_search_possibility_query.order_by(
                 '-chosen_and_updated', 'not_a_match', '-likelihood_score')
-            google_search_possibility_list = list(google_search_possibility_query)
-
+            if positive_value_exists(show_all_google_search_users):
+                google_search_possibility_list = list(google_search_possibility_query)
+            else:
+                google_search_possibility_list.append(google_search_possibility_query[0])
         except Exception as e:
             pass
 

--- a/google_custom_search/controllers.py
+++ b/google_custom_search/controllers.py
@@ -7,6 +7,7 @@
 from .models import GoogleSearchUserManager
 from config.base import get_environment_variable
 from googleapiclient.discovery import build
+from image.controllers import BALLOTPEDIA, LINKEDIN, FACEBOOK, TWITTER, WIKIPEDIA
 from import_export_wikipedia.controllers import reach_out_to_wikipedia_with_guess, \
     retrieve_candidate_images_from_wikipedia_page
 from re import sub
@@ -291,21 +292,21 @@ def analyze_google_search_results(search_results, search_term, candidate_name,
                     political_party in google_json['item_meta_tags_description']:
                 likelihood_score += 20
 
-            if "ballotpedia" in google_json['item_link']:
+            if BALLOTPEDIA in google_json['item_link']:
                 from_ballotpedia = True
-                likelihood_score += 80
-            if "linkedin" in google_json['item_link']:
+                likelihood_score += 20
+            if LINKEDIN in google_json['item_link']:
                 from_linkedin = True
-                likelihood_score += 55
-            if "facebook" in google_json['item_link']:
+                likelihood_score += 20
+            if FACEBOOK in google_json['item_link']:
                 from_facebook = True
-                likelihood_score += 55
-            if "twitter" in google_json['item_link']:
+                likelihood_score += 20
+            if TWITTER in google_json['item_link']:
                 from_twitter = True
-                likelihood_score += 55
-            if "wikipedia" in google_json['item_link']:
+                likelihood_score += 20
+            if WIKIPEDIA in google_json['item_link']:
                 from_wikipedia = True
-                likelihood_score += 50
+                likelihood_score += 20
 
             # Check (each word individually) if office name is in description
             # This also checks if state code is in description
@@ -440,7 +441,7 @@ def update_google_search_with_wikipedia_results(wikipedia_page, search_term, can
 
 def analyze_wikipedia_search_results(wikipedia_page, search_term, candidate_name,
                                      candidate_campaign):
-    likelihood_score = 50
+    likelihood_score = 20
     possible_google_search_users_list = []
     state_code = candidate_campaign.state_code
     state_full_name = convert_state_code_to_state_text(state_code)

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -171,83 +171,16 @@ span.wrap_word { word-break: break-word; }
 <div class="form-group">
     <label for="google_search_image_file_id" class="col-sm-3 control-label">Google Search</label>
     <div class="col-sm-8">
-        <input type="hidden" name="google_search_image_file" id="google_search_image_file_id" class="form-control"
-               value="{{ google_search_image_file }}" />
-        <input type="hidden" name="google_search_link" id="google_search_link_id" class="form-control"
-               value="{{ google_search_link }}" />
+        (<a href="{% url 'google_custom_search:retrieve_possible_google_search_users' candidate.we_vote_id %}">retrieve possible google search users</a>)
+        (<a href="{% url 'google_custom_search:delete_possible_google_search_users' candidate.we_vote_id %}">delete possible google search users</a>)
+        (<a href="{% url 'google_custom_search:bulk_possible_google_search_users_do_not_match' candidate.we_vote_id %}">these possible candidates don't match</a>)
 
-    (<a href="{% url 'google_custom_search:retrieve_possible_google_search_users' candidate.we_vote_id %}">retrieve possible google search users</a>)
-    (<a href="{% url 'google_custom_search:delete_possible_google_search_users' candidate.we_vote_id %}">delete possible google search users</a>)
-    (<a href="{% url 'google_custom_search:bulk_possible_google_search_users_do_not_match' candidate.we_vote_id %}">these possible candidates don't match</a>)
-
-    <table border="1" cellpadding="5" cellspacing="5" class="table">
-        <tr>
-            <th>#</th>
-            <th>Score</th>
-            <th>Image</th>
-            <th>Google search description</th>
-            <th>Google search link</th>
-        </tr>
-    {% for one_row in google_search_possibility_list %}
-        <tr>
-            <td style="width:5%;">{{ forloop.counter }}</td>
-            <td style="text-align:center;width:5%;">
-                {% if one_row.chosen_and_updated %}
-                    <img src="/static/green_ok.png" height="16px"/><br />
-                {% endif %}
-                {% if one_row.not_a_match %}
-                    <img src="/static/red_cross.png" height="16px"/><br />
-                {% endif %}
-                {{ one_row.likelihood_score|default_if_none:"n/a" }}
-                <br />
-                {% if not one_row.chosen_and_updated and not one_row.not_a_match %}
-                    <a href="{% url 'google_custom_search:possible_google_search_user_do_not_match' %}?candidate_we_vote_id={{ candidate.we_vote_id }}&item_link={{ one_row.item_link }}">Not a match</a>
-                {% endif %}
-            </td>
-            <td style="text-align:center;width:10%">
-                {% if one_row.item_image %}
-                    <img src='{{ one_row.item_image }}' height="48px"/><br />
-                {% endif %}
-                {{ one_row.item_title }}
-                <br />
-                {% if not one_row.not_a_match %}
-                    {% if one_row.item_image %}
-                        <input id="choose_and_update_{{ forloop.counter }}" type="button" value="Choose and Update" onclick="document.getElementById('google_search_image_file_id').value = '{{ one_row.item_image }}'
-                            document.getElementById('google_search_link_id').value = '{{ one_row.item_link }}';document.getElementById('candidate_edit').submit();" />
-                    {% endif %}
-                    <br />
-                    {% if one_row.from_ballotpedia %}
-                        <input id="save_ballotpedia_{{ forloop.counter }}" type="button" value="Save Ballotpedia Link" onclick="document.getElementById('google_search_link_id').value = '{{ one_row.item_link }}';document.getElementById('candidate_edit').submit();" />
-                    {% elif one_row.from_facebook %}
-                        <input id="save_facebook_{{ forloop.counter }}" type="button" value="Save Facebook Link" onclick="document.getElementById('google_search_link_id').value = '{{ one_row.item_link }}';document.getElementById('candidate_edit').submit();" />
-                    {% elif one_row.from_linkedin %}
-                        <input id="save_linkedin_{{ forloop.counter }}" type="button" value="Save Linkedin Link" onclick="document.getElementById('google_search_link_id').value = '{{ one_row.item_link }}';document.getElementById('candidate_edit').submit();" />
-                    {% elif one_row.from_twitter %}
-                        <input id="save_twitter_{{ forloop.counter }}" type="button" value="Save Twitter Link" onclick="document.getElementById('google_search_link_id').value = '{{ one_row.item_link }}';document.getElementById('candidate_edit').submit();" />
-                    {% elif one_row.from_wikipedia %}
-                        <input id="save_wikipedia_{{ forloop.counter }}" type="button" value="Save Wikipedia Link" onclick="document.getElementById('google_search_link_id').value = '{{ one_row.item_link }}';document.getElementById('candidate_edit').submit();" />
-                    {% else %}
-                        <input id="save_link_{{ forloop.counter }}" type="button" value="Save Candidate Link" onclick="document.getElementById('google_search_link_id').value = '{{ one_row.item_link }}';document.getElementById('candidate_edit').submit();" />
-                    {% endif %}
-                {% endif %}
-            </td>
-
-            <td style="width:40%;word-break:break-word;">
-                {{ one_row.item_snippet|default_if_none:"n/a" }}
-                <br />
-                {{ one_row.item_meta_tags_description|default_if_none:"n/a" }}
-            </td>
-            <td style="width:50%;">
-                <span class="wrap_word">
-                    <a href="{{ one_row.item_link }}" target="_blank">{{ one_row.item_link|default_if_none:"" }}</a>
-                    <a href="{{ one_row.item_formatted_link }}" target="_blank">{{ one_row.item_formatted_url|default_if_none:"" }}</a>
-                    <br />
-                    <a href="{{ one_row.search_request_url }}" target="_blank">{{ one_row.search_request_url|default_if_none:"" }}</a>
-                </span>
-            </td>
-        </tr>
-    {% endfor %}
-    </table>
+        {% include "candidate/google_search_users_for_candidate_table.html" with candidate=candidate google_search_possibility_list=google_search_possibility_list %}
+        {% if google_search_possibility_list|length == 1 %}
+            <a href="{% url 'candidate:candidate_edit' candidate.id %}?show_all_google_search_users=1">Show more google search users</a>
+        {% elif google_search_possibility_list|length > 1 %}
+            <a href="{% url 'candidate:candidate_edit' candidate.id %}?show_all_google_search_users=0">Show less google search user</a>
+        {% endif %}
     </div>
 </div>
 

--- a/templates/candidate/candidate_list.html
+++ b/templates/candidate/candidate_list.html
@@ -189,6 +189,18 @@
                             {{ candidate.google_search_merge_possibility.likelihood_score }}</a>)<br />
                         <a href="{{ candidate.google_search_merge_possibility.item_link }}" target="_blank">{{ candidate.google_search_merge_possibility.item_link|default_if_none:"" }}</a><br />
                         {{ candidate.google_search_merge_possibility.item_snippet }}
+                        {% if candidate.google_search_merge_possibility.likelihood_score >= 50 %}
+                            <form action="{% url 'candidate:candidate_edit_process' %}" id="candidate_edit_process" method="post" class="form-horizontal">
+                                {% csrf_token %}
+                                <input type="hidden" name="google_search_link" value="{{ candidate.google_search_merge_possibility.item_link }}" />
+                                <input type="hidden" name="google_search_image_file" value="{{ candidate.google_search_merge_possibility.item_image }}" />
+                                <input type="hidden" name="candidate_id" value="{{ candidate.id }}" />
+                                <input type="hidden" name="google_civic_election_id" value="{{ google_civic_election_id }}" />
+                                <input type="hidden" name="state_code" value="{{ state_code }}" />
+                                <input type="hidden" name="redirect_to_candidate_list" value="1" />
+                                <input id="choose_and_update_{{ forloop.counter }}" type="submit" value="Choose and Update" />
+                            </form>
+                        {% endif %}
                     {% else %}
                         <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
                             <img src='{{ candidate.google_search_merge_possibility.item_image }}' height="25px" /></a>&nbsp;

--- a/templates/candidate/candidate_list.html
+++ b/templates/candidate/candidate_list.html
@@ -81,7 +81,7 @@
         Retrieve Possible Twitter Handles</a> (10 at a time - about 30 seconds)</li>
 
         <li><a href="{% url 'google_custom_search:bulk_retrieve_possible_google_search_users' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" >
-        Retrieve Possible Candidates from Google</a> (10 at a time - 1-2 minutes)</li>
+        Retrieve Possible Candidates from Google</a> (20 at a time - 1-2 minutes)</li>
 
         <li><a href="{% url 'import_export_twitter:refresh_twitter_candidate_details_for_election' google_civic_election_id %}?state_code={{ state_code }}" >
         Retrieve/Refresh Candidate Twitter Info for this Election</a> (1-2 minutes)</li>

--- a/wevote_functions/functions.py
+++ b/wevote_functions/functions.py
@@ -504,6 +504,54 @@ def extract_nickname_from_full_name(full_name):
     return ""
 
 
+def extract_website_from_url(url_string):
+    """
+
+    :param url_string:
+    :return:
+    """
+    if not url_string:
+        return ""
+    if not positive_value_exists(url_string):
+        return ""
+    url_string = str(url_string)
+    url_string.strip()
+    url_string = url_string.replace("https://www.", "")
+    url_string = url_string.replace("http://www.", "")
+    url_string = url_string.replace("https://", "")
+    url_string = url_string.replace("http://", "")
+    url_string = url_string.replace("www://", "")
+    url_string = url_string.split("/")[0]
+    return url_string
+
+
+def extract_facebook_username_from_text_string(facebook_text_string):
+    """
+
+    :param facebook_text_string:
+    :return:
+    """
+    if not facebook_text_string:
+        return ""
+    if not positive_value_exists(facebook_text_string):
+        return ""
+    facebook_text_string = str(facebook_text_string)
+    facebook_text_string.strip()
+    facebook_text_string = facebook_text_string.lower()
+    facebook_text_string = facebook_text_string.replace("http://facebook.com", "")
+    facebook_text_string = facebook_text_string.replace("http://www.facebook.com", "")
+    facebook_text_string = facebook_text_string.replace("http://m.facebook.com", "")
+    facebook_text_string = facebook_text_string.replace("https://facebook.com", "")
+    facebook_text_string = facebook_text_string.replace("https://www.facebook.com", "")
+    facebook_text_string = facebook_text_string.replace("https://m.facebook.com", "")
+    facebook_text_string = facebook_text_string.replace("www.facebook.com", "")
+    facebook_text_string = facebook_text_string.replace("facebook.com", "")
+    facebook_text_string = facebook_text_string.replace("@", "")
+    facebook_text_string = facebook_text_string.replace("/", "")
+    facebook_text_string = facebook_text_string.split("?", 1)[0]  # Remove everything after first "?" (including "?")
+    return facebook_text_string
+
+
 def extract_twitter_handle_from_text_string(twitter_text_string):
     """
 
@@ -519,7 +567,9 @@ def extract_twitter_handle_from_text_string(twitter_text_string):
     twitter_text_string = twitter_text_string.lower()
     twitter_text_string = twitter_text_string.replace("http://twitter.com", "")
     twitter_text_string = twitter_text_string.replace("http://www.twitter.com", "")
+    twitter_text_string = twitter_text_string.replace("http://m.twitter.com", "")
     twitter_text_string = twitter_text_string.replace("https://twitter.com", "")
+    twitter_text_string = twitter_text_string.replace("https://m.twitter.com", "")
     twitter_text_string = twitter_text_string.replace("https://www.twitter.com", "")
     twitter_text_string = twitter_text_string.replace("www.twitter.com", "")
     twitter_text_string = twitter_text_string.replace("twitter.com", "")


### PR DESCRIPTION
- Created google_search_users_for_candidate_table tamplate to load google serach users table.
- Show one google search user on candidate edit page with show more and show less link
- Choose and Update button for twitter search will not cache image instead refresh_candidate_twitter_details will do caching at the end of candidate_edit_process
- Updated likelihood_score for Ballotpedia, linkedin, facebook, twitter and wikipedia links
- Top google search result on candidate list page filters out on the basis of image, score
- Added Choose and update button to select google search user on candidate list page
- Added common function extract_website_from_url, extract_facebook_username_from_text_string