### PR TITLE
Implemented RemoteRequestHistory into retrieval of possible Twitter handles, merged keywords lists

### DIFF
--- a/google_custom_search/controllers.py
+++ b/google_custom_search/controllers.py
@@ -11,7 +11,8 @@ from image.controllers import BALLOTPEDIA, LINKEDIN, FACEBOOK, TWITTER, WIKIPEDI
 from import_export_wikipedia.controllers import reach_out_to_wikipedia_with_guess, \
     retrieve_candidate_images_from_wikipedia_page
 from re import sub
-from wevote_functions.functions import positive_value_exists, convert_state_code_to_state_text
+from wevote_functions.functions import positive_value_exists, convert_state_code_to_state_text, \
+    POSITIVE_SEARCH_KEYWORDS, NEGATIVE_SEARCH_KEYWORDS
 
 GOOGLE_SEARCH_ENGINE_ID = get_environment_variable("GOOGLE_SEARCH_ENGINE_ID")
 GOOGLE_SEARCH_API_KEY = get_environment_variable("GOOGLE_SEARCH_API_KEY")
@@ -20,39 +21,6 @@ GOOGLE_SEARCH_API_VERSION = get_environment_variable("GOOGLE_SEARCH_API_VERSION"
 BALLOTPEDIA_LOGO_URL = "ballotpedia-logo-square"
 MAXIMUM_GOOGLE_SEARCH_USERS = 10
 MAXIMUM_CHARACTERS_LENGTH = 1000
-
-GOOGLE_SEARCH_POSITIVE_KEYWORDS = [
-    "affiliate",
-    "candidate",
-    "chair",
-    "city",
-    "civic",
-    "country",
-    "county",
-    "district",
-    "elect",
-    "endorse",
-    "local",
-    "office",
-    "official",
-    "public",
-    "represent",
-    "running",
-    "state",
-    'leader',
-    'democratic',
-    'council',
-    'municipal',
-    'party',
-    'politic',
-]
-
-GOOGLE_SEARCH_NEGATIVE_KEYWORDS = [
-    "fake",
-    "parody",
-    'musician',
-    'singer',
-]
 
 
 def delete_possible_google_search_users(candidate_campaign):
@@ -357,14 +325,14 @@ def analyze_google_search_results(search_results, search_term, candidate_name,
                     likelihood_score -= 5
 
             # Increase the score for every positive keyword we find
-            for keyword in GOOGLE_SEARCH_POSITIVE_KEYWORDS:
+            for keyword in POSITIVE_SEARCH_KEYWORDS:
                 if google_json['item_snippet'] and keyword in google_json['item_snippet'].lower() or \
                         google_json['item_meta_tags_description'] and \
                         keyword in google_json['item_meta_tags_description'].lower():
                     likelihood_score += 5
 
             # Decrease the score for every negative keyword we find
-            for keyword in GOOGLE_SEARCH_NEGATIVE_KEYWORDS:
+            for keyword in NEGATIVE_SEARCH_KEYWORDS:
                 if (google_json['item_snippet'] and keyword in google_json['item_snippet'].lower()) or \
                     (google_json['item_meta_tags_description'] and
                      keyword in google_json['item_meta_tags_description'].lower()):
@@ -535,12 +503,12 @@ def analyze_wikipedia_search_results(wikipedia_page, search_term, candidate_name
             likelihood_score -= 5
 
     # Increase the score for every positive keyword we find
-    for keyword in GOOGLE_SEARCH_POSITIVE_KEYWORDS:
+    for keyword in POSITIVE_SEARCH_KEYWORDS:
         if google_json['item_snippet'] and keyword in google_json['item_snippet'].lower():
             likelihood_score += 5
 
     # Decrease the score for every negative keyword we find
-    for keyword in GOOGLE_SEARCH_NEGATIVE_KEYWORDS:
+    for keyword in NEGATIVE_SEARCH_KEYWORDS:
         if google_json['item_snippet'] and keyword in google_json['item_snippet'].lower():
             likelihood_score -= 20
 

--- a/twitter/controllers.py
+++ b/twitter/controllers.py
@@ -12,6 +12,7 @@ from office.models import ContestOfficeManager
 from organization.models import OrganizationListManager
 from wevote_functions.functions import convert_state_code_to_state_text, convert_state_code_to_utc_offset, \
     convert_to_int, positive_value_exists
+from wevote_settings.models import RemoteRequestHistoryManager, RETRIEVE_POSSIBLE_TWITTER_HANDLES
 from math import floor, log2
 from re import sub
 from time import time
@@ -193,6 +194,7 @@ def delete_possible_twitter_handles(candidate_campaign):
 def retrieve_possible_twitter_handles(candidate_campaign):
     status = ""
     twitter_user_manager = TwitterUserManager()
+    remote_request_history_manager = RemoteRequestHistoryManager()
 
     if not candidate_campaign:
         status = "RETRIEVE_POSSIBLE_TWITTER_HANDLES-CANDIDATE_MISSING "
@@ -280,6 +282,11 @@ def retrieve_possible_twitter_handles(candidate_campaign):
             save_twitter_user_results = twitter_user_manager.update_or_create_twitter_link_possibility(
                 candidate_campaign.we_vote_id, possibility_result['twitter_json'],
                 possibility_result['search_term'], possibility_result['likelihood_score'])
+
+    # Create a record denoting that we have retrieved from Twitter for this candidate
+    save_results_history = remote_request_history_manager.create_remote_request_history_entry(
+        RETRIEVE_POSSIBLE_TWITTER_HANDLES, candidate_campaign.google_civic_election_id,
+        candidate_campaign.we_vote_id, None, len(possible_twitter_handles_list), status)
 
     results = {
         'success':                  True,

--- a/twitter/controllers.py
+++ b/twitter/controllers.py
@@ -11,7 +11,7 @@ from config.base import get_environment_variable
 from office.models import ContestOfficeManager
 from organization.models import OrganizationListManager
 from wevote_functions.functions import convert_state_code_to_state_text, convert_state_code_to_utc_offset, \
-    convert_to_int, positive_value_exists
+    convert_to_int, positive_value_exists, POSITIVE_SEARCH_KEYWORDS, NEGATIVE_SEARCH_KEYWORDS
 from wevote_settings.models import RemoteRequestHistoryManager, RETRIEVE_POSSIBLE_TWITTER_HANDLES
 from math import floor, log2
 from re import sub
@@ -21,31 +21,6 @@ TWITTER_CONSUMER_KEY = get_environment_variable("TWITTER_CONSUMER_KEY")
 TWITTER_CONSUMER_SECRET = get_environment_variable("TWITTER_CONSUMER_SECRET")
 TWITTER_ACCESS_TOKEN = get_environment_variable("TWITTER_ACCESS_TOKEN")
 TWITTER_ACCESS_TOKEN_SECRET = get_environment_variable("TWITTER_ACCESS_TOKEN_SECRET")
-
-POSITIVE_KEYWORDS = [
-    "affiliate",
-    "candidate",
-    "chair",
-    "city",
-    "civic",
-    "country",
-    "county",
-    "district",
-    "elect",
-    "endorse",
-    "local",
-    "office",
-    "official",
-    "public",
-    "represent",
-    "running",
-    "state",
-]
-
-NEGATIVE_KEYWORDS = [
-    "fake",
-    "parody",
-]
 
 
 def analyze_twitter_search_results(search_results, search_results_length, candidate_name,
@@ -126,12 +101,12 @@ def analyze_twitter_search_results(search_results, search_results_length, candid
                 likelihood_score -= 10
 
         # Increase the score for every positive keyword we find
-        for keyword in POSITIVE_KEYWORDS:
+        for keyword in POSITIVE_SEARCH_KEYWORDS:
             if one_result.description and keyword in one_result.description.lower():
                 likelihood_score += 5
 
         # Decrease the score for every negative keyword we find
-        for keyword in NEGATIVE_KEYWORDS:
+        for keyword in NEGATIVE_SEARCH_KEYWORDS:
             if one_result.description and keyword in one_result.description.lower():
                 likelihood_score -= 20
 

--- a/twitter/views_admin.py
+++ b/twitter/views_admin.py
@@ -92,7 +92,7 @@ def bulk_retrieve_possible_twitter_handles_view(request):
             if not positive_value_exists(one_candidate.candidate_twitter_handle):
                 # Candidate does not have a Twitter account linked
                 request_history = RemoteRequestHistory.objects.filter(
-                    candidate_campaign_we_vote_id=one_candidate.we_vote_id)
+                    candidate_campaign_we_vote_id__iexact=one_candidate.we_vote_id)
                 request_history_list = list(request_history)
 
                 if not positive_value_exists(request_history_list):

--- a/twitter/views_admin.py
+++ b/twitter/views_admin.py
@@ -13,6 +13,7 @@ from django.http import HttpResponseRedirect
 from voter.models import voter_has_authority
 from wevote_functions.functions import convert_to_int, positive_value_exists
 import wevote_functions.admin
+from wevote_settings.models import RemoteRequestHistory
 
 logger = wevote_functions.admin.get_logger(__name__)
 
@@ -90,18 +91,12 @@ def bulk_retrieve_possible_twitter_handles_view(request):
             one_candidate = candidate_list[current_candidate_index]
             if not positive_value_exists(one_candidate.candidate_twitter_handle):
                 # Candidate does not have a Twitter account linked
-                twitter_link_possibility_list = []
-                try:
-                    twitter_possibility_query = TwitterLinkPossibility.objects.order_by('-likelihood_score')
-                    twitter_possibility_query = twitter_possibility_query.filter(
-                        candidate_campaign_we_vote_id=one_candidate.we_vote_id)
-                    twitter_link_possibility_list = list(twitter_possibility_query)
-                except Exception as e:
-                    pass
+                request_history = RemoteRequestHistory.objects.filter(
+                    candidate_campaign_we_vote_id=one_candidate.we_vote_id)
+                request_history_list = list(request_history)
 
-                if not positive_value_exists(twitter_link_possibility_list):
+                if not positive_value_exists(request_history_list):
                     # Twitter account search and analysis has not been run on this candidate yet
-                    # (or no results have been found for this candidate, at least)
                     results = retrieve_possible_twitter_handles(one_candidate)
                     number_of_candidates_to_search -= 1
             current_candidate_index += 1

--- a/wevote_functions/functions.py
+++ b/wevote_functions/functions.py
@@ -137,6 +137,39 @@ UTC_OFFSET_MAP = {
     'WY': -25200,
 }
 
+POSITIVE_SEARCH_KEYWORDS = [
+    "affiliate",
+    "candidate",
+    "chair",
+    "city",
+    "civic",
+    'council',
+    "country",
+    "county",
+    'democratic',
+    "district",
+    "elect",
+    "endorse",
+    'leader',
+    "local",
+    'municipal',
+    "office",
+    "official",
+    'party',
+    'politic',
+    "public",
+    "represent",
+    "running",
+    "state",
+]
+
+NEGATIVE_SEARCH_KEYWORDS = [
+    "fake",
+    'musician',
+    "parody",
+    'singer',
+]
+
 AMERICAN_INDEPENDENT = 'AMERICAN_INDEPENDENT'
 DEMOCRAT = 'DEMOCRAT'
 D_R = 'D_R'

--- a/wevote_functions/functions.py
+++ b/wevote_functions/functions.py
@@ -143,20 +143,20 @@ POSITIVE_SEARCH_KEYWORDS = [
     "chair",
     "city",
     "civic",
-    'council',
+    "council",
     "country",
     "county",
-    'democratic',
+    "democratic",
     "district",
     "elect",
     "endorse",
-    'leader',
+    "leader",
     "local",
-    'municipal',
+    "municipal",
     "office",
     "official",
-    'party',
-    'politic',
+    "party",
+    "politic",
     "public",
     "represent",
     "running",
@@ -165,9 +165,9 @@ POSITIVE_SEARCH_KEYWORDS = [
 
 NEGATIVE_SEARCH_KEYWORDS = [
     "fake",
-    'musician',
+    "musician",
     "parody",
-    'singer',
+    "singer",
 ]
 
 AMERICAN_INDEPENDENT = 'AMERICAN_INDEPENDENT'

--- a/wevote_settings/models.py
+++ b/wevote_settings/models.py
@@ -10,6 +10,8 @@ import wevote_functions.admin
 from wevote_functions.functions import convert_to_int, generate_random_string
 
 
+RETRIEVE_POSSIBLE_TWITTER_HANDLES = 'RETRIEVE_POSSIBLE_TWITTER_HANDLES'
+
 logger = wevote_functions.admin.get_logger(__name__)
 
 
@@ -410,7 +412,7 @@ class RemoteRequestHistoryManager(models.Model):
         """
 
         success = False
-        status = ""
+        create_status = ""
         remote_request_history_entry_created = False
         remote_request_history_entry = ''
 
@@ -423,18 +425,18 @@ class RemoteRequestHistoryManager(models.Model):
                 status=status)
             if remote_request_history_entry:
                 success = True
-                status += "REMOTE_REQUEST_HISTORY_ENTRY_CREATED"
+                create_status += "REMOTE_REQUEST_HISTORY_ENTRY_CREATED"
                 remote_request_history_entry_created = True
             else:
                 success = False
-                status += "CREATE_REMOTE_REQUEST_HISTORY_ENTRY_FAILED"
+                create_status += "CREATE_REMOTE_REQUEST_HISTORY_ENTRY_FAILED"
         except Exception as e:
             status += "REMOTE_REQUEST_HISTORY_ENTRY_ERROR"
             handle_record_not_saved_exception(e, logger=logger)
 
         results = {
             'success': success,
-            'status': status,
+            'status': create_status,
             'remote_request_history_entry_created': remote_request_history_entry_created,
             'remote_request_history_entry': remote_request_history_entry,
         }


### PR DESCRIPTION
Implemented RemoteRequestHistory into retrieval of possible Twitter handles to check whether the search has been done on a candidate before (#568). Fixed a bug preventing the status message parameter from being added to the RemoteRequestHistory object. Merged keywords lists from Google and Twitter searches into one common list.