### PR TITLE
Exclude all PERCENT_RATING entries (from Vote Smart). We want to move exclusively to support/oppose/info_only. We also label prior voter guides that are "vote_smart_ratings_only" so we can avoid retrieving them.

### DIFF
--- a/admin_tools/views.py
+++ b/admin_tools/views.py
@@ -1424,6 +1424,8 @@ def data_voter_statistics_view(request):
         # ################################
         # For this election, how many individual voters saved at least one PositionForFriends entry?
         voter_position_for_friends_query = PositionForFriends.objects.all()
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        voter_position_for_friends_query = voter_position_for_friends_query.exclude(stance__iexact='PERCENT_RATING')
         voter_position_for_friends_query = voter_position_for_friends_query.filter(
             google_civic_election_id=one_election.google_civic_election_id)
         voter_position_for_friends_query = voter_position_for_friends_query.exclude(
@@ -1436,6 +1438,8 @@ def data_voter_statistics_view(request):
         # ################################
         # For this election, how many Public PositionForFriends entries were saved by voters?
         voter_position_for_friends_query = PositionForFriends.objects.all()
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        voter_position_for_friends_query = voter_position_for_friends_query.exclude(stance__iexact='PERCENT_RATING')
         voter_position_for_friends_query = voter_position_for_friends_query.filter(
             google_civic_election_id=one_election.google_civic_election_id)
         one_election.voter_position_for_friends_count = voter_position_for_friends_query.count()

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -423,10 +423,13 @@ def candidate_list_view(request):
 
             # Number of Voter Guides
             voter_guide_query = VoterGuide.objects.filter(google_civic_election_id=election.google_civic_election_id)
+            voter_guide_query = voter_guide_query.exclude(vote_smart_ratings_only=True)
             election.voter_guides_count = voter_guide_query.count()
 
             # Number of Public Positions
             position_query = PositionEntered.objects.filter(google_civic_election_id=election.google_civic_election_id)
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            position_query = position_query.exclude(stance__iexact='PERCENT_RATING')
             election.public_positions_count = position_query.count()
 
     # Make sure we always include the current election in the election_list, even if it is older
@@ -656,8 +659,10 @@ def candidate_edit_view(request, candidate_id=0, candidate_campaign_we_vote_id="
 
         # Working with We Vote Positions
         try:
-            candidate_position_list = PositionEntered.objects.order_by('stance')
-            candidate_position_list = candidate_position_list.filter(candidate_campaign_id=candidate_id)
+            candidate_position_query = PositionEntered.objects.order_by('stance')
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            candidate_position_query = candidate_position_query.exclude(stance__iexact='PERCENT_RATING')
+            candidate_position_list = candidate_position_query.filter(candidate_campaign_id=candidate_id)
             # if positive_value_exists(google_civic_election_id):
             #     organization_position_list = candidate_position_list.filter(
             #         google_civic_election_id=google_civic_election_id)

--- a/election/views_admin.py
+++ b/election/views_admin.py
@@ -817,10 +817,13 @@ def election_list_view(request):
 
         # Number of Voter Guides
         voter_guide_query = VoterGuide.objects.filter(google_civic_election_id=election.google_civic_election_id)
+        voter_guide_query = voter_guide_query.exclude(vote_smart_ratings_only=True)
         election.voter_guides_count = voter_guide_query.count()
 
         # Number of Public Positions
         position_query = PositionEntered.objects.filter(google_civic_election_id=election.google_civic_election_id)
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        position_query = position_query.exclude(stance__iexact='PERCENT_RATING')
         election.public_positions_count = position_query.count()
 
         election_list_modified.append(election)
@@ -1008,12 +1011,15 @@ def nationwide_election_list_view(request):
 
         # Number of Voter Guides
         voter_guide_query = VoterGuide.objects.filter(google_civic_election_id=election.google_civic_election_id)
+        voter_guide_query = voter_guide_query.exclude(vote_smart_ratings_only=True)
         if is_national_election:
             voter_guide_query = voter_guide_query.filter(state_code__iexact=election.state_code)
         election.voter_guides_count = voter_guide_query.count()
 
         # Number of Public Positions
         position_query = PositionEntered.objects.filter(google_civic_election_id=election.google_civic_election_id)
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        position_query = position_query.exclude(stance__iexact='PERCENT_RATING')
         if is_national_election:
             position_query = position_query.filter(state_code__iexact=election.state_code)
         election.public_positions_count = position_query.count()
@@ -1290,6 +1296,7 @@ def election_summary_view(request, election_local_id=0, google_civic_election_id
         # Number of Voter Guides
         voter_guide_query = VoterGuide.objects.filter(
             google_civic_election_id=election.google_civic_election_id)
+        voter_guide_query = voter_guide_query.exclude(vote_smart_ratings_only=True)
         if positive_value_exists(state_code):
             voter_guide_query = voter_guide_query.filter(state_code__iexact=state_code)
         election.voter_guides_count = voter_guide_query.count()
@@ -1297,6 +1304,8 @@ def election_summary_view(request, election_local_id=0, google_civic_election_id
         # Number of Public Positions
         position_query = PositionEntered.objects.filter(
             google_civic_election_id=election.google_civic_election_id)
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        position_query = position_query.exclude(stance__iexact='PERCENT_RATING')
         if positive_value_exists(state_code):
             position_query = position_query.filter(state_code__iexact=state_code)
         election.public_positions_count = position_query.count()

--- a/organization/views_admin.py
+++ b/organization/views_admin.py
@@ -795,6 +795,8 @@ def organization_position_list_view(request, organization_id=0, organization_we_
         organization_position_list_found = False
         try:
             public_position_query = PositionEntered.objects.all()
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            public_position_query = public_position_query.exclude(stance__iexact='PERCENT_RATING')
             public_position_query = public_position_query.filter(organization_id=organization_id)
             if positive_value_exists(google_civic_election_id):
                 public_position_query = public_position_query.filter(
@@ -804,6 +806,8 @@ def organization_position_list_view(request, organization_id=0, organization_we_
             public_position_list = list(public_position_query)
 
             friends_only_position_query = PositionForFriends.objects.all()
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            friends_only_position_query = friends_only_position_query.exclude(stance__iexact='PERCENT_RATING')
             friends_only_position_query = friends_only_position_query.filter(organization_id=organization_id)
             if positive_value_exists(google_civic_election_id):
                 friends_only_position_query = friends_only_position_query.filter(
@@ -959,12 +963,14 @@ def organization_position_new_view(request, organization_id):
         contest_measures_for_this_election_list = results['measure_list_objects']
 
     try:
-        organization_position_list = PositionEntered.objects.order_by('stance')
-        organization_position_list = organization_position_list.filter(organization_id=organization_id)
+        organization_position_query = PositionEntered.objects.order_by('stance')
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        organization_position_query = organization_position_query.exclude(stance__iexact='PERCENT_RATING')
+        organization_position_query = organization_position_query.filter(organization_id=organization_id)
         if positive_value_exists(google_civic_election_id):
-            organization_position_list = organization_position_list.filter(
+            organization_position_query = organization_position_query.filter(
                 google_civic_election_id=google_civic_election_id)
-        organization_position_list = organization_position_list.order_by(
+        organization_position_list = organization_position_query.order_by(
             'google_civic_election_id', '-vote_smart_time_span')
         if len(organization_position_list):
             organization_position_list_found = True

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -301,8 +301,10 @@ def politician_edit_view(request, politician_id):
 
         # Working with We Vote Positions
         try:
-            politician_position_list = PositionEntered.objects.order_by('stance')
-            politician_position_list = politician_position_list.filter(
+            politician_position_query = PositionEntered.objects.order_by('stance')
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            politician_position_query = politician_position_query.exclude(stance__iexact='PERCENT_RATING')
+            politician_position_list = politician_position_query.filter(
                 politician_we_vote_id__iexact=politician_on_stage.we_vote_id)
         except Exception as e:
             politician_position_list = []

--- a/position/controllers.py
+++ b/position/controllers.py
@@ -646,6 +646,8 @@ def find_organizations_referenced_in_positions_for_this_voter(voter):
 
     # PositionEntered
     position_list_query = PositionEntered.objects.all()
+    # As of Aug 2018 we are no longer using PERCENT_RATING
+    position_list_query = position_list_query.exclude(stance__iexact='PERCENT_RATING')
     position_list_query = position_list_query.filter(final_position_filters)
 
     for one_position in position_list_query:
@@ -663,6 +665,8 @@ def find_organizations_referenced_in_positions_for_this_voter(voter):
 
     # PositionForFriends
     position_list_query = PositionForFriends.objects.all()
+    # As of Aug 2018 we are no longer using PERCENT_RATING
+    position_list_query = position_list_query.exclude(stance__iexact='PERCENT_RATING')
     position_list_query = position_list_query.filter(final_position_filters)
 
     for one_position in position_list_query:

--- a/position/models.py
+++ b/position/models.py
@@ -1051,6 +1051,8 @@ class PositionListManager(models.Model):
         try:
             public_position_list = PositionEntered.objects.using('readonly').all()
             public_position_list = public_position_list.exclude(voter_we_vote_id=None)  # Don't include if no we_vote_id
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            public_position_list = public_position_list.exclude(stance__iexact=PERCENT_RATING)
 
             if positive_value_exists(candidate_campaign_id):
                 public_position_list = public_position_list.filter(candidate_campaign_id=candidate_campaign_id)
@@ -1058,13 +1060,15 @@ class PositionListManager(models.Model):
                 public_position_list = public_position_list.filter(
                     candidate_campaign_we_vote_id__iexact=candidate_campaign_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
+            # if stance_we_are_looking_for != ANY_STANCE:
+            #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+            #     if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
+            #         public_position_list = public_position_list.filter(
+            #             Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
+            #     else:
+            #         public_position_list = public_position_list.filter(stance=stance_we_are_looking_for)
             if stance_we_are_looking_for != ANY_STANCE:
-                # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
-                    public_position_list = public_position_list.filter(
-                        Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
-                else:
-                    public_position_list = public_position_list.filter(stance=stance_we_are_looking_for)
+                public_position_list = public_position_list.filter(stance__iexact=stance_we_are_looking_for)
 
             # Now filter out the positions that have a percent rating that doesn't match the stance_we_are_looking_for
             if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
@@ -1092,6 +1096,8 @@ class PositionListManager(models.Model):
         try:
             friends_only_position_list = PositionForFriends.objects.using('readonly').all()
             friends_only_position_list = friends_only_position_list.exclude(voter_we_vote_id=None)  # No we_vote_id
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            friends_only_position_list = friends_only_position_list.exclude(stance__iexact='PERCENT_RATING')
 
             if positive_value_exists(candidate_campaign_id):
                 friends_only_position_list = friends_only_position_list.filter(
@@ -1100,13 +1106,15 @@ class PositionListManager(models.Model):
                 friends_only_position_list = friends_only_position_list.filter(
                     candidate_campaign_we_vote_id__iexact=candidate_campaign_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
+            # if stance_we_are_looking_for != ANY_STANCE:
+            #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+            #     if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
+            #         friends_only_position_list = friends_only_position_list.filter(
+            #             Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
+            #     else:
+            #         friends_only_position_list = friends_only_position_list.filter(stance=stance_we_are_looking_for)
             if stance_we_are_looking_for != ANY_STANCE:
-                # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
-                    friends_only_position_list = friends_only_position_list.filter(
-                        Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
-                else:
-                    friends_only_position_list = friends_only_position_list.filter(stance=stance_we_are_looking_for)
+                friends_only_position_list = friends_only_position_list.filter(stance__iexact=stance_we_are_looking_for)
 
             # Now filter out the positions that have a percent rating that doesn't match the stance_we_are_looking_for
             if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
@@ -1158,6 +1166,8 @@ class PositionListManager(models.Model):
         try:
             public_position_list = PositionEntered.objects.using('readonly').all()
             public_position_list = public_position_list.exclude(voter_we_vote_id=None)  # Don't include if no we_vote_id
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            public_position_list = public_position_list.exclude(stance__iexact=PERCENT_RATING)
 
             if positive_value_exists(contest_measure_id):
                 public_position_list = public_position_list.filter(contest_measure_id=contest_measure_id)
@@ -1165,13 +1175,16 @@ class PositionListManager(models.Model):
                 public_position_list = public_position_list.filter(
                     contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
+            # if stance_we_are_looking_for != ANY_STANCE:
+            #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+            #     if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
+            #         public_position_list = public_position_list.filter(
+            #             Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
+            #     else:
+            #         public_position_list = public_position_list.filter(stance=stance_we_are_looking_for)
+
             if stance_we_are_looking_for != ANY_STANCE:
-                # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
-                    public_position_list = public_position_list.filter(
-                        Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
-                else:
-                    public_position_list = public_position_list.filter(stance=stance_we_are_looking_for)
+                public_position_list = public_position_list.filter(stance__iexact=stance_we_are_looking_for)
 
             # Now filter out the positions that have a percent rating that doesn't match the stance_we_are_looking_for
             if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
@@ -1199,6 +1212,8 @@ class PositionListManager(models.Model):
         try:
             friends_only_position_list = PositionForFriends.objects.using('readonly').all()
             friends_only_position_list = friends_only_position_list.exclude(voter_we_vote_id=None)  # No we_vote_id
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            friends_only_position_list = friends_only_position_list.exclude(stance__iexact='PERCENT_RATING')
 
             if positive_value_exists(contest_measure_id):
                 friends_only_position_list = friends_only_position_list.filter(contest_measure_id=contest_measure_id)
@@ -1206,13 +1221,15 @@ class PositionListManager(models.Model):
                 friends_only_position_list = friends_only_position_list.filter(
                     contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
+            # if stance_we_are_looking_for != ANY_STANCE:
+            #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+            #     if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
+            #         friends_only_position_list = friends_only_position_list.filter(
+            #             Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
+            #     else:
+            #         friends_only_position_list = friends_only_position_list.filter(stance=stance_we_are_looking_for)
             if stance_we_are_looking_for != ANY_STANCE:
-                # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
-                    friends_only_position_list = friends_only_position_list.filter(
-                        Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
-                else:
-                    friends_only_position_list = friends_only_position_list.filter(stance=stance_we_are_looking_for)
+                friends_only_position_list = friends_only_position_list.filter(stance__iexact=stance_we_are_looking_for)
 
             # Now filter out the positions that have a percent rating that doesn't match the stance_we_are_looking_for
             if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
@@ -1263,23 +1280,29 @@ class PositionListManager(models.Model):
                 position_on_stage = PositionForFriends()
 
             position_list = position_on_stage_starter.objects.using('readonly').order_by('date_entered')
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            position_list = position_list.exclude(stance__iexact=PERCENT_RATING)
+
             position_list = position_list.filter(organization_we_vote_id__iexact=organization_we_vote_id)
             position_list = position_list.filter(google_civic_election_id=google_civic_election_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
-            if stance_we_are_looking_for != ANY_STANCE:
-                # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                if stance_we_are_looking_for == SUPPORT:
-                    position_list = position_list.filter(
-                        Q(stance=stance_we_are_looking_for) |  # Matches "is_support"
-                        (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__gte=66))
-                    )  # Matches "is_positive_rating"
-                elif stance_we_are_looking_for == OPPOSE:
-                    position_list = position_list.filter(
-                        Q(stance=stance_we_are_looking_for) |  # Matches "is_oppose"
-                        (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__lte=33))
-                    )  # Matches "is_negative_rating"
-                else:
-                    position_list = position_list.filter(stance=stance_we_are_looking_for)
+            # if stance_we_are_looking_for != ANY_STANCE:
+            #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+            #     if stance_we_are_looking_for == SUPPORT:
+            #         position_list = position_list.filter(
+            #             Q(stance=stance_we_are_looking_for) |  # Matches "is_support"
+            #             (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__gte=66))
+            #         )  # Matches "is_positive_rating"
+            #     elif stance_we_are_looking_for == OPPOSE:
+            #         position_list = position_list.filter(
+            #             Q(stance=stance_we_are_looking_for) |  # Matches "is_oppose"
+            #             (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__lte=33))
+            #         )  # Matches "is_negative_rating"
+            #     else:
+            #         position_list = position_list.filter(stance=stance_we_are_looking_for)
+
+            position_list = position_list.filter(stance__iexact=stance_we_are_looking_for)
+
             # Limit to positions in the last x years - currently we are not limiting
             # position_list = position_list.filter(election_id=election_id)
 
@@ -1546,6 +1569,8 @@ class PositionListManager(models.Model):
             # Retrieve by organization_id
             public_positions_list_query = PositionEntered.objects.all()
             public_positions_list_query = public_positions_list_query.filter(organization_id=organization_id)
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            public_positions_list_query = public_positions_list_query.exclude(stance__iexact=PERCENT_RATING)
             public_positions_list = list(public_positions_list_query)  # Force the query to run
             for public_position in public_positions_list:
                 public_position_to_be_saved = False
@@ -1573,6 +1598,8 @@ class PositionListManager(models.Model):
             public_positions_list_query = PositionEntered.objects.all()
             public_positions_list_query = public_positions_list_query.filter(
                 organization_we_vote_id__iexact=organization_we_vote_id)
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            public_positions_list_query = public_positions_list_query.exclude(stance__iexact=PERCENT_RATING)
             public_positions_list = list(public_positions_list_query)  # Force the query to run
             for public_position in public_positions_list:
                 public_position_to_be_saved = False
@@ -1807,19 +1834,24 @@ class PositionListManager(models.Model):
                     position_list_query = PositionForFriends.objects.order_by('date_entered')
                 retrieve_friends_positions = True
 
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            position_list_query = position_list_query.exclude(stance__iexact=PERCENT_RATING)
+
             if positive_value_exists(candidate_campaign_id):
                 position_list_query = position_list_query.filter(candidate_campaign_id=candidate_campaign_id)
             else:
                 position_list_query = position_list_query.filter(
                     candidate_campaign_we_vote_id__iexact=candidate_campaign_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
+            # if stance_we_are_looking_for != ANY_STANCE:
+            #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+            #     if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
+            #         position_list_query = position_list_query.filter(
+            #             Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
+            #     else:
+            #         position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
             if stance_we_are_looking_for != ANY_STANCE:
-                # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
-                    position_list_query = position_list_query.filter(
-                        Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
-                else:
-                    position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+                position_list_query = position_list_query.filter(stance__iexact=stance_we_are_looking_for)
 
             # Only one of these blocks will be used at a time
             if retrieve_friends_positions and friends_we_vote_id_list:
@@ -1951,6 +1983,9 @@ class PositionListManager(models.Model):
                     position_list_query = PositionForFriends.objects.order_by('date_entered')
                 retrieve_friends_positions = True
 
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            position_list_query = position_list_query.exclude(stance__iexact=PERCENT_RATING)
+
             if positive_value_exists(contest_measure_id):
                 position_list_query = position_list_query.filter(contest_measure_id=contest_measure_id)
             else:
@@ -1959,7 +1994,7 @@ class PositionListManager(models.Model):
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
                 # If we passed in the stance "ANY" it means we want to not filter down the list
-                position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+                position_list_query = position_list_query.filter(stance__iexact=stance_we_are_looking_for)
                 # NOTE: We don't have a special case for
                 # "if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE"
                 # for contest_measure (like we do for candidate_campaign) because we don't have to deal with
@@ -2045,6 +2080,9 @@ class PositionListManager(models.Model):
                 position_list_query = PositionForFriends.objects.order_by('date_entered')
                 retrieve_friends_positions = True
 
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            position_list_query = position_list_query.exclude(stance__iexact=PERCENT_RATING)
+
             if positive_value_exists(contest_office_we_vote_id):
                 position_list_query = position_list_query.filter(
                     contest_office_we_vote_id__iexact=contest_office_we_vote_id)
@@ -2053,7 +2091,7 @@ class PositionListManager(models.Model):
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
                 # If we passed in the stance "ANY" it means we want to not filter down the list
-                position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+                position_list_query = position_list_query.filter(stance__iexact=stance_we_are_looking_for)
                 # NOTE: We don't have a special case for
                 # "if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE"
                 # for contest_office (like we do for candidate_campaign) because we don't have to deal with
@@ -2264,22 +2302,28 @@ class PositionListManager(models.Model):
             status += "RETRIEVE_PUBLIC_POSITIONS "
             try:
                 # We intentionally do not use 'readonly' here since we need to save based on the results of this query
+                # Removed this order_by: '-vote_smart_time_span',
                 public_positions_list = PositionEntered.objects.order_by('ballot_item_display_name',
-                                                                         '-vote_smart_time_span',
                                                                          '-google_civic_election_id')
+                # As of Aug 2018 we are no longer using PERCENT_RATING
+                public_positions_list = public_positions_list.exclude(stance__iexact=PERCENT_RATING)
+
                 if positive_value_exists(organization_id):
                     public_positions_list = public_positions_list.filter(organization_id=organization_id)
                 else:
                     public_positions_list = public_positions_list.filter(
                         organization_we_vote_id__iexact=organization_we_vote_id)
                 # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
+                # if stance_we_are_looking_for != ANY_STANCE:
+                #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+                #     if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
+                #         public_positions_list = public_positions_list.filter(stance=stance_we_are_looking_for
+                #             Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))
+                #  | Q(stance=GRADE_RATING))
+                #     else:
+                #         public_positions_list = public_positions_list.filter(stance=stance_we_are_looking_for)
                 if stance_we_are_looking_for != ANY_STANCE:
-                    # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                    if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
-                        public_positions_list = public_positions_list.filter(
-                            Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
-                    else:
-                        public_positions_list = public_positions_list.filter(stance=stance_we_are_looking_for)
+                    public_positions_list = public_positions_list.filter(stance__iexact=stance_we_are_looking_for)
 
                 google_civic_election_id_local_scope = 0
                 if positive_value_exists(show_positions_current_voter_election) \
@@ -2382,9 +2426,12 @@ class PositionListManager(models.Model):
                 if voter_is_friend_of_organization:
                     # If here, then the viewer is a friend with the organization. Look up positions that
                     #  are only shown to friends.
+                    # '-vote_smart_time_span',
                     friends_positions_list = PositionForFriends.objects.order_by('ballot_item_display_name',
-                                                                                 '-vote_smart_time_span',
                                                                                  '-google_civic_election_id')
+                    # As of Aug 2018 we are no longer using PERCENT_RATING
+                    friends_positions_list = friends_positions_list.exclude(stance__iexact=PERCENT_RATING)
+
                     # Get the entries saved by the organization's voter account
                     if positive_value_exists(organization_voter_local_id):
                         friends_positions_list = friends_positions_list.filter(
@@ -2394,14 +2441,16 @@ class PositionListManager(models.Model):
                             voter_we_vote_id__iexact=organization_voter_we_vote_id)
 
                     # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
+                    # if stance_we_are_looking_for != ANY_STANCE:
+                    #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+                    #     if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
+                    #         friends_positions_list = friends_positions_list.filter(
+                    #             Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))
+                    #         # | Q(stance=GRADE_RATING))
+                    #     else:
+                    #         friends_positions_list = friends_positions_list.filter(stance=stance_we_are_looking_for)
                     if stance_we_are_looking_for != ANY_STANCE:
-                        # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                        if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
-                            friends_positions_list = friends_positions_list.filter(
-                                Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))
-                            # | Q(stance=GRADE_RATING))
-                        else:
-                            friends_positions_list = friends_positions_list.filter(stance=stance_we_are_looking_for)
+                        friends_positions_list = friends_positions_list.filter(stance__iexact=stance_we_are_looking_for)
 
                     # Gather the ids for all positions in this election so we can figure out which positions
                     # relate to the election the voter is currently looking at, vs. for all other elections
@@ -2569,6 +2618,10 @@ class PositionListManager(models.Model):
             # Retrieve public positions
             try:
                 public_positions_list_query = PositionEntered.objects.all()
+
+                # As of Aug 2018 we are no longer using PERCENT_RATING
+                public_positions_list_query = public_positions_list_query.exclude(stance__iexact=PERCENT_RATING)
+
                 if positive_value_exists(voter_id):
                     public_positions_list_query = public_positions_list_query.filter(voter_id=voter_id)
                 elif positive_value_exists(voter_we_vote_id):
@@ -2584,14 +2637,18 @@ class PositionListManager(models.Model):
                     public_positions_list_query = public_positions_list_query.filter(state_code__iexact=state_code)
 
                 # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
+                # if stance_we_are_looking_for != ANY_STANCE:
+                #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+                #     if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
+                #         public_positions_list_query = public_positions_list_query.filter(
+                #             Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))
+                #  | Q(stance=GRADE_RATING))
+                #     else:
+                #         public_positions_list_query = public_positions_list_query.filter(
+                #             stance=stance_we_are_looking_for)
                 if stance_we_are_looking_for != ANY_STANCE:
-                    # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                    if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
-                        public_positions_list_query = public_positions_list_query.filter(
-                            Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
-                    else:
-                        public_positions_list_query = public_positions_list_query.filter(
-                            stance=stance_we_are_looking_for)
+                    public_positions_list_query = public_positions_list_query.filter(
+                        stance=stance_we_are_looking_for)
 
                 # Force the position for the most recent election to show up last
                 public_positions_list_query = public_positions_list_query.order_by('google_civic_election_id')
@@ -2611,6 +2668,10 @@ class PositionListManager(models.Model):
             # Retrieve positions meant for friends only
             try:
                 friends_positions_list_query = PositionForFriends.objects.all()
+
+                # As of Aug 2018 we are no longer using PERCENT_RATING
+                friends_positions_list_query = friends_positions_list_query.exclude(stance__iexact=PERCENT_RATING)
+
                 if positive_value_exists(voter_id):
                     friends_positions_list_query = friends_positions_list_query.filter(voter_id=voter_id)
                 elif positive_value_exists(voter_we_vote_id):
@@ -2626,14 +2687,18 @@ class PositionListManager(models.Model):
                     friends_positions_list_query = friends_positions_list_query.filter(state_code__iexact=state_code)
 
                 # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
+                # if stance_we_are_looking_for != ANY_STANCE:
+                #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+                #     if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
+                #         friends_positions_list_query = friends_positions_list_query.filter(
+                #             Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))
+                #  | Q(stance=GRADE_RATING))
+                #     else:
+                #         friends_positions_list_query = friends_positions_list_query.filter(
+                #             stance=stance_we_are_looking_for)
                 if stance_we_are_looking_for != ANY_STANCE:
-                    # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                    if stance_we_are_looking_for == SUPPORT or stance_we_are_looking_for == OPPOSE:
-                        friends_positions_list_query = friends_positions_list_query.filter(
-                            Q(stance=stance_we_are_looking_for) | Q(stance=PERCENT_RATING))  # | Q(stance=GRADE_RATING))
-                    else:
-                        friends_positions_list_query = friends_positions_list_query.filter(
-                            stance=stance_we_are_looking_for)
+                    friends_positions_list_query = friends_positions_list_query.filter(
+                        stance=stance_we_are_looking_for)
 
                 # Force the position for the most recent election to show up last
                 friends_positions_list_query = friends_positions_list_query.order_by('google_civic_election_id')
@@ -2742,6 +2807,10 @@ class PositionListManager(models.Model):
         # Retrieve public positions
         try:
             public_positions_list_query = PositionEntered.objects.all()
+
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            public_positions_list_query = public_positions_list_query.exclude(stance__iexact=PERCENT_RATING)
+
             if positive_value_exists(voter_id):
                 public_positions_list_query = public_positions_list_query.filter(voter_id=voter_id)
             elif positive_value_exists(voter_we_vote_id):
@@ -2767,6 +2836,10 @@ class PositionListManager(models.Model):
         # Retrieve positions meant for friends only
         try:
             friends_positions_list_query = PositionForFriends.objects.all()
+
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            friends_positions_list_query = friends_positions_list_query.exclude(stance__iexact=PERCENT_RATING)
+
             if positive_value_exists(voter_id):
                 friends_positions_list_query = friends_positions_list_query.filter(voter_id=voter_id)
             elif positive_value_exists(voter_we_vote_id):
@@ -2878,10 +2951,14 @@ class PositionListManager(models.Model):
                 position_list_query = PositionForFriends.objects.order_by('date_entered')
 
             position_list_query = position_list_query.filter(google_civic_election_id=google_civic_election_id)
+
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            position_list_query = position_list_query.exclude(stance__iexact=PERCENT_RATING)
+
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
                 # If we passed in the stance "ANY" it means we want to not filter down the list
-                position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+                position_list_query = position_list_query.filter(stance__iexact=stance_we_are_looking_for)
             if positive_value_exists(limit_to_organization_we_vote_ids) and len(limit_to_organization_we_vote_ids):
                 position_list_query = position_list_query.filter(
                     organization_we_vote_id__in=limit_to_organization_we_vote_ids)
@@ -2983,6 +3060,9 @@ class PositionListManager(models.Model):
             retrieve_public_positions = True
             position_list_query = PositionEntered.objects.using('readonly').all()
 
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        position_list_query = position_list_query.exclude(stance__iexact=PERCENT_RATING)
+
         if retrieve_public_positions:
             # If retrieving PositionEntered, make sure we have the necessary variables
             if type(organizations_followed_we_vote_id_list) is list \
@@ -3003,29 +3083,30 @@ class PositionListManager(models.Model):
                     candidate_campaign_we_vote_id__iexact=candidate_campaign_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
-                # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                if stance_we_are_looking_for == SUPPORT:
-                    if retrieve_public_positions:
-                        # If here, include Vote Smart Ratings
-                        position_list_query = position_list_query.filter(
-                            Q(stance=stance_we_are_looking_for) |  # Matches "is_support"
-                            (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__gte=66))
-                        )  # Matches "is_positive_rating"
-                    else:
-                        # If looking for FRIENDS_ONLY positions, we can ignore Vote Smart data
-                        position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
-                elif stance_we_are_looking_for == OPPOSE:
-                    if retrieve_public_positions:
-                        # If here, include Vote Smart Ratings
-                        position_list_query = position_list_query.filter(
-                            Q(stance=stance_we_are_looking_for) |  # Matches "is_oppose"
-                            (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__lte=33))
-                        )  # Matches "is_negative_rating"
-                    else:
-                        # If looking for FRIENDS_ONLY positions, we can ignore Vote Smart data
-                        position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
-                else:
-                    position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+                # # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+                # if stance_we_are_looking_for == SUPPORT:
+                #     if retrieve_public_positions:
+                #         # If here, include Vote Smart Ratings
+                #         position_list_query = position_list_query.filter(
+                #             Q(stance=stance_we_are_looking_for) |  # Matches "is_support"
+                #             (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__gte=66))
+                #         )  # Matches "is_positive_rating"
+                #     else:
+                #         # If looking for FRIENDS_ONLY positions, we can ignore Vote Smart data
+                #         position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+                # elif stance_we_are_looking_for == OPPOSE:
+                #     if retrieve_public_positions:
+                #         # If here, include Vote Smart Ratings
+                #         position_list_query = position_list_query.filter(
+                #             Q(stance=stance_we_are_looking_for) |  # Matches "is_oppose"
+                #             (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__lte=33))
+                #         )  # Matches "is_negative_rating"
+                #     else:
+                #         # If looking for FRIENDS_ONLY positions, we can ignore Vote Smart data
+                #         position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+                # else:
+                #     position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+                position_list_query = position_list_query.filter(stance__iexact=stance_we_are_looking_for)
 
             # Only one of these blocks will be used at a time
             if retrieve_friends_positions and friends_we_vote_id_list is not False:
@@ -3091,6 +3172,9 @@ class PositionListManager(models.Model):
         else:
             position_list_query = PositionEntered.objects.using('readonly').all()
 
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        position_list_query = position_list_query.exclude(stance__iexact=PERCENT_RATING)
+
         # Retrieve the support positions for this contest_office_id
         position_count = 0
         try:
@@ -3102,18 +3186,21 @@ class PositionListManager(models.Model):
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
                 # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                if stance_we_are_looking_for == SUPPORT:
-                    position_list_query = position_list_query.filter(
-                        Q(stance=stance_we_are_looking_for) |  # Matches "is_support"
-                        (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__gte=66))  # "is_positive_rating"
-                    )  # | Q(stance=GRADE_RATING))
-                elif stance_we_are_looking_for == OPPOSE:
-                    position_list_query = position_list_query.filter(
-                        Q(stance=stance_we_are_looking_for) |  # Matches "is_oppose"
-                        (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__lte=33))  # "is_negative_rating"
-                    )  # | Q(stance=GRADE_RATING))
-                else:
-                    position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+                # if stance_we_are_looking_for == SUPPORT:
+                #     position_list_query = position_list_query.filter(
+                #         Q(stance=stance_we_are_looking_for) |  # Matches "is_support"
+                #         (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__gte=66))  # "is_positive_rating"
+                #     )  # | Q(stance=GRADE_RATING))
+                # elif stance_we_are_looking_for == OPPOSE:
+                #     position_list_query = position_list_query.filter(
+                #         Q(stance=stance_we_are_looking_for) |  # Matches "is_oppose"
+                #         (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__lte=33))  # "is_negative_rating"
+                #     )  # | Q(stance=GRADE_RATING))
+                # else:
+                #     position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+
+                position_list_query = position_list_query.filter(stance__iexact=stance_we_are_looking_for)
+
             # Limit to positions in the last x years - currently we are not limiting
             # position_list = position_list.filter(election_id=election_id)
 
@@ -3162,6 +3249,9 @@ class PositionListManager(models.Model):
         else:
             position_list_query = PositionEntered.objects.using('readonly').all()
 
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        position_list_query = position_list_query.exclude(stance__iexact=PERCENT_RATING)
+
         # Retrieve the support positions for this contest_measure_id
         position_count = 0
         try:
@@ -3172,19 +3262,21 @@ class PositionListManager(models.Model):
                     contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
-                # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
-                if stance_we_are_looking_for == SUPPORT:
-                    position_list_query = position_list_query.filter(
-                        Q(stance=stance_we_are_looking_for) |  # Matches "is_support"
-                        (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__gte=66))  # "is_positive_rating"
-                    )  # | Q(stance=GRADE_RATING))
-                elif stance_we_are_looking_for == OPPOSE:
-                    position_list_query = position_list_query.filter(
-                        Q(stance=stance_we_are_looking_for) |  # Matches "is_oppose"
-                        (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__lte=33))  # "is_negative_rating"
-                    )  # | Q(stance=GRADE_RATING))
-                else:
-                    position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+                # # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
+                # if stance_we_are_looking_for == SUPPORT:
+                #     position_list_query = position_list_query.filter(
+                #         Q(stance=stance_we_are_looking_for) |  # Matches "is_support"
+                #         (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__gte=66))  # "is_positive_rating"
+                #     )  # | Q(stance=GRADE_RATING))
+                # elif stance_we_are_looking_for == OPPOSE:
+                #     position_list_query = position_list_query.filter(
+                #         Q(stance=stance_we_are_looking_for) |  # Matches "is_oppose"
+                #         (Q(stance=PERCENT_RATING) & Q(vote_smart_rating_integer__lte=33))  # "is_negative_rating"
+                #     )  # | Q(stance=GRADE_RATING))
+                # else:
+                #     position_list_query = position_list_query.filter(stance=stance_we_are_looking_for)
+                position_list_query = position_list_query.filter(stance__iexact=stance_we_are_looking_for)
+
             # Limit to positions in the last x years - currently we are not limiting
             # position_list = position_list.filter(election_id=election_id)
 
@@ -3203,6 +3295,10 @@ class PositionListManager(models.Model):
 
         try:
             position_queryset = PositionEntered.objects.all()
+
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            position_queryset = position_queryset.exclude(stance__iexact=PERCENT_RATING)
+
             position_queryset = position_queryset.filter(google_civic_election_id=google_civic_election_id)
             # We don't look for office_we_vote_id because of the chance that locally we are using a
             # different we_vote_id
@@ -7423,6 +7519,9 @@ class PositionManager(models.Model):
         else:
             position_item_queryset = PositionForFriends.objects.all()
 
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        position_item_queryset = position_item_queryset.exclude(stance__iexact=PERCENT_RATING)
+
         positions_count = 0
         success = False
         if positive_value_exists(google_civic_election_id):
@@ -7462,6 +7561,10 @@ class PositionMetricsManager(models.Model):
         count_result = None
         try:
             count_query = PositionEntered.objects.using('readonly').all()
+
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
+
             if positive_value_exists(google_civic_election_id):
                 count_query = count_query.filter(google_civic_election_id=google_civic_election_id)
             if positions_taken_by_these_voter_we_vote_ids is not False:
@@ -7476,6 +7579,10 @@ class PositionMetricsManager(models.Model):
         count_result = None
         try:
             count_query = PositionEntered.objects.using('readonly').all()
+
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
+
             if positive_value_exists(google_civic_election_id):
                 count_query = count_query.filter(google_civic_election_id=google_civic_election_id)
             count_query = count_query.exclude(
@@ -7494,6 +7601,8 @@ class PositionMetricsManager(models.Model):
         count_result = None
         try:
             count_query = PositionForFriends.objects.using('readonly').all()
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
             if positive_value_exists(google_civic_election_id):
                 count_query = count_query.filter(google_civic_election_id=google_civic_election_id)
             if positions_taken_by_these_voter_we_vote_ids is not False:
@@ -7508,6 +7617,8 @@ class PositionMetricsManager(models.Model):
         count_result = None
         try:
             count_query = PositionForFriends.objects.using('readonly').all()
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
             if positive_value_exists(google_civic_election_id):
                 count_query = count_query.filter(google_civic_election_id=google_civic_election_id)
             count_query = count_query.exclude(
@@ -7525,6 +7636,8 @@ class PositionMetricsManager(models.Model):
         count_result = None
         try:
             count_query = PositionForFriends.objects.using('readonly').all()
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
             count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
             count_query = count_query.exclude(
                 (Q(statement_text__isnull=True) | Q(statement_text__exact='')) &
@@ -7539,6 +7652,10 @@ class PositionMetricsManager(models.Model):
         count_result = None
         try:
             count_query = PositionEntered.objects.using('readonly').all()
+
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
+
             count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
             count_query = count_query.exclude(
                 (Q(statement_text__isnull=True) | Q(statement_text__exact='')) &
@@ -7553,6 +7670,8 @@ class PositionMetricsManager(models.Model):
         count_result = None
         try:
             count_query = PositionForFriends.objects.using('readonly').all()
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
             count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
             count_result = count_query.count()
         except Exception as e:
@@ -7563,6 +7682,10 @@ class PositionMetricsManager(models.Model):
         count_result = None
         try:
             count_query = PositionEntered.objects.using('readonly').all()
+
+            # As of Aug 2018 we are no longer using PERCENT_RATING
+            count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
+
             count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
             count_result = count_query.count()
         except Exception as e:
@@ -7592,12 +7715,20 @@ class PositionMetricsManager(models.Model):
 
         # PositionEntered
         position_list_query = PositionEntered.objects.using('readonly').all()
+
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        position_list_query = position_list_query.exclude(stance__iexact=PERCENT_RATING)
+
         position_list_query = position_list_query.filter(final_position_filters)
 
         position_entered_count = position_list_query.count()
 
         # PositionForFriends
         position_list_query = PositionForFriends.objects.using('readonly').all()
+
+        # As of Aug 2018 we are no longer using PERCENT_RATING
+        position_list_query = position_list_query.exclude(stance__iexact=PERCENT_RATING)
+
         position_list_query = position_list_query.filter(final_position_filters)
 
         position_for_friends_count = position_list_query.count()

--- a/templates/voter_guide/voter_guide_list.html
+++ b/templates/voter_guide/voter_guide_list.html
@@ -46,7 +46,7 @@
 </ul>
 
 
-    <form name="voter_guide_choose_election" method="get" action="{% url 'voter_guide:voter_guide_list' %}">
+<form name="voter_guide_choose_election" method="get" action="{% url 'voter_guide:voter_guide_list' %}">
         {% csrf_token %}
 {% if election_list %}
     <select id="google_civic_election_id" name="google_civic_election_id">
@@ -68,13 +68,20 @@
     </label>
     &nbsp;&nbsp;&nbsp;&nbsp;
 
+    {# Default to excluding voter guides for individuals #}
+    <label for="show_individuals_id">
+      <input type="checkbox" name="show_individuals" id="show_individuals_id" value="1"
+             {% if show_individuals %}checked{% endif %} /> Show Individuals
+    </label>
+    &nbsp;&nbsp;&nbsp;&nbsp;
+
     {% if voter_guide_search %}
             <a href="{% url 'voter_guide:voter_guide_list' %}?google_civic_election_id={{ google_civic_election_id }}&show_all_elections={{ show_all_elections }}">
                  clear search</a>&nbsp;
         {% endif %}
     <input type="text" name="voter_guide_search" id="voter_guide_search_id" value="{{ voter_guide_search }}" />
     <input type="submit" value="Search for Voter Guides" />
-    </form>
+</form>
 
 <p></p>
 {% if voter_guide_list %}
@@ -145,6 +152,11 @@
     <br />
     <br />
     <script>
+    $(function() {
+        $('#show_individuals_id').change(function() {
+            this.form.submit();
+        });
+    });
     $(function() {
         $('#google_civic_election_id').change(function() {
             this.form.submit();

--- a/voter_guide/controllers.py
+++ b/voter_guide/controllers.py
@@ -1229,12 +1229,13 @@ def retrieve_voter_guides_to_follow_by_ballot_item(voter_id, kind_of_ballot_item
                     vote_smart_time_span=None,
                     organization_we_vote_id=one_position.organization_we_vote_id)
             else:
-                # vote_smart_time_span
-                results = voter_guide_manager.retrieve_voter_guide(
-                    voter_guide_id=0,
-                    google_civic_election_id=0,
-                    vote_smart_time_span=one_position.vote_smart_time_span,
-                    organization_we_vote_id=one_position.organization_we_vote_id)
+                results['voter_guide_found'] = False
+                # As of Aug 2018, we no longer use vote_smart_time_span
+                # results = voter_guide_manager.retrieve_voter_guide(
+                #     voter_guide_id=0,
+                #     google_civic_election_id=0,
+                #     vote_smart_time_span=one_position.vote_smart_time_span,
+                #     organization_we_vote_id=one_position.organization_we_vote_id)
 
         elif positive_value_exists(one_position.public_figure_we_vote_id):
             results['voter_guide_found'] = False
@@ -1412,64 +1413,67 @@ def retrieve_voter_guides_to_follow_by_election_for_api(voter_id, google_civic_e
         voter_guide_list_from_election_id = []
         list_from_election_id_found = False
 
-    # Second, retrieve the voter_guides stored by org & vote_smart_time_span
-    # All positions were found above with position_list_manager.retrieve_all_positions_for_election
-    # We give precedence to full voter guides from above, where we have an actual position of an org (as opposed to
-    # Vote Smart ratings)
-    maximum_number_of_guides_to_retrieve_by_time_span = \
-        maximum_number_to_retrieve - len(voter_guide_list_from_election_id)
-    if positive_value_exists(maximum_number_of_guides_to_retrieve_by_time_span):
-        org_list_found_by_time_span = []
-        orgs_we_need_found_by_position_and_time_span_list_of_dicts = []
-        for one_position in positions_list_minus_ignored_and_followed:
-            # If this was a position found that was based on vote_smart_time_span...
-            #  (That is, ignore the positions already retrieved based on google_civic_election_id)
-            if positive_value_exists(one_position.organization_we_vote_id) and \
-                    positive_value_exists(one_position.vote_smart_time_span):
-                # This shouldn't be possible, but we have it here for safety
-                org_found_by_election_id_above = one_position.organization_we_vote_id in \
-                    org_list_found_by_google_civic_election_id
-                # If we already recorded that we want to look for this org under a different time span...
-                org_found_by_different_time_span = one_position.organization_we_vote_id in \
-                    org_list_found_by_time_span
-                # Don't record that we want to look for a voter guide by this org we_vote_id or time span
-                if org_found_by_election_id_above or org_found_by_different_time_span:
-                    continue
+    # # Second, retrieve the voter_guides stored by org & vote_smart_time_span
+    # # All positions were found above with position_list_manager.retrieve_all_positions_for_election
+    # # We give precedence to full voter guides from above, where we have an actual position of an org (as opposed to
+    # # Vote Smart ratings)
+    # maximum_number_of_guides_to_retrieve_by_time_span = \
+    #     maximum_number_to_retrieve - len(voter_guide_list_from_election_id)
+    # if positive_value_exists(maximum_number_of_guides_to_retrieve_by_time_span):
+    #     org_list_found_by_time_span = []
+    #     orgs_we_need_found_by_position_and_time_span_list_of_dicts = []
+    #     for one_position in positions_list_minus_ignored_and_followed:
+    #         # If this was a position found that was based on vote_smart_time_span...
+    #         #  (That is, ignore the positions already retrieved based on google_civic_election_id)
+    #         if positive_value_exists(one_position.organization_we_vote_id) and \
+    #                 positive_value_exists(one_position.vote_smart_time_span):
+    #             # This shouldn't be possible, but we have it here for safety
+    #             org_found_by_election_id_above = one_position.organization_we_vote_id in \
+    #                 org_list_found_by_google_civic_election_id
+    #             # If we already recorded that we want to look for this org under a different time span...
+    #             org_found_by_different_time_span = one_position.organization_we_vote_id in \
+    #                 org_list_found_by_time_span
+    #             # Don't record that we want to look for a voter guide by this org we_vote_id or time span
+    #             if org_found_by_election_id_above or org_found_by_different_time_span:
+    #                 continue
+    #
+    #             org_list_found_by_time_span.append(one_position.organization_we_vote_id)
+    #             one_position_dict = {'organization_we_vote_id': one_position.organization_we_vote_id,
+    #                                  'vote_smart_time_span': one_position.vote_smart_time_span}
+    #             orgs_we_need_found_by_position_and_time_span_list_of_dicts.append(one_position_dict)
+    #
+    #     voter_guide_time_span_results = voter_guide_list_manager.retrieve_voter_guides_to_follow_by_time_span(
+    #         orgs_we_need_found_by_position_and_time_span_list_of_dicts,
+    #         search_string,
+    #         maximum_number_of_guides_to_retrieve_by_time_span, sort_by, sort_order)
+    #
+    #     if voter_guide_time_span_results['voter_guide_list_found']:
+    #         voter_guide_list_from_time_span = voter_guide_time_span_results['voter_guide_list']
+    #         list_from_time_span_found = True
+    #     else:
+    #         voter_guide_list_from_time_span = []
+    #         list_from_time_span_found = False
+    # else:
+    #     voter_guide_list_from_time_span = []
+    #     list_from_time_span_found = False
+    #
+    # # Merge these two lists
+    # if list_from_election_id_found and list_from_time_span_found:
+    #     voter_guide_list = list(chain(voter_guide_list_from_election_id, voter_guide_list_from_time_span))
+    # elif list_from_election_id_found:
+    #     voter_guide_list = list(voter_guide_list_from_election_id)
+    # elif list_from_time_span_found:
+    #     voter_guide_list = list(voter_guide_list_from_time_span)
+    # else:
+    #     voter_guide_list = []
+    # # IFF we wanted to sort here:
+    # # voter_guide_list = sorted(
+    # #     chain(voter_guide_list_from_election_id, voter_guide_list_from_time_span),
+    # #     key=attrgetter(sort_by))
+    # # But we don't, we just want to combine them with existing order
 
-                org_list_found_by_time_span.append(one_position.organization_we_vote_id)
-                one_position_dict = {'organization_we_vote_id': one_position.organization_we_vote_id,
-                                     'vote_smart_time_span': one_position.vote_smart_time_span}
-                orgs_we_need_found_by_position_and_time_span_list_of_dicts.append(one_position_dict)
-
-        voter_guide_time_span_results = voter_guide_list_manager.retrieve_voter_guides_to_follow_by_time_span(
-            orgs_we_need_found_by_position_and_time_span_list_of_dicts,
-            search_string,
-            maximum_number_of_guides_to_retrieve_by_time_span, sort_by, sort_order)
-
-        if voter_guide_time_span_results['voter_guide_list_found']:
-            voter_guide_list_from_time_span = voter_guide_time_span_results['voter_guide_list']
-            list_from_time_span_found = True
-        else:
-            voter_guide_list_from_time_span = []
-            list_from_time_span_found = False
-    else:
-        voter_guide_list_from_time_span = []
-        list_from_time_span_found = False
-
-    # Merge these two lists
-    if list_from_election_id_found and list_from_time_span_found:
-        voter_guide_list = list(chain(voter_guide_list_from_election_id, voter_guide_list_from_time_span))
-    elif list_from_election_id_found:
-        voter_guide_list = list(voter_guide_list_from_election_id)
-    elif list_from_time_span_found:
-        voter_guide_list = list(voter_guide_list_from_time_span)
-    else:
-        voter_guide_list = []
-    # IFF we wanted to sort here:
-    # voter_guide_list = sorted(
-    #     chain(voter_guide_list_from_election_id, voter_guide_list_from_time_span),
-    #     key=attrgetter(sort_by))
-    # But we don't, we just want to combine them with existing order
+    # Since we turned off using voter guides from time spans
+    voter_guide_list = list(voter_guide_list_from_election_id)
 
     status += 'SUCCESSFUL_RETRIEVE_OF_VOTER_GUIDES_BY_ELECTION '
     success = True
@@ -1553,7 +1557,7 @@ def retrieve_voter_guides_to_follow_generic_for_api(voter_id, search_string, fil
     filter_voter_guides_by_issue = positive_value_exists(filter_voter_guides_by_issue)
     voter_guide_list_found = False
 
-    # Start with orgs followed and ignored by this voter
+    # Start with organizations followed and ignored by this voter
     return_we_vote_id = True
     follow_organization_list_manager = FollowOrganizationList()
     if positive_value_exists(search_string):

--- a/voter_guide/urls.py
+++ b/voter_guide/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     url(r'^import/$',
         views_admin.voter_guides_import_from_master_server_view,
         name='voter_guides_import_from_master_server'),
+    url(r'^label/', views_admin.label_vote_smart_voter_guides_view, name='label_vote_smart_voter_guides'),
     url(r'^possibility_list/', views_admin.voter_guide_possibility_list_view, name='voter_guide_possibility_list', ),
     url(r'^refresh/', views_admin.refresh_existing_voter_guides_view, name='refresh_existing_voter_guides'),
     url(r'^search/', views_admin.voter_guide_search_view, name='voter_guide_search'),


### PR DESCRIPTION
Exclude all PERCENT_RATING entries (from Vote Smart). We want to move exclusively to support/oppose/info_only. We also label prior voter guides that are "vote_smart_ratings_only" so we can avoid retrieving them.