### PR TITLE
Fixes for Twitter sign in for Android Native

### DIFF
--- a/apis_v1/views/views_twitter.py
+++ b/apis_v1/views/views_twitter.py
@@ -137,12 +137,23 @@ def twitter_native_sign_in_save_view(request):  # twitterNativeSignInSave
     voter_device_id = get_voter_device_id(request)  # We standardize how we take in the voter_device_id
     twitter_access_token = request.GET.get('twitter_access_token', '')
     twitter_access_token_secret = request.GET.get('twitter_access_token_secret', '')
-    results = twitter_native_sign_in_save_for_api(voter_device_id, twitter_access_token, twitter_access_token_secret)
+    resultsNative = twitter_native_sign_in_save_for_api(voter_device_id, twitter_access_token, twitter_access_token_secret)
+
+    if resultsNative['success'] != True:
+        logger.error("Bad save in twitter_native_sign_in_save_view: " + resultsNative['status'])
+
+    # Call equivalent of oAuth for WebApp Step 3
+    resultsVoterInfo = twitter_sign_in_request_voter_info_for_api(voter_device_id, "Native API Call, No Return URL")
 
     json_data = {
-        'status': results['status'],
-        'success': results['success'],
-        'voter_device_id': voter_device_id,
+        'status':               resultsVoterInfo['status'] + ' '  + resultsNative['status'],
+        'success':              resultsVoterInfo['success'],
+        'twitter_handle':       resultsVoterInfo['twitter_handle'],
+        'twitter_handle_found': resultsVoterInfo['twitter_handle_found'],
+        'twitter_secret_key':   resultsVoterInfo['twitter_secret_key'],
+        'voter_device_id':      resultsVoterInfo['voter_device_id'],
+        'voter_info_retrieved': resultsVoterInfo['voter_info_retrieved'],
+        'switch_accounts':      resultsVoterInfo['switch_accounts'],
     }
     return HttpResponse(json.dumps(json_data), content_type='application/json')
 
@@ -187,17 +198,17 @@ def twitter_sign_in_retrieve_view(request):  # twitterSignInRetrieve
     json_data = {
         'status':                                   results['status'],
         'success':                                  results['success'],
-        'voter_device_id':                          voter_device_id,
-        'voter_we_vote_id':                         results['voter_we_vote_id'],
-        'voter_has_data_to_preserve':               results['voter_has_data_to_preserve'],
         'existing_twitter_account_found':           results['existing_twitter_account_found'],
-        'voter_we_vote_id_attached_to_twitter':     results['voter_we_vote_id_attached_to_twitter'],
+        'twitter_profile_image_url_https':          results['twitter_profile_image_url_https'],
         'twitter_retrieve_attempted':               True,
+        'twitter_secret_key':                       results['twitter_secret_key'],
+        'twitter_sign_in_failed':                   results['twitter_sign_in_failed'],
         'twitter_sign_in_found':                    results['twitter_sign_in_found'],
         'twitter_sign_in_verified':                 results['twitter_sign_in_verified'],
-        'twitter_sign_in_failed':                   results['twitter_sign_in_failed'],
-        'twitter_secret_key':                       results['twitter_secret_key'],
-        'twitter_profile_image_url_https':          results['twitter_profile_image_url_https'],
+        'voter_device_id':                          voter_device_id,
+        'voter_has_data_to_preserve':               results['voter_has_data_to_preserve'],
+        'voter_we_vote_id':                         results['voter_we_vote_id'],
+        'voter_we_vote_id_attached_to_twitter':     results['voter_we_vote_id_attached_to_twitter'],
         'we_vote_hosted_profile_image_url_large':   results['we_vote_hosted_profile_image_url_large'],
         'we_vote_hosted_profile_image_url_medium':  results['we_vote_hosted_profile_image_url_medium'],
         'we_vote_hosted_profile_image_url_tiny':    results['we_vote_hosted_profile_image_url_tiny'],

--- a/import_export_twitter/controllers.py
+++ b/import_export_twitter/controllers.py
@@ -828,11 +828,12 @@ def twitter_native_sign_in_save_for_api(voter_device_id, twitter_access_token, t
 
         twitter_auth_response = auth_create_results['twitter_auth_response']
 
-
     try:
         if positive_value_exists(twitter_access_token) and positive_value_exists(twitter_access_secret):
             twitter_auth_response.twitter_access_token = twitter_access_token
             twitter_auth_response.twitter_access_secret = twitter_access_secret
+            twitter_auth_response.twitter_request_token = 'native'
+            twitter_auth_response.twitter_request_secret = 'native'
             twitter_auth_response.save()
 
             success = True

--- a/wevote_functions/functions.py
+++ b/wevote_functions/functions.py
@@ -689,6 +689,10 @@ def get_voter_device_id(request, generate_if_no_value=False):
     if positive_value_exists(voter_device_id):
         return voter_device_id
 
+    # Then check for a cookie (in Native)
+    if 'voter_device_id' in request.COOKIES:
+        return request.COOKIES['voter_device_id']
+
     if generate_if_no_value:
         voter_device_id = generate_voter_device_id()
         logger.debug("generate_voter_device_id, voter_device_id: {voter_device_id}".format(


### PR DESCRIPTION
Support change over to react-native-cookies on client side.
In views_twitter, new code for oAuth via react-native-oauth
in import_export_twitter/controllers, indicate in postgres when a native
authentication -- rather than leave blank fields for request token and
secret, that could cause concern.
In wevote_functions/functions, support voter_device_id via cookie
in response (request object).