### PR TITLE
Added storage of photos to Candidate Tiny, Medium and Large photo fields. Created "Retrieve Facebook Photo" view so we can test against one candidate. Fixed some formatting that was violating PEP8.

### DIFF
--- a/candidate/controllers.py
+++ b/candidate/controllers.py
@@ -1347,62 +1347,63 @@ def retrieve_candidate_list_for_all_upcoming_elections(upcoming_google_civic_ele
     return results
 
 
-def save_google_search_image_to_candidate_table(candidate, google_search_image_file, google_search_link):
+def save_image_to_candidate_table(candidate, image_url, source_link, kind_of_source_website=None):
     cache_results = {
         'we_vote_hosted_profile_image_url_large':   None,
         'we_vote_hosted_profile_image_url_medium':  None,
         'we_vote_hosted_profile_image_url_tiny':    None
     }
 
-    google_search_website_name = extract_website_from_url(google_search_link)
-    if BALLOTPEDIA_IMAGE_SOURCE in google_search_website_name:
+    if not positive_value_exists(kind_of_source_website):
+        kind_of_source_website = extract_website_from_url(source_link)
+    if BALLOTPEDIA_IMAGE_SOURCE in kind_of_source_website:
         cache_results = cache_master_and_resized_image(
             candidate_id=candidate.id, candidate_we_vote_id=candidate.we_vote_id,
-            ballotpedia_profile_image_url=google_search_image_file,
+            ballotpedia_profile_image_url=image_url,
             image_source=BALLOTPEDIA_IMAGE_SOURCE)
         cached_ballotpedia_profile_image_url_https = cache_results['cached_ballotpedia_image_url_https']
         candidate.ballotpedia_photo_url = cached_ballotpedia_profile_image_url_https
-        candidate.ballotpedia_page_title = google_search_link
+        candidate.ballotpedia_page_title = source_link
 
-    elif LINKEDIN in google_search_website_name:
+    elif LINKEDIN in kind_of_source_website:
         cache_results = cache_master_and_resized_image(
             candidate_id=candidate.id, candidate_we_vote_id=candidate.we_vote_id,
-            linkedin_profile_image_url=google_search_image_file,
+            linkedin_profile_image_url=image_url,
             image_source=LINKEDIN)
         cached_linkedin_profile_image_url_https = cache_results['cached_linkedin_image_url_https']
-        candidate.linkedin_url = google_search_link
+        candidate.linkedin_url = source_link
         candidate.linkedin_photo_url = cached_linkedin_profile_image_url_https
 
-    elif WIKIPEDIA in google_search_website_name:
+    elif WIKIPEDIA in kind_of_source_website:
         cache_results = cache_master_and_resized_image(
             candidate_id=candidate.id, candidate_we_vote_id=candidate.we_vote_id,
-            wikipedia_profile_image_url=google_search_image_file,
+            wikipedia_profile_image_url=image_url,
             image_source=WIKIPEDIA)
         cached_wikipedia_profile_image_url_https = cache_results['cached_wikipedia_image_url_https']
         candidate.wikipedia_photo_url = cached_wikipedia_profile_image_url_https
-        candidate.wikipedia_page_title = google_search_link
+        candidate.wikipedia_page_title = source_link
 
-    elif TWITTER in google_search_website_name:
-        twitter_screen_name = extract_twitter_handle_from_text_string(google_search_link)
+    elif TWITTER in kind_of_source_website:
+        twitter_screen_name = extract_twitter_handle_from_text_string(source_link)
         candidate.candidate_twitter_handle = twitter_screen_name
-        candidate.twitter_url = google_search_link
+        candidate.twitter_url = source_link
 
-    elif FACEBOOK in google_search_website_name:
+    elif FACEBOOK in kind_of_source_website:
         cache_results = cache_master_and_resized_image(
             candidate_id=candidate.id, candidate_we_vote_id=candidate.we_vote_id,
-            facebook_profile_image_url_https=google_search_image_file,
+            facebook_profile_image_url_https=image_url,
             image_source=FACEBOOK)
         cached_facebook_profile_image_url_https = cache_results['cached_facebook_profile_image_url_https']
-        candidate.facebook_url = google_search_link
+        candidate.facebook_url = source_link
         candidate.facebook_profile_image_url_https = cached_facebook_profile_image_url_https
 
     else:
         cache_results = cache_master_and_resized_image(
             candidate_id=candidate.id, candidate_we_vote_id=candidate.we_vote_id,
-            other_source_image_url=google_search_image_file,
-            other_source=google_search_website_name)
+            other_source_image_url=image_url,
+            other_source=kind_of_source_website)
         cached_other_source_image_url_https = cache_results['cached_other_source_image_url_https']
