### PR TITLE
Storing OrganizationLinkToHashtag; fails on iteration

### DIFF
--- a/organization/controllers.py
+++ b/organization/controllers.py
@@ -31,8 +31,6 @@ import re
 from organization.models import OrganizationLinkToHashtag
 from import_export_twitter.models import TwitterAuthManager
 
-import pandas as pd
-
 
 logger = wevote_functions.admin.get_logger(__name__)
 
@@ -52,25 +50,43 @@ def organization_retrieve_tweets_from_twitter(organization_we_vote_id):
     :param organization_we_vote_id:
     :return:
     """
-    try:
-        auth = tweepy.OAuthHandler(TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET)
-        auth.set_access_token(TWITTER_ACCESS_TOKEN, TWITTER_ACCESS_TOKEN_SECRET)
-        api = tweepy.API(auth)
+    status = ""
+    success = False
+    tweets_saved = None
+    tweets_not_saved = None
 
-        number_to_retrieve = 200  # TODO Remove this
-        organization_manager = OrganizationManager()
+    if not positive_value_exists(organization_we_vote_id):
+        status = "ORGANIZATION_WE_VOTE_ID_MISSING"
+        results = {
+        'success':          success,
+        'status':           status,
+        'tweets_saved':     tweets_saved,
+        'tweets_not_saved': tweets_not_saved
+        }
+        return results
+    auth = tweepy.OAuthHandler(TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET)
+    auth.set_access_token(TWITTER_ACCESS_TOKEN, TWITTER_ACCESS_TOKEN_SECRET)
+    api = tweepy.API(auth)
+
+    number_to_retrieve = 200  # TODO Remove this
+    organization_manager = OrganizationManager()
+    try:
         organization_twitter_id = organization_manager.fetch_twitter_handle_from_organization_we_vote_id(
             organization_we_vote_id)
         new_tweets = api.user_timeline(organization_twitter_id, count=number_to_retrieve)
     except tweepy.error.TweepError as e:
-        success = False
         status = "ORGANIZATION_RETRIEVE_TWEETS_FROM_TWITTER_AUTH_FAIL "
-    # Exceptions
+        results = {
+            'success': success,
+            'status': status,
+            'tweets_saved': tweets_saved,
+            'tweets_not_saved': tweets_not_saved
+        }
+        return results
+
     twitter_user_manager = TwitterUserManager()
     tweets_saved = 0
     tweets_not_saved = 0
-    status = ""
-
     for tweet_json in new_tweets:
         results = twitter_user_manager.update_or_create_tweet(tweet_json, organization_we_vote_id)
         if results['success']:
@@ -78,14 +94,12 @@ def organization_retrieve_tweets_from_twitter(organization_we_vote_id):
         else:
             tweets_not_saved += 1
 
-    # unclear on the status 
     results = {
-        'success': True,
-        'status': status,
-        'tweets_saved': tweets_saved,
+        'success':          success,
+        'status':           status,
+        'tweets_saved':     tweets_saved,
         'tweets_not_saved': tweets_not_saved,
     }
-
     return results
 
 
@@ -97,13 +111,36 @@ def organization_analyze_tweets(organization_we_vote_id):
     :param organization_we_vote_id:
     :return:
     """
+    status = ""
+    success = False
+    hastags_retrieved = None
+    cached_tweets = None
+    unique_hashtags = None
+    organization_link_to_hashtag_results = None
+
+    if not positive_value_exists(organization_we_vote_id):
+        results = {
+            'status': status,
+            'success': success,
+            'hash_tags_retrieved': hastags_retrieved,
+            'cached_tweets': cached_tweets,
+            'unique_hashtags': unique_hashtags,
+            'organization_link_to_hashtag_results': organization_link_to_hashtag_results,
+        }
+        return results
+
     twitter_user_manager = TwitterUserManager()
     retrieve_tweets_cached_locally_results = twitter_user_manager.retrieve_tweets_cached_locally(
         organization_we_vote_id)
     if retrieve_tweets_cached_locally_results['status'] == 'NO_TWEETS_FOUND':
+        status = "NO_TWEETS_CACHED_LOCALLY",
         results = {
-            'status':  'NO_TWEETS_CACHED_LOCALLY',
-            'success': False,
+            'status':                               status,
+            'success':                              success,
+            'hash_tags_retrieved':                  hastags_retrieved,
+            'cached_tweets':                        cached_tweets,
+            'unique_hashtags':                      unique_hashtags,
+            'organization_link_to_hashtag_results': organization_link_to_hashtag_results,
         }
         return results
     cached_tweets = retrieve_tweets_cached_locally_results["tweet_list"]
