### PR TITLE
When running issueRetrieve, we now accept ballot_location_shortcut and ballot_returned_we_vote_id because there are times in WebApp where we don't know the google_civic_election_id. Now when we return the organization_we_vote_ids that make up an Issue Score, we return two lists, one for support and another for oppose.

### DIFF
--- a/apis_v1/documentation_source/issues_retrieve_doc.py
+++ b/apis_v1/documentation_source/issues_retrieve_doc.py
@@ -63,7 +63,11 @@ def issues_retrieve_doc_template_values(url_root):
                    '     "ballot_item_we_vote_id": string,\n' \
                    '     "issue_support_score": integer,\n' \
                    '     "issue_oppose_score": integer,\n' \
-                   '     "organizations_included_list": list\n' \
+                   '     "organization_support_list": list\n' \
+                   '      [\n' \
+                   '         "organization_we_vote_id": string,\n' \
+                   '      ],\n' \
+                   '     "organization_oppose_list": list\n' \
                    '      [\n' \
                    '         "organization_we_vote_id": string,\n' \
                    '      ],\n' \

--- a/apis_v1/views/views_voter.py
+++ b/apis_v1/views/views_voter.py
@@ -913,16 +913,19 @@ def voter_guides_to_follow_retrieve_view(request):  # voterGuidesToFollowRetriev
 def voter_issue_follow_view(request):  # issueFollow
     voter_device_id = get_voter_device_id(request)  # We standardize how we take in the voter_device_id
     issue_we_vote_id = request.GET.get('issue_we_vote_id', False)
+    google_civic_election_id = request.GET.get('google_civic_election_id', 0)
     follow_value = positive_value_exists(request.GET.get('follow', False))
     user_agent_string = request.META['HTTP_USER_AGENT']
     user_agent_object = get_user_agent(request)
     ignore_value = positive_value_exists(request.GET.get('ignore', False))
 
-    return voter_issue_follow_for_api(voter_device_id=voter_device_id,
-                                      issue_we_vote_id=issue_we_vote_id,
-                                      follow_value=follow_value,
-                                      ignore_value=ignore_value, user_agent_string=user_agent_string,
-                                      user_agent_object=user_agent_object)
+    result = voter_issue_follow_for_api(voter_device_id=voter_device_id,
+                                        issue_we_vote_id=issue_we_vote_id,
+                                        follow_value=follow_value,
+                                        ignore_value=ignore_value, user_agent_string=user_agent_string,
+                                        user_agent_object=user_agent_object)
+    result['google_civic_election_id'] = google_civic_election_id
+    return HttpResponse(json.dumps(result), content_type='application/json')
 
 
 def voter_location_retrieve_from_ip_view(request):  # voterLocationRetrieveFromIP - GeoIP geo location

--- a/follow/controllers.py
+++ b/follow/controllers.py
@@ -360,7 +360,7 @@ def voter_issue_follow_for_api(voter_device_id, issue_we_vote_id, follow_value, 
             'follow_issue_id': result['follow_issue_id'],
         }
 
-    return HttpResponse(json.dumps(new_result), content_type='application/json')
+    return new_result
 
 
 def move_organization_followers_to_another_organization(from_organization_id, from_organization_we_vote_id,

--- a/issue/views_admin.py
+++ b/issue/views_admin.py
@@ -74,11 +74,14 @@ def issues_sync_out_view(request):  # issuesSyncOut
 def issues_retrieve_view(request):  # issuesRetrieve
     voter_device_id = get_voter_device_id(request)  # We standardize how we take in the voter_device_id
     sort_formula = request.GET.get('sort_formula', MOST_LINKED_ORGANIZATIONS)
+    ballot_location_shortcut = request.GET.get('ballot_location_shortcut', False)
+    ballot_returned_we_vote_id = request.GET.get('ballot_returned_we_vote_id', False)
     google_civic_election_id = request.GET.get('google_civic_election_id', False)
     voter_issues_only = request.GET.get('voter_issues_only', False)
     include_voter_follow_status = request.GET.get('include_voter_follow_status', False)
     http_response = issues_retrieve_for_api(voter_device_id, sort_formula, google_civic_election_id,
-                                            voter_issues_only, include_voter_follow_status)
+                                            voter_issues_only, include_voter_follow_status,
+                                            ballot_location_shortcut, ballot_returned_we_vote_id)
     return http_response
 
 


### PR DESCRIPTION
When running issueRetrieve, we now accept ballot_location_shortcut and ballot_returned_we_vote_id because there are times in WebApp where we don't know the google_civic_election_id. Now when we return the organization_we_vote_ids that make up an Issue Score, we return two lists, one for support and another for oppose.