-        candidate.other_source_url = google_search_link
+        candidate.other_source_url = source_link
         candidate.other_source_photo_url = cached_other_source_image_url_https
 
     we_vote_hosted_profile_image_url_large = cache_results['we_vote_hosted_profile_image_url_large']

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -6,7 +6,7 @@ from .controllers import candidates_import_from_master_server, candidates_import
     candidate_politician_match, fetch_duplicate_candidate_count, figure_out_candidate_conflict_values, find_duplicate_candidate, \
     merge_if_duplicate_candidates, merge_these_two_candidates, \
     refresh_candidate_data_from_master_tables, retrieve_candidate_photos, \
-    retrieve_candidate_politician_match_options, save_google_search_image_to_candidate_table, \
+    retrieve_candidate_politician_match_options, save_image_to_candidate_table, \
     save_google_search_link_to_candidate_table
 from .models import CandidateCampaign, CandidateCampaignListManager, CandidateCampaignManager, \
     CANDIDATE_UNIQUE_IDENTIFIERS
@@ -314,21 +314,20 @@ def candidate_list_view(request):
     #     is not null and facebook_profile_image_url_https is null
     facebook_urls_without_picture_urls = 0;
     try:
-        candidate_list = CandidateCampaign.objects.all()
+        candidate_facebook_missing_query = CandidateCampaign.objects.all()
         if positive_value_exists(google_civic_election_id):
-            candidate_list = candidate_list.filter(google_civic_election_id=google_civic_election_id)
+            candidate_facebook_missing_query = candidate_facebook_missing_query.filter(google_civic_election_id=google_civic_election_id)
 
         # include profile images that are null or ''
-        candidate_list = candidate_list.filter(Q(facebook_profile_image_url_https__isnull=True) | Q(facebook_profile_image_url_https__exact=''))
+        candidate_facebook_missing_query = candidate_facebook_missing_query.filter(Q(facebook_profile_image_url_https__isnull=True) | Q(facebook_profile_image_url_https__exact=''))
 
         # exclude facebook_urls that are null or ''
-        candidate_list = candidate_list.exclude(facebook_url__isnull=True).exclude(facebook_url__iexact='')
+        candidate_facebook_missing_query = candidate_facebook_missing_query.exclude(facebook_url__isnull=True).exclude(facebook_url__iexact='')
 
-        facebook_urls_without_picture_urls = candidate_list.count()
+        facebook_urls_without_picture_urls = candidate_facebook_missing_query.count()
 
     except Exception as e:
         logger.error("Find facebook URLs without facebook pictures in candidate: " + e)
-
 
     status_print_list = ""
     status_print_list += "candidate_list_count: " + \
@@ -988,8 +987,8 @@ def candidate_edit_process_view(request):
 
             if google_search_image_file:
                 # If google search image exist then cache master and resized images and save them to candidate table
-                save_google_search_image_to_candidate_table(candidate_on_stage, google_search_image_file,
-                                                            google_search_link)
+                save_image_to_candidate_table(candidate_on_stage, google_search_image_file,
+                                              google_search_link)
                 google_search_user_manager = GoogleSearchUserManager()
                 google_search_user_results = google_search_user_manager.retrieve_google_search_user_from_item_link(
                     candidate_on_stage.we_vote_id, google_search_link)

--- a/import_export_facebook/controllers.py
+++ b/import_export_facebook/controllers.py
@@ -964,8 +964,10 @@ def voter_facebook_sign_in_save_for_api(voter_device_id,  # voterFacebookSignInS
     }
     return json_data
 
+
 def scrape_facebook_photo_url_from_web_page(facebook_candidate_url):
     candidate_we_vote_ids_list = []
+    photo_url = ""
     status = ""
     success = False
     if "http://" in facebook_candidate_url:
@@ -987,7 +989,7 @@ def scrape_facebook_photo_url_from_web_page(facebook_candidate_url):
             'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36',
            }
 