@@ -118,6 +155,10 @@ def organization_analyze_tweets(organization_we_vote_id):
     unique_hashtags_count_dict = dict(zip(all_hastags_list, [0] * len(all_hastags_list)))
     for hashtag in all_hastags_list:
         unique_hashtags_count_dict[hashtag] += 1
+
+    hashtags_retrieved = len(all_hashtags)
+    cached_tweets = len(cached_tweets)
+    unique_hashtags = len(unique_hashtags_count_dict)
 
     # TODO (eayoungs@gmail.com) This is Abed's code; left to be considered for future work
     # This is giving a weird output!
@@ -136,27 +177,18 @@ def organization_analyze_tweets(organization_we_vote_id):
     #organization_link_to_hashtag = OrganizationLinkToHashtag()
     #organization_link_to_hashtag.organization_we_vote_id = organization_we_vote_id
 
-    unique_hashtags_list = list(unique_hashtags_count_dict.keys())
     organization_manager = OrganizationManager()
-    organization_link_to_hashtag_results = organization_manager.create_or_update_organization_link_to_hashtag(
-        organization_we_vote_id, unique_hashtags_list[0])
+    for key, value in unique_hashtags_count_dict.items():
+        if value > 2: # TODO (eayoungs@gmail.com): First pass at testing for relevance; requires further discussion
+            organization_link_to_hashtag_results = organization_manager.create_or_update_organization_link_to_hashtag(
+                organization_we_vote_id, key)
 
-    #all_hashtags = []
-    #for i in range(0, len(tweet_list)):
-    #    if re.findall(r"#(\w+)", tweet_list[i].tweet_text):
-    #        organization_link_to_hashtag.hashtag_text = re.findall(r"#(\w+)", tweet_list[i].tweet_text)
-    #        organization_link_to_hashtag.tweet_id = tweet_list[i].tweet_id
-    #        organization_link_to_hashtag.published_datetime = tweet_list[i].date_published
-
-    # For now it returns a list of hashtags and frequency dictionary of all words.
-
-    # return all_hashtags, counts
     results = {
-        'status':                               'HASHTAGS_FOUND_IN_TWEETS_CACHED_LOCALLY',
-        'success':                              True,
-        'hash_tags_retrieved':                  len(all_hashtags),
-        'cached_tweets':                        len(cached_tweets),
-        'unique_hashtags_count_dict':           len(unique_hashtags_count_dict),
+        'status':                               status,
+        'success':                              success,
+        'hash_tags_retrieved':                  hashtags_retrieved,
+        'cached_tweets':                        cached_tweets,
+        'unique_hashtags':                      unique_hashtags,
         'organization_link_to_hashtag_results': organization_link_to_hashtag_results,
     }
     return results

--- a/organization/models.py
+++ b/organization/models.py
@@ -15,7 +15,6 @@ from twitter.models import TwitterLinkToOrganization, TwitterLinkToVoter, Twitte
 from voter.models import VoterManager
 from wevote_functions.functions import convert_to_int, extract_twitter_handle_from_text_string, positive_value_exists
 from wevote_settings.models import fetch_next_we_vote_id_org_integer, fetch_site_unique_id_prefix
-from twitter.models import Tweet
 
 
 # Also see a copy of these in wevote_function/functions.py
