### PR TITLE
Keep the load balancer from rotating to another node during a long query

### DIFF
--- a/issue/controllers.py
+++ b/issue/controllers.py
@@ -805,3 +805,37 @@ def retrieve_issues_not_linked_to_organization_for_api(organization_we_vote_id):
 
     issues_linked_result['issue_list'] = issues_not_linked
     return issues_linked_result
+
+
+# Steve, Temporary location for this function, as of July 16, 2018 --
+# It could be left "as is" as a "pinger" that keeps the load balancer channel open (Keeps it from rotating to another
+# node in mid request) or we could move this to the place where it can read a global value with progress statistics
+# that you want to display for some script
+global_dot_string = ""
+global_dot_string_increasing = True
+
+
+def test_real_time_update(request):  # testRealTimeUpdate
+
+    global global_dot_string
+    global global_dot_string_increasing
+    length = len(global_dot_string)
+
+    if global_dot_string_increasing:
+        if length == 10:
+            global_dot_string_increasing = False
+            global_dot_string = global_dot_string[0:9]
+        else:
+            global_dot_string = global_dot_string + "."
+    else:
+        if length == 0:
+            global_dot_string_increasing = True
+            global_dot_string = "."
+        else:
+            global_dot_string = global_dot_string[0:length-1]
+
+    json_data = {
+        'text': global_dot_string,
+    }
+
+    return HttpResponse(json.dumps(json_data), content_type='application/json')

--- a/templates/election/election_list.html
+++ b/templates/election/election_list.html
@@ -22,6 +22,8 @@
 
 <h1>Elections</h1>
 
+Pinging API Server <span id="testDots" >.</span></p>
+
 <p><a href="{% url 'election:election_remote_retrieve' %}">Retrieve all elections</a>.
     <a href="https://votinginfoproject.org/news/vip-continues-support-elections-through-2018/" target="_blank">VIP elections supported.</a></p>
 
@@ -196,6 +198,20 @@
             this.form.submit();
         });
     });
+
+    // Ping the server to keep the load balancer channel open (Stay on the same load balancer node)
+    setInterval(function () {
+      let origin = new URL('{{request.build_absolute_uri}}').origin;
+      let apiURL = origin + '/apis/v1/testRealTimeUpdate';
+      $.ajax({
+        type: "GET",
+        url: apiURL,
+        success: function (data) {
+          let dots = data.text;
+          $('#testDots').html('<font color="LIMEGREEN">' + dots +'</font>');
+        },
+      });
+    }, 2000);
 </script>
 
 {% endblock %}

--- a/templates/template_base.html
+++ b/templates/template_base.html
@@ -22,7 +22,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T" crossorigin="anonymous"></script>
 
-    <script src="https://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     {# IGNORE FOR NOW <script src="{% url "js_settings" %}"></script> #}
 
     {#  Load CSS and JavaScript #}


### PR DESCRIPTION
New JavaScript in election_list that hits an API every two seconds to
avoid having the load balancer session timeout.

"Fixes" wevote/WeVoteServer/issues/822