-    #https://www.facebook.com/KamalaHarris/
+    # https://www.facebook.com/KamalaHarris/
     # <div class ="uiScaledImageContainer _62ui">
     #     <img class="scaledImageFitWidth img" src="https://scontent.fsnc1-1.fna.fbcdn.net/v/t1.0-1/p720x720/19420547_10155764935092923_4741672932915645516_n.jpg?_nc_cat=1&amp;oh=2e3a0af38385415f680ccc346faf876f&amp;oe=5BCE1B27" alt="" width="500" height="500" data-ft="&#123;&quot;tn&quot;:&quot;-^&quot;&#125;" itemprop="image" />
     # </div>
@@ -1003,7 +1005,7 @@ def scrape_facebook_photo_url_from_web_page(facebook_candidate_url):
                 except Exception:
                     logger.info("==> EXCEPTION ON DECODE")
                     continue
-                #logger.info("==>" + decoded_line)
+                # logger.info("==>" + decoded_line)
                 if 'scaledImageFitWidth img' in decoded_line:
                     p = re.compile('<img class=\"scaledImageFitWidth img\" src=\"(.*?)\"')
                     photo_url = p.search(decoded_line).group(1).replace("&amp;", "&")

--- a/import_export_facebook/urls.py
+++ b/import_export_facebook/urls.py
@@ -8,9 +8,8 @@ from . import views, views_admin
 
 
 urlpatterns = [
-    # views
-
-    # views_admin
-    url(r'^bulk_retrieve_facebook_photos_view/$',
-        views_admin.bulk_retrieve_facebook_photos_view, name='bulk_retrieve_facebook_photos_view', ),
+    url(r'^bulk_retrieve_facebook_photos/$',
+        views_admin.bulk_retrieve_facebook_photos_view, name='bulk_retrieve_facebook_photos', ),
+    url(r'^scrape_and_save_facebook_photo/$',
+        views_admin.scrape_and_save_facebook_photo_view, name='scrape_and_save_facebook_photo', ),
 ]

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -294,6 +294,13 @@ span.wrap_word { word-break: break-word; }
     <div class="col-sm-8">
         <input type="text" name="facebook_url" id="facebook_url_id" class="form-control"
                value="{% if candidate %}{{ candidate.facebook_url|default_if_none:"" }}{% else %}{{ facebook_url|default_if_none:"" }}{% endif %}" />
+      {% if candidate.facebook_url %}
+      <a href="{% url 'import_export_facebook:scrape_and_save_facebook_photo' %}?candidate_we_vote_id={{ candidate.we_vote_id }}&google_civic_election_id={{ google_civic_election_id }}">
+            Refresh Facebook Photo</a>
+          {% if candidate.facebook_profile_image_url_https %}
+          (<a href="{{ candidate.facebook_profile_image_url_https|default_if_none:"" }}" target="_blank">see photo in new window</a>)
+          {% endif %}
+      {% endif %}
     </div>
 </div>
 

--- a/templates/candidate/candidate_list.html
+++ b/templates/candidate/candidate_list.html
@@ -199,7 +199,7 @@
         <li><a href="{% url 'twitter2:bulk_retrieve_possible_twitter_handles' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&page={{ current_page_number }}" target="_blank" >
         Retrieve Possible Twitter Handles</a> (25 at a time - about 30 seconds - Open in New Window)</li>
 
-        <li><a href="{% url 'import_export_facebook:bulk_retrieve_facebook_photos_view' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&page={{ current_page_number }}" target="_blank" >
+        <li><a href="{% url 'import_export_facebook:bulk_retrieve_facebook_photos' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&page={{ current_page_number }}" target="_blank" >
             Retrieve Facebook Photos for up to <b>{{facebook_urls_without_picture_urls}}</b> Candidates</a> (If the count does not decrease with each click, you are done for this election - Opens in a new tab)</li>
 
         <li><a href="{% url 'google_custom_search:bulk_retrieve_possible_google_search_users' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" target="_blank" >


### PR DESCRIPTION
Hello @SailingSteve, I reviewed your pull request from last night. Thank you for moving this along so quickly! The political data team will be very happy. This pull request has some tweaks and additions, ready for your review and approval. I used the routine "save_image_to_candidate_table" instead of saving directly in the candidate object, so that we can take advantage of the local caching and image resizing. This now shows you the retrieved photo on the Candidate listing page.

I also added the ability to retrieve the Facebook photo for one candidate at a time, with the link "Refresh Facebook Photo" on the Candidate Edit page.

Please note with the candidate "Tim Gildersleeve" as an example, the photo retrieved did not match the Facebook profile image: https://www.facebook.com/timgildersleeve ...but instead seemed to retrieve a photo further down on the page.