### PR TITLE
Changes to handle twitter oAuth flows for Apache Cordova

### DIFF
--- a/import_export_twitter/controllers.py
+++ b/import_export_twitter/controllers.py
@@ -581,11 +581,12 @@ def transfer_candidate_twitter_handles_from_google_civic(google_civic_election_i
     return results
 
 
-def twitter_sign_in_start_for_api(voter_device_id, return_url):  # twitterSignInStart
+def twitter_sign_in_start_for_api(voter_device_id, return_url, cordova):  # twitterSignInStart
     """
 
     :param voter_device_id:
     :param return_url: Where to direct the browser at the very end of the process
+    :param cordova:
     :return:
     """
     # Get voter_id from the voter_device_id
@@ -706,6 +707,7 @@ def twitter_sign_in_start_for_api(voter_device_id, return_url):  # twitterSignIn
     callback_url = WE_VOTE_SERVER_ROOT_URL + "/apis/v1/twitterSignInRequestAccessToken/"
     callback_url += "?voter_device_id=" + voter_device_id
     callback_url += "&return_url=" + return_url
+    callback_url += "&cordova=" + str(cordova)
 
     try:
         # We take the Consumer Key and the Consumer Secret, and request a token & token_secret
@@ -872,7 +874,7 @@ def twitter_native_sign_in_save_for_api(voter_device_id, twitter_access_token, t
 
 def twitter_sign_in_request_access_token_for_api(voter_device_id,
                                                  incoming_request_token, incoming_oauth_verifier,
-                                                 return_url):
+                                                 return_url, cordova):
     """
     twitterSignInRequestAccessToken
     After signing in and agreeing to the application's terms, the user is redirected back to the application with
@@ -886,6 +888,7 @@ def twitter_sign_in_request_access_token_for_api(voter_device_id,
     :param incoming_request_token:
     :param incoming_oauth_verifier:
     :param return_url: If a value is provided, return to this URL when the whole process is complete
+    :param cordova:
     :return:
     """
     # Get voter_id from the voter_device_id
@@ -897,6 +900,7 @@ def twitter_sign_in_request_access_token_for_api(voter_device_id,
             'voter_device_id':                  voter_device_id,
             'access_token_and_secret_returned': False,
             'return_url':                       return_url,
+            'cordova':                          cordova,
         }
         return results
 
@@ -909,6 +913,7 @@ def twitter_sign_in_request_access_token_for_api(voter_device_id,
             'voter_device_id':                  voter_device_id,
             'access_token_and_secret_returned': False,
             'return_url':                       return_url,
+            'cordova':                          cordova,
         }
         return results
 
@@ -923,6 +928,7 @@ def twitter_sign_in_request_access_token_for_api(voter_device_id,
             'voter_device_id':                  voter_device_id,
             'access_token_and_secret_returned': False,
             'return_url':                       return_url,
+            'cordova':                          cordova,
         }
         return results
 
@@ -935,6 +941,7 @@ def twitter_sign_in_request_access_token_for_api(voter_device_id,
             'voter_device_id':                  voter_device_id,
             'access_token_and_secret_returned': False,
             'return_url':                       return_url,
+            'cordova':                          cordova,
         }
         return results
 
@@ -980,6 +987,7 @@ def twitter_sign_in_request_access_token_for_api(voter_device_id,
             'voter_device_id':                  voter_device_id,
             'access_token_and_secret_returned': True,
             'return_url':                       return_url,
+            'cordova':                          cordova,
         }
     else:
         results = {
@@ -988,13 +996,14 @@ def twitter_sign_in_request_access_token_for_api(voter_device_id,
             'voter_device_id':                  voter_device_id,
             'access_token_and_secret_returned': False,
             'return_url':                       return_url,
+            'cordova':                          cordova,
         }
     return results
 
 
 def twitter_sign_in_request_voter_info_for_api(voter_device_id, return_url):
     """
-    twitterSignInRequestVoterInfo
+    (not directly called by) twitterSignInRequestVoterInfo
     When here, the incoming voter_device_id should already be authenticated
     :param voter_device_id:
     :param return_url: Where to return the browser when sign in process is complete

--- a/templates/cordova/cordova_ios_redirect_to_scheme.html
+++ b/templates/cordova/cordova_ios_redirect_to_scheme.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none';script-src 'unsafe-inline';">
+        <script>
+            window.location.href = "wevotetwitterscheme://{{ query_string }}";
+        </script>
+    </head>
+    <body>
+    </body>
+</html>


### PR DESCRIPTION
In views_twitter.py, pass a 'cordova' boolean value through the various
steps, because if in iOS cordova, we need to use a native Apple
mechanism called a url scheme handler (wevotetwitterscheme) to allow us
to redirect back to the app.
In import_export_twitter/controllers, also pass around and add to URLs
the 'cordova' boolean value.
New template called cordova_ios_redirect_to_scheme.html, that contains
a one line JavaScript that sets the window.location.href with the Apple
custom scheme 'wevotetwitterscheme'