### PR TITLE
Show top Twitter search result on candidate edit page with show more/less link

### DIFF
--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -346,6 +346,7 @@ def candidate_edit_view(request, candidate_id=0, candidate_campaign_we_vote_id="
     maplight_id = request.GET.get('maplight_id', False)
     state_code = request.GET.get('state_code', "")
     show_all_google_search_users = request.GET.get('show_all_google_search_users', False)
+    show_all_twitter_search_results = request.GET.get('show_all_twitter_search_results', False)
 
     messages_on_stage = get_messages(request)
     candidate_id = convert_to_int(candidate_id)
@@ -410,7 +411,10 @@ def candidate_edit_view(request, candidate_id=0, candidate_campaign_we_vote_id="
             twitter_possibility_query = TwitterLinkPossibility.objects.order_by('-likelihood_score')
             twitter_possibility_query = twitter_possibility_query.filter(
                 candidate_campaign_we_vote_id=candidate_on_stage.we_vote_id)
-            twitter_link_possibility_list = list(twitter_possibility_query)
+            if positive_value_exists(show_all_twitter_search_results):
+                twitter_link_possibility_list = list(twitter_possibility_query)
+            else:
+                twitter_link_possibility_list.append(twitter_possibility_query[0])
         except Exception as e:
             pass
 

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -165,6 +165,11 @@ span.wrap_word { word-break: break-word; }
     {% endfor %}
     </table>
 
+    {% if twitter_link_possibility_list|length == 1 %}
+        <a href="{% url 'candidate:candidate_edit' candidate.id %}?show_all_twitter_search_results=1">Show more Twitter search results</a>
+    {% elif twitter_link_possibility_list|length > 1 %}
+        <a href="{% url 'candidate:candidate_edit' candidate.id %}?show_all_twitter_search_results=0">Show fewer Twitter search results</a>
+    {% endif %}
     </div>
 </div>
 

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -177,9 +177,9 @@ span.wrap_word { word-break: break-word; }
 
         {% include "candidate/google_search_users_for_candidate_table.html" with candidate=candidate google_search_possibility_list=google_search_possibility_list %}
         {% if google_search_possibility_list|length == 1 %}
-            <a href="{% url 'candidate:candidate_edit' candidate.id %}?show_all_google_search_users=1">Show more google search users</a>
+            <a href="{% url 'candidate:candidate_edit' candidate.id %}?show_all_google_search_users=1">Show more Google search users</a>
         {% elif google_search_possibility_list|length > 1 %}
-            <a href="{% url 'candidate:candidate_edit' candidate.id %}?show_all_google_search_users=0">Show less google search user</a>
+            <a href="{% url 'candidate:candidate_edit' candidate.id %}?show_all_google_search_users=0">Show fewer Google search users</a>
         {% endif %}
     </div>
 </div>

--- a/templates/candidate/google_search_users_for_candidate_table.html
+++ b/templates/candidate/google_search_users_for_candidate_table.html
@@ -1,4 +1,4 @@
-{# templates/analytics/google_search_users_for_candidate_table.html #}
+{# templates/candidate/google_search_users_for_candidate_table.html #}
 
 <input type="hidden" name="google_search_image_file" id="google_search_image_file_id" class="form-control"
        value="{{ google_search_image_file }}" />


### PR DESCRIPTION
Implemented the ability to show only the top Twitter search result in the candidate edit page and added a link to toggle showing all results.