### PR TITLE
Started auth & retrieve tweets

### DIFF
--- a/organization/controllers.py
+++ b/organization/controllers.py
@@ -33,8 +33,11 @@ logger = wevote_functions.admin.get_logger(__name__)
 
 WE_VOTE_API_KEY = get_environment_variable("WE_VOTE_API_KEY")
 ORGANIZATIONS_SYNC_URL = get_environment_variable("ORGANIZATIONS_SYNC_URL")
+# Seems like the following lines are repeated from import_export_twitter/controllers.py
 TWITTER_CONSUMER_KEY = get_environment_variable("TWITTER_CONSUMER_KEY")
 TWITTER_CONSUMER_SECRET = get_environment_variable("TWITTER_CONSUMER_SECRET")
+# As far as I can tell this following env vars specify the wevote org; this is over-ridden
+# by specifying the twitter_id in line 53
 TWITTER_ACCESS_TOKEN = get_environment_variable("TWITTER_ACCESS_TOKEN")
 TWITTER_ACCESS_TOKEN_SECRET = get_environment_variable("TWITTER_ACCESS_TOKEN_SECRET")
 
@@ -47,10 +50,12 @@ def organization_retrieve_tweets(organization_we_vote_id, number_to_retrieve):
 
     api = tweepy.API(auth)
 
-    return api.user_timeline()
+    # TODO(eayoungs@gmail.com): Lookup twitter credential by we_vote_id
+    # This is a temporary test; hard coding the twitter id is not recommmended practice
+    return api.user_timeline('106502456') # The number of tweets DESPERATELY needs to be limited!
+    
 
-
-def organization_analyze_tweets(organization_we_vote_id):
+def organization_analyze_tweets():
     # For one organization, retrieve X Tweets, and capture all #Hashtags used.
     # Loop through Tweets and create OrganizationLinkToHashtag and OrganizationLinkToWordOrPhrase
     pass

--- a/organization/controllers.py
+++ b/organization/controllers.py
@@ -26,17 +26,28 @@ from voter_guide.models import VoterGuide, VoterGuideManager
 import wevote_functions.admin
 from wevote_functions.functions import convert_to_int, extract_twitter_handle_from_text_string, positive_value_exists, \
     process_request_from_master
+import tweepy
+
 
 logger = wevote_functions.admin.get_logger(__name__)
 
 WE_VOTE_API_KEY = get_environment_variable("WE_VOTE_API_KEY")
 ORGANIZATIONS_SYNC_URL = get_environment_variable("ORGANIZATIONS_SYNC_URL")
+TWITTER_CONSUMER_KEY = get_environment_variable("TWITTER_CONSUMER_KEY")
+TWITTER_CONSUMER_SECRET = get_environment_variable("TWITTER_CONSUMER_SECRET")
+TWITTER_ACCESS_TOKEN = get_environment_variable("TWITTER_ACCESS_TOKEN")
+TWITTER_ACCESS_TOKEN_SECRET = get_environment_variable("TWITTER_ACCESS_TOKEN_SECRET")
 
 
 def organization_retrieve_tweets(organization_we_vote_id, number_to_retrieve):
     # For one organization, retrieve X Tweets, and capture all #Hashtags used.
     # Sample code: Search for tweepy http://tweepy.readthedocs.io/en/v3.5.0/
-    pass
+    auth = tweepy.OAuthHandler(TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET)
+    auth.set_access_token(TWITTER_ACCESS_TOKEN, TWITTER_ACCESS_TOKEN_SECRET)
+
+    api = tweepy.API(auth)
+
+    return api.user_timeline()
 
 
 def organization_analyze_tweets(organization_we_vote_id):

--- a/organization/views_admin.py
+++ b/organization/views_admin.py
@@ -21,6 +21,7 @@ from issue.models import ALPHABETICAL_ASCENDING, IssueListManager, IssueManager,
 from measure.models import ContestMeasure, ContestMeasureList, ContestMeasureManager
 import operator
 from organization.models import OrganizationListManager, OrganizationManager, ORGANIZATION_TYPE_MAP, UNKNOWN
+from organization.controllers import organization_retrieve_tweets
 from position.models import PositionEntered, PositionManager, INFORMATION_ONLY, OPPOSE, \
     STILL_DECIDING, SUPPORT
 from voter.models import retrieve_voter_authority, voter_has_authority, VoterManager
@@ -43,8 +44,11 @@ logger = wevote_functions.admin.get_logger(__name__)
 
 
 def organization_retrieve_tweets_view(request, organization_we_vote_id):
-    #For one organization, retrieve X Tweets, and capture all #Hashtags used.
-    return HttpResponse("Hello, world. You're at the organization_retrieve_tweets_view page.")
+    # For one organization, retrieve X Tweets, and capture all #Hashtags used.
+    number_to_retrieve = 5
+    org_tweets = organization_retrieve_tweets(organization_we_vote_id, number_to_retrieve)
+
+    return HttpResponse(org_tweets)
 
 
 # This page does not need to be protected.


### PR DESCRIPTION
This barely works and is a total hack but it more proves the concept of what I'm trying to achieve.
- [ ] Is there a way to get the stored twitter credentials from the model rather than re-authorizing? (I poked around a bit but figured it's probably better to just ask)
- [x] The tweepy API function `user_timeline()` has a optional parameter for limiting the number of tweets returned but, as far as I can tell it's positional and I can't specifying it as a kwarg. I'll dig a little further into this later, as it's late right now so I'm probably overlooking something obvious.