@@ -63,16 +62,17 @@ alphanumeric = RegexValidator(r'^[0-9a-zA-Z]*$', message='Only alphanumeric char
 logger = wevote_functions.admin.get_logger(__name__)
 
 
-class OrganizationLinkToHashtag():
-    def __unicode__(self):
-        return "OrganizationLinkToHashtag"
-    
-    organization_we_vote_id = models.CharField(verbose_name="we vote permanent id", max_length=255, unique=True)
+class OrganizationLinkToHashtag(models.Model):
+    #def __unicode__(self):
+    #    return "OrganizationLinkToHashtag"
+
+    id = models.AutoField(primary_key=True) # Throwing an exception for non unique key values on iteration
+    organization_we_vote_id = models.CharField(verbose_name="we vote permanent id", max_length=255, unique=False)
     hashtag_text = models.CharField(verbose_name="hashtag text", max_length=255, unique=False)
-    tweet_id = models.BigIntegerField(verbose_name="tweet id", unique=True)
-    published_datetime = models.DateTimeField(verbose_name="published datetime")
-    organization_twitter_handle = models.CharField(verbose_name="organization twitter handle", max_length=15,
-                                                   unique=False)
+    #tweet_id = models.BigIntegerField(verbose_name="tweet id", unique=True)
+    #published_datetime = models.DateTimeField(verbose_name="published datetime")
+    #organization_twitter_handle = models.CharField(verbose_name="organization twitter handle", max_length=15,
+    #                                               unique=False)
 
 
 class OrganizationLinkToWordOrPhrase():
@@ -97,37 +97,44 @@ class OrganizationManager(models.Manager):
     """
     # DO WE WANT CREATE OR UPDATE AND CREATE # Do we want the organization twitter handle
     def create_or_update_organization_link_to_hashtag(self, organization_we_vote_id, hashtag):
+        success = False
+        status = ""
+        organization_link_to_hashtag_created = False
+
         if not positive_value_exists(organization_we_vote_id):
-            organization_link_to_hashtag = OrganizationLinkToHashtag()
+            status = 'CREATE_ORGANIZATION_LINK_TO_HASHTAG_MISSING_WE_VOTE_ID '
             results = {
-                'success': False,
-                'status': 'CREATE_ORGANIZATION_LINK_TO_HASHTAG_MISSING_WE_VOTE_ID ',
-                'organization_link_to_hashtag': organization_link_to_hashtag,
-                'organization_link_to_hashtag_created': False
+                'success':                              success,
+                'status':                               status,
+                'organization_link_to_hashtag_created': organization_link_to_hashtag_created,
             }
             return results
         # add required for hashtag_text similar to organization_we_vote_id
         try:    
-            organization_link_to_hashtag = OrganizationLinkToHashtag.objects.create(
-                                                        organization_we_vote_id=organization_we_vote_id,
-                                                        hashtag_text=hashtag)
+
+            new_organization_link_to_hastag, created = OrganizationLinkToHashtag.objects.update_or_create(
+                organization_we_vote_id=organization_we_vote_id,
+                hashtag_text=hashtag)
+            # NOTE: Hashtags are only significant if there are more than one for a particular issue so I'm not sure
+            #   if it makes sense to have indivitual tweet's id or date.
+            #tweet_id=hashtag['tweet_id'],
+            #published_datetime=tweet_list['date_published'],
+            #organization_twitter_handle=tweet_list['author_handle'])
             status = "CREATE_ORGANIZATION_LINK_TO_HASHTAG_SUCCESSFUL"
             success = True
-            organization_link_to_hashtag = organization_link_to_hashtag
             organization_link_to_hashtag_created = True
         except Exception as e:
             handle_record_not_saved_exception(e, logger=logger)
-            status = "CREATE_ORGANIZATION_LINK_TO_HASHTAG_FAILED"
             success = False
+            status = "CREATE_ORGANIZATION_LINK_TO_HASHTAG_FAILED"
             organization_link_to_hashtag_created = False
-            organization_link_to_hashtag = None
         results = {
             'success':                              success,
             'status':                               status,
-            'organization_link_to_hashtag':         organization_link_to_hashtag,
             'organization_link_to_hashtag_created': organization_link_to_hashtag_created,
         }
         return results
+
 
     def create_organization_simple(self, organization_name, organization_website, organization_twitter_handle,
                                    organization_email='', organization_facebook='', organization_image='',

--- a/organization/urls.py
+++ b/organization/urls.py
@@ -21,6 +21,8 @@ urlpatterns = [
         views_admin.organization_position_list_view, name='organization_position_list',),
     url(r'^(?P<organization_we_vote_id>wv[\w]{2}org[\w]+)/retrieve_tweets/$',
         views_admin.organization_retrieve_tweets_view, name='organization_retrieve_tweets',),
+    url(r'^(?P<organization_we_vote_id>wv[\w]{2}org[\w]+)/organization_analyze_tweets/$',
+        views_admin.organization_analyze_tweets_view, name='organization_analyze_tweets',),
     url(r'^(?P<organization_we_vote_id>wv[\w]{2}org[\w]+)/pos/$',
         views_admin.organization_position_list_view, name='organization_we_vote_id_position_list',),
     url(r'^(?P<incorrect_integer>[0-9]+)/pos/$',

--- a/organization/views_admin.py
+++ b/organization/views_admin.py
@@ -45,9 +45,31 @@ logger = wevote_functions.admin.get_logger(__name__)
 
 @login_required
 def organization_analyze_tweets_view(request, organization_we_vote_id):
+    """
+
+    :param request:
+    :param organization_we_vote_id:
+    :return:
+    """
+    google_civic_election_id = convert_to_int(request.GET.get('google_civic_election_id', 0))
+    state_code = request.GET.get('state_code', False)
 
     org_hashtags = organization_analyze_tweets(organization_we_vote_id)
-    return HttpResponse(org_tweets)
+    messages.add_message(request, messages.INFO, 'Tweets stored locally: {cached_tweets}, '
+                                                 'Hash tags retrieved: {hash_tags_retrieved}, '
+                                                 'Number of unique hashtags found in cached tweets: '
+                                                 '{unique_hashtags}, '
+                                                 'Organization links to hashtags: '
+                                                 '{organization_link_to_hashtag_results}'
+                                                 ''.format(cached_tweets=org_hashtags['cached_tweets'],
+                                                           hash_tags_retrieved=org_hashtags['hash_tags_retrieved'],
+                                                           unique_hashtags=org_hashtags['unique_hashtags'],
+                                                           organization_link_to_hashtag_results=
+                                                           org_hashtags['organization_link_to_hashtag_results']))
+    return HttpResponseRedirect(reverse('organization:organization_we_vote_id_position_list',
+                                        args=(organization_we_vote_id,)) +
+                                "?google_civic_election_id=" + str(google_civic_election_id) + "&state_code=" +
+                                str(state_code))
 
 
 @login_required
@@ -63,24 +85,11 @@ def organization_retrieve_tweets_view(request, organization_we_vote_id):
     state_code = request.GET.get('state_code', False)
 
     org_tweets_results = organization_retrieve_tweets_from_twitter(organization_we_vote_id)
-    org_hashtags = organization_analyze_tweets(organization_we_vote_id)
     messages.add_message(request, messages.INFO, 'Organization retrieve tweets executed, '
-                                                 'Tweets retrieved: {tweets_saved},'
-                                                 'Tweets not retrieved: {tweets_not_saved},'
-                                                 'Hash tags retrieved: {hash_tags_retrieved},'
-                                                 'Tweets stored locally: {cached_tweets},'
-                                                 'Number of unique hashtags found in cached tweets: '
-                                                 '{unique_hashtags_count_dict},'
-                                                 'Organization links to hashtags: '
-                                                 '{organization_link_to_hashtag_results}'
+                                                 'Tweets retrieved: {tweets_saved}, '
+                                                 'Tweets not retrieved: {tweets_not_saved}, '
                                                  ''.format(tweets_saved=org_tweets_results['tweets_saved'],
-                                                           tweets_not_saved=org_tweets_results['tweets_not_saved'],
-                                                           hash_tags_retrieved=org_hashtags['hash_tags_retrieved'],
-                                                           cached_tweets=org_hashtags['cached_tweets'],
-                                                           unique_hashtags_count_dict=org_hashtags[
-                                                               'unique_hashtags_count_dict'],
-                                                           organization_link_to_hashtag_results=
-                                                                org_hashtags['organization_link_to_hashtag_results']))
+                                                           tweets_not_saved=org_tweets_results['tweets_not_saved'],))
     return HttpResponseRedirect(reverse('organization:organization_we_vote_id_position_list',
                                         args=(organization_we_vote_id,)) +
                                 "?google_civic_election_id=" + str(google_civic_election_id) + "&state_code=" +

--- a/templates/organization/organization_position_list.html
+++ b/templates/organization/organization_position_list.html
@@ -111,7 +111,8 @@
 <p>
     <a href="{% url 'import_export_wikipedia:import_organization_logo' organization.id %}">Retrieve photos from Wikipedia</a>,
     <a href="{% url 'import_export_twitter:scrape_website_for_social_media' organization.id %}">Scrape org website for Twitter Acounts</a>,
-    <a href="{% url 'organization:organization_retrieve_tweets' organization.we_vote_id %}">Linked issues in bulk</a>,
+    <a href="{% url 'organization:organization_retrieve_tweets' organization.we_vote_id %}">Retrieve tweets for organization</a>,
+    <a href="{% url 'organization:organization_analyze_tweets' organization.we_vote_id %}">Link issues from twitter feed</a>,
 </p>
 
 <p>


### PR DESCRIPTION
Using the frequency of hashtags as an indicator of an issue to be recommended to the organization (still needs to be matched with an actual WeVote issue to be followed). Currently only a single OrganizationLinkToHashtag object is stored. A `duplicate key value violates unique constraint` is thrown for further iterations, despite `setting=False` for fields and explicitly adding `id = models.AutoField(primary_key=True`.