### PR TITLE
Fixed problem with the district_list passing too many characters for the Ballotpedia server to be able to retrieve. We now limit the length of the URL to under 4096 characters. Added election internal_notes for Political Data management team.

### DIFF
--- a/election/models.py
+++ b/election/models.py
@@ -60,6 +60,9 @@ class Election(models.Model):
     state_code = models.CharField(verbose_name="state code for the election", max_length=2, null=True, blank=True)
     include_in_list_for_voters = models.BooleanField(default=False)
 
+    # For internal notes regarding gathering data for this election
+    internal_notes = models.TextField(null=True, blank=True, default=None)
+
     def election_is_upcoming(self):
         if not positive_value_exists(self.election_day_text):
             return False

--- a/templates/election/election_edit.html
+++ b/templates/election/election_edit.html
@@ -83,6 +83,16 @@
 </div>
 
 <div class="form-group">
+    <label for="internal_notes_id" class="col-sm-3 control-label">Internal Notes about Election Data Gathering</label>
+    <div class="col-sm-8">
+        <textarea name="internal_notes"
+                  class="form-control animated"
+                  id="internal_notes_id"
+                  placeholder="Status of data gathering?">{% if candidate %}{{ candidate.internal_notes|default_if_none:"" }}{% else %}{{ internal_notes|default_if_none:"" }}{% endif %}</textarea>
+    </div>
+</div>
+
+<div class="form-group">
     <label for="update_ballot_id" class="col-sm-3 control-label">
         {% if election %}
         <a href="{% url 'election:election_summary' election.id %}">cancel</a>

--- a/templates/election/election_list.html
+++ b/templates/election/election_list.html
@@ -69,8 +69,16 @@
     {% for election in election_list %}
         <tr>
             <td>{{ forloop.counter }}</td>
-            <td><a href="{% url 'election:election_summary' election.id %}" target="_blank">{{ election.election_name }}</a></td>
-            <td>{{ election.election_day_text }}</td>
+            <td>
+                <a href="{% url 'election:election_summary' election.id %}" target="_blank">{{ election.election_name }}</a>
+                {% if election.internal_notes %}
+                <br /><span style="color: darkgray">{{ election.internal_notes|default_if_none:""|truncatechars:50 }}</span>
+                {% endif %}
+            </td>
+            <td>
+                {{ election.election_day_text }}
+                {% if election.days_until_election > 0 %} <span class="{% if election.days_until_election < 46 %}font-weight-bold text-danger{% endif %}">(in {{ election.days_until_election }} days)</span>{% endif %}
+            </td>
             <td align="middle">{{ election.google_civic_election_id }}</td>
             <td align="middle">{{ election.ballotpedia_election_id|default_if_none:"" }}</td>
             <td align="middle">{{ election.state_code }}</td>


### PR DESCRIPTION
Fixed problem with the district_list passing too many characters for the Ballotpedia server to be able to retrieve. We now limit the length of the URL to under 4096 characters. Added election internal_notes for Political Data management team.