### PR TITLE
Retrieving Candidate Photos from Facebook

### DIFF
--- a/apis_v1/urls.py
+++ b/apis_v1/urls.py
@@ -16,7 +16,7 @@ from apis_v1.views import views_docs, views_analytics, views_ballot, views_candi
 from ballot.views_admin import ballot_items_sync_out_view, ballot_returned_sync_out_view
 from candidate.views_admin import candidates_sync_out_view
 from issue.views_admin import issues_sync_out_view, issues_retrieve_view, retrieve_issues_to_follow_view, \
-    organization_link_to_issue_sync_out_view
+    organization_link_to_issue_sync_out_view, test_real_time_update
 from measure.views_admin import measures_sync_out_view
 from office.views_admin import offices_sync_out_view
 from organization.views_admin import organizations_sync_out_view
@@ -119,6 +119,7 @@ urlpatterns = [
     url(r'^retrieveIssuesToFollow/', retrieve_issues_to_follow_view, name='retrieveIssuesToFollowView'),
     url(r'^saveAnalyticsAction/', views_analytics.save_analytics_action_view, name='saveAnalyticsActionView'),
     url(r'^searchAll/', views_misc.search_all_view, name='searchAllView'),
+    url(r'^testRealTimeUpdate/', test_real_time_update, name='testRealTimeUpdate'),
     url(r'^twitterIdentityRetrieve/', views_twitter.twitter_identity_retrieve_view, name='twitterIdentityRetrieveView'),
     url(r'^twitterNativeSignInSave/', views_twitter.twitter_native_sign_in_save_view, name='twitterNativeSignInSave'),
     url(r'^twitterSignInRequestAccessToken/',

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -309,6 +309,27 @@ def candidate_list_view(request):
         # This is fine, create new
         pass
 
+    # How many facebook_url's don't have facebook_profile_image_url_https
+    # SELECT * FROM public.candidate_candidatecampaign where google_civic_election_id = '1000052' and facebook_url
+    #     is not null and facebook_profile_image_url_https is null
+    facebook_urls_without_picture_urls = 0;
+    try:
+        candidate_list = CandidateCampaign.objects.all()
+        if positive_value_exists(google_civic_election_id):
+            candidate_list = candidate_list.filter(google_civic_election_id=google_civic_election_id)
+
+        # include profile images that are null or ''
+        candidate_list = candidate_list.filter(Q(facebook_profile_image_url_https__isnull=True) | Q(facebook_profile_image_url_https__exact=''))
+
+        # exclude facebook_urls that are null or ''
+        candidate_list = candidate_list.exclude(facebook_url__isnull=True).exclude(facebook_url__iexact='')
+
+        facebook_urls_without_picture_urls = candidate_list.count()
+
+    except Exception as e:
+        logger.error("Find facebook URLs without facebook pictures in candidate: " + e)
+
+
     status_print_list = ""
     status_print_list += "candidate_list_count: " + \
                          str(candidate_list_count) + " "
@@ -479,6 +500,7 @@ def candidate_list_view(request):
         'current_page_minus_candidate_tools_url':   current_page_minus_candidate_tools_url,
         'election':                 election,
         'election_list':            election_list,
+        'facebook_urls_without_picture_urls':       facebook_urls_without_picture_urls,
         'google_civic_election_id': google_civic_election_id,
         'hide_candidate_tools':     hide_candidate_tools,
         'messages_on_stage':        messages_on_stage,

--- a/config/urls.py
+++ b/config/urls.py
@@ -19,10 +19,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
 
-from django.conf import settings
 from django.conf.urls import include, url
-from django.conf.urls.static import static
-from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from config import startup, views
 from admin_tools.views import login_we_vote, logout_we_vote
@@ -48,6 +45,7 @@ urlpatterns = [
     url(r'^image/', include('image.urls', namespace="image")),
     url(r'^import_export_batches/', include('import_export_batches.urls', namespace="import_export_batches")),
     url(r'^import_export_ctcl/', include('import_export_ctcl.urls', namespace="import_export_ctcl")),
+    url(r'^import_export_facebook/', include('import_export_facebook.urls', namespace="import_export_facebook")),
     url(r'^import_export_google_civic/', include(
         'import_export_google_civic.urls', namespace="import_export_google_civic")),
     url(r'^import_export_maplight/', include('import_export_maplight.urls', namespace="import_export_maplight")),

--- a/import_export_facebook/urls.py
+++ b/import_export_facebook/urls.py
@@ -11,12 +11,6 @@ urlpatterns = [
     # views
 
     # views_admin
-    # url(r'^(?P<candidate_id>[0-9]+)/refresh_twitter_candidate_details/$',
-    #     views_admin.refresh_twitter_candidate_details_view, name='refresh_twitter_candidate_details',),
-    # url(r'^(?P<organization_id>[0-9]+)/refresh_twitter_organization_details/$',
-    #     views_admin.refresh_twitter_organization_details_view, name='refresh_twitter_organization_details',),
-    url(r'^(?P<organization_id>[0-9]+)/scrape_website_for_social_media/$',
-        views_admin.scrape_website_for_social_media_view, name='scrape_website_for_social_media',),
-    url(r'^scrape_social_media_from_all_organizations/$',
-        views_admin.scrape_social_media_from_all_organizations_view, name='scrape_social_media_from_all_organizations'),
+    url(r'^bulk_retrieve_facebook_photos_view/$',
+        views_admin.bulk_retrieve_facebook_photos_view, name='bulk_retrieve_facebook_photos_view', ),
 ]

--- a/import_export_facebook/views_admin.py
+++ b/import_export_facebook/views_admin.py
@@ -3,6 +3,116 @@
 # -*- coding: UTF-8 -*-
 
 import wevote_functions.admin
+from admin_tools.views import redirect_to_sign_in_page
+from candidate.models import CandidateCampaign
+from .controllers import scrape_facebook_photo_url_from_web_page
+from django.contrib.auth.decorators import login_required
+from django.contrib import messages
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
+from voter.models import voter_has_authority
+from wevote_functions.functions import convert_to_int, positive_value_exists
+import wevote_functions.admin
+from wevote_settings.models import RemoteRequestHistory, RemoteRequestHistoryManager, RETRIEVE_POSSIBLE_FACEBOOK_PHOTOS
+
 
 logger = wevote_functions.admin.get_logger(__name__)
 
+# Test SQL for pgAdmin 4
+# Set all the facebook facebook_profile_image_url_https picture urls to null
+#   UPDATE public.candidate_candidatecampaign SET facebook_profile_image_url_https = NULL;
+# Set all the  all the facebook_urls that are '' to null
+#   UPDATE public.candidate_candidatecampaign SET facebook_url = NULL where facebook_url = '';
+# Count all the facebook_profile_image_url_https picture urls
+#   SELECT COUNT(facebook_profile_image_url_https) FROM public.candidate_candidatecampaign;
+# Count how many facebook_urls exist
+#   SELECT COUNT(facebook_url) FROM public.candidate_candidatecampaign;
+# Get all the lines for a specific google_civic_election_id
+#   SELECT * FROM public.candidate_candidatecampaign where google_civic_election_id = '1000052';
+# Ignoring remote_request_history_manager, how many facebook_urls are there to process?
+#   SELECT COUNT(facebook_url) FROM public.candidate_candidatecampaign where facebook_profile_image_url_https is null and google_civic_election_id = '1000052'; … 17
+# Clear the wevote_settings_remoterequesthistory table to allow all lines to be processed, by right cliking on the table in pgAdmin and choosing truncate
+
+@login_required
+def bulk_retrieve_facebook_photos_view(request):
+    remote_request_history_manager = RemoteRequestHistoryManager()
+
+    authority_required = {'verified_volunteer'}  # admin, verified_volunteer
+    if not voter_has_authority(request, authority_required):
+        return redirect_to_sign_in_page(request, authority_required)
+
+    google_civic_election_id = convert_to_int(request.GET.get('google_civic_election_id', 0))
+    hide_candidate_tools = request.GET.get('hide_candidate_tools', False)
+    page = request.GET.get('page', 0)
+    state_code = request.GET.get('state_code', '')
+    limit = convert_to_int(request.GET.get('show_all', 0))
+
+    if not positive_value_exists(google_civic_election_id) and not positive_value_exists(state_code) \
+            and not positive_value_exists(limit):
+        messages.add_message(request, messages.ERROR,
+                             'bulk_retrieve_facebook_photos_view, LIMITING_VARIABLE_REQUIRED')
+        return HttpResponseRedirect(reverse('candidate:candidate_list', args=()) +
+                                    '?google_civic_election_id=' + str(google_civic_election_id) +
+                                    '&state_code=' + str(state_code) +
+                                    '&hide_candidate_tools=' + str(hide_candidate_tools) +
+                                    '&page=' + str(page)
+                                    )
+
+    try:
+        candidate_list = CandidateCampaign.objects.all()
+        if positive_value_exists(google_civic_election_id):
+            candidate_list = candidate_list.filter(google_civic_election_id=google_civic_election_id)
+        if positive_value_exists(state_code):
+            candidate_list = candidate_list.filter(state_code__iexact=state_code)
+        candidate_list = candidate_list.order_by('candidate_name')
+        if positive_value_exists(limit):
+            candidate_list = candidate_list[:limit]
+        candidate_list_count = candidate_list.count()
+
+         # Run Facebook account search and analysis on candidates with a linked or possible Facebook account
+        number_of_candidates_to_search = 25
+        current_candidate_index = 0
+        while positive_value_exists(number_of_candidates_to_search) \
+                and (current_candidate_index < candidate_list_count):
+            one_candidate = candidate_list[current_candidate_index]
+            # If the candidate has a facebook_url, but no facebook_profile_image_url_https,
+            # see if we already tried to scrape them
+            if positive_value_exists(one_candidate.facebook_url) \
+                    and not positive_value_exists(one_candidate.facebook_profile_image_url_https):
+                # Check to see if we have already tried to find their photo link from Facebook. We don't want to
+                #  search Facebook more than once.
+                request_history_query = RemoteRequestHistory.objects.filter(
+                    candidate_campaign_we_vote_id__iexact=one_candidate.we_vote_id,
+                    kind_of_action=RETRIEVE_POSSIBLE_FACEBOOK_PHOTOS)
+                request_history_list = list(request_history_query)
+
+                if not positive_value_exists(request_history_list):
+                    # Facebook profile image url scrape has not been run on this candidate yet
+                    results = scrape_facebook_photo_url_from_web_page(one_candidate.facebook_url)
+                    if results.get('success'):
+                        photo_url = results.get('photo_url')
+                        if not photo_url.startswith('https://scontent'):
+                            logger.info("Rejected URL: " + one_candidate.facebook_url + " X '" + photo_url + "'")
+                        else:
+                            logger.info("Scraped URL: " + one_candidate.facebook_url + " ==> " + photo_url)
+                            one_candidate.facebook_profile_image_url_https = photo_url
+                            one_candidate.save()
+                    number_of_candidates_to_search -= 1
+                    # Create a record denoting that we have retrieved from Facebook for this candidate
+                    save_results_history = remote_request_history_manager.create_remote_request_history_entry(
+                        RETRIEVE_POSSIBLE_FACEBOOK_PHOTOS, one_candidate.google_civic_election_id,
+                        one_candidate.we_vote_id, None, 1, "CANDIDATE_FACEBOOK_URL_PARSED " + one_candidate.facebook_url)
+                else:
+                    logger.info("Skipped URL: " + one_candidate.facebook_url)
+
+            current_candidate_index += 1
+    except CandidateCampaign.DoesNotExist:
+        # This is fine, do nothing
+        pass
+
+    return HttpResponseRedirect(reverse('candidate:candidate_list', args=()) +
+                                '?google_civic_election_id=' + str(google_civic_election_id) +
+                                '&state_code=' + str(state_code) +
+                                '&hide_candidate_tools=' + str(hide_candidate_tools) +
+                                '&page=' + str(page)
+                                )

--- a/templates/candidate/candidate_list.html
+++ b/templates/candidate/candidate_list.html
@@ -199,6 +199,9 @@
         <li><a href="{% url 'twitter2:bulk_retrieve_possible_twitter_handles' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&page={{ current_page_number }}" target="_blank" >
         Retrieve Possible Twitter Handles</a> (25 at a time - about 30 seconds - Open in New Window)</li>
 
+        <li><a href="{% url 'import_export_facebook:bulk_retrieve_facebook_photos_view' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&page={{ current_page_number }}" target="_blank" >
+            Retrieve Facebook Photos for up to <b>{{facebook_urls_without_picture_urls}}</b> Candidates</a> (If the count does not decrease with each click, you are done for this election - Opens in a new tab)</li>
+
         <li><a href="{% url 'google_custom_search:bulk_retrieve_possible_google_search_users' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" target="_blank" >
         Retrieve Possible Candidates from Google</a> (20 at a time - 1-2 minutes - Open in New Window)</li>
 

--- a/wevote_settings/models.py
+++ b/wevote_settings/models.py
@@ -10,11 +10,13 @@ import wevote_functions.admin
 from wevote_functions.functions import convert_to_int, generate_random_string, positive_value_exists
 
 
+RETRIEVE_POSSIBLE_FACEBOOK_PHOTOS = 'RETRIEVE_POSSIBLE_FACEBOOK_PHOTOS'
 RETRIEVE_POSSIBLE_GOOGLE_LINKS = 'RETRIEVE_POSSIBLE_GOOGLE_LINKS'
 RETRIEVE_POSSIBLE_TWITTER_HANDLES = 'RETRIEVE_POSSIBLE_TWITTER_HANDLES'
 STOP_BULK_SEARCH_TWITTER_LINK_POSSIBILITY = 'STOP_BULK_SEARCH_TWITTER_LINK_POSSIBILITY'
 
 KIND_OF_ACTION_CHOICES = (
+    (RETRIEVE_POSSIBLE_FACEBOOK_PHOTOS, 'Retrieve possible Facebook photos'),
     (RETRIEVE_POSSIBLE_GOOGLE_LINKS, 'Retrieve possible google links'),
     (RETRIEVE_POSSIBLE_TWITTER_HANDLES, 'Retrieve possible twitter handles'),
     (STOP_BULK_SEARCH_TWITTER_LINK_POSSIBILITY, 'Stop search for Bulk twitter links'),


### PR DESCRIPTION
Implements wevote/WeVoteServer/issues/840
In candidate/views_admin candidate_list_view, added a template value
facebook_urls_without_picture_urls so we can see how many are left to
process.
In import_export_facebook controllers, added
scrape_facebook_photo_url_from_web_page to do the screen scrape of the
candidate picture via a regex.
In import_export_facebook views_admin, added bulk_retrieve_facebook_photos_view
to step through the candidate list and find facebook_url's without
facebook_profile_image_url_https entries to scrape.
In candidate_list.html added a line for the new "Retrieve Facebook Photos"
option "#3", to start the scrape.  Shows how many lines are left to
process after each run of ~25.