### PR TITLE
Replace Facebook "screen scrape for picture" with an API call

### DIFF
--- a/admin_tools/views.py
+++ b/admin_tools/views.py
@@ -1794,10 +1794,10 @@ def redirect_to_sign_in_page(request, authority_required={}):
     authority_required_text = ''
     for each_authority in authority_required:
         if each_authority == 'admin':
-            authority_required_text += 'or ' if len(authority_required_text) > 0 else ''
+            authority_required_text += ' or ' if len(authority_required_text) > 0 else ''
             authority_required_text += 'has Admin rights'
         if each_authority == 'verified_volunteer':
-            authority_required_text += 'or ' if len(authority_required_text) > 0 else ''
+            authority_required_text += ' or ' if len(authority_required_text) > 0 else ''
             authority_required_text += 'has Verified Volunteer rights'
     error_message = "You must sign in with account that " \
                     "{authority_required_text} to see that page." \

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -541,6 +541,7 @@ def candidate_new_view(request):
     ballot_guide_official_statement = request.GET.get('ballot_guide_official_statement', "")
     vote_smart_id = request.GET.get('vote_smart_id', "")
     maplight_id = request.GET.get('maplight_id', "")
+    page = request.GET.get('page', 0)
     politician_we_vote_id = request.GET.get('politician_we_vote_id', "")
 
     # These are the Offices already entered for this election
@@ -590,6 +591,7 @@ def candidate_new_view(request):
         'ballot_guide_official_statement':  ballot_guide_official_statement,
         'vote_smart_id':                    vote_smart_id,
         'maplight_id':                      maplight_id,
+        'page':                             page,
         'politician_we_vote_id':            politician_we_vote_id,
     }
     return render(request, 'candidate/candidate_edit.html', template_values)
@@ -621,6 +623,7 @@ def candidate_edit_view(request, candidate_id=0, candidate_campaign_we_vote_id="
     ballotpedia_race_id = request.GET.get('ballotpedia_race_id', False)
     vote_smart_id = request.GET.get('vote_smart_id', False)
     maplight_id = request.GET.get('maplight_id', False)
+    page = request.GET.get('page', 0)
     state_code = request.GET.get('state_code', "")
     show_all_google_search_users = request.GET.get('show_all_google_search_users', False)
     show_all_twitter_search_results = request.GET.get('show_all_twitter_search_results', False)
@@ -744,6 +747,7 @@ def candidate_edit_view(request, candidate_id=0, candidate_campaign_we_vote_id="
             'ballotpedia_race_id':              ballotpedia_race_id,
             'vote_smart_id':                    vote_smart_id,
             'maplight_id':                      maplight_id,
+            'page':                             page,
         }
     else:
         template_values = {

--- a/import_export_facebook/urls.py
+++ b/import_export_facebook/urls.py
@@ -10,6 +10,6 @@ from . import views, views_admin
 urlpatterns = [
     url(r'^bulk_retrieve_facebook_photos/$',
         views_admin.bulk_retrieve_facebook_photos_view, name='bulk_retrieve_facebook_photos', ),
-    url(r'^scrape_and_save_facebook_photo/$',
-        views_admin.scrape_and_save_facebook_photo_view, name='scrape_and_save_facebook_photo', ),
+    url(r'^get_and_save_facebook_photo/$',
+        views_admin.get_and_save_facebook_photo_view, name='get_and_save_facebook_photo', ),
 ]

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -8,7 +8,7 @@
 <style>
 span.wrap_word { word-break: break-word; }
 </style>
-<a href="{% url 'candidate:candidate_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+<a href="{% url 'candidate:candidate_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&page={{ page }}">
     < Back to Candidates</a>
 
 <h1>{% if candidate %}Edit Candidate "{{ candidate.candidate_name }}"{% else %}New Candidate{% endif %}</h1>
@@ -295,7 +295,7 @@ span.wrap_word { word-break: break-word; }
         <input type="text" name="facebook_url" id="facebook_url_id" class="form-control"
                value="{% if candidate %}{{ candidate.facebook_url|default_if_none:"" }}{% else %}{{ facebook_url|default_if_none:"" }}{% endif %}" />
       {% if candidate.facebook_url %}
-      <a href="{% url 'import_export_facebook:scrape_and_save_facebook_photo' %}?candidate_we_vote_id={{ candidate.we_vote_id }}&google_civic_election_id={{ google_civic_election_id }}">
+      <a href="{% url 'import_export_facebook:get_and_save_facebook_photo' %}?candidate_we_vote_id={{ candidate.we_vote_id }}&google_civic_election_id={{ google_civic_election_id }}&page={{ page }}">
             Refresh Facebook Photo</a>
           {% if candidate.facebook_url_is_broken %}
             <b> &nbsp;&nbsp; The previous attempt at getting a photo from this link failed, it may be a broken link</b>

--- a/templates/candidate/candidate_list.html
+++ b/templates/candidate/candidate_list.html
@@ -298,7 +298,7 @@
                 <td>{{ forloop.counter|add:candidate_count_start }}</td>
                 <td>
                     {% if candidate.candidate_photo_url %}
-                    <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}"
+                    <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&page={{ current_page_number }}"
                        target="_blank">
                         <img src='{{ candidate.candidate_photo_url }}' height="25px" />
                     </a>
@@ -306,7 +306,7 @@
                 </td>
                 <td>
                 <span class="u-no-break">
-                  <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}"
+                  <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&page={{ current_page_number }}"
                      target="_blank">{{ candidate.candidate_name }}</a>
                 </span>
                 <br />
@@ -460,14 +460,14 @@
                 <td>{{ forloop.counter|add:candidate_count_start }}</td>
                 <td>
                     {% if candidate.candidate_photo_url %}
-                    <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}"
+                    <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&page={{ current_page_number }}"
                        target="_blank">
                         <img src='{{ candidate.candidate_photo_url }}' height="25px" />
                     </a>
                     {% endif %}
                 </td>
                 <td>
-                  <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}"
+                  <a href="{% url 'candidate:candidate_edit' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&page={{ current_page_number }}"
                      target="_blank">{{ candidate.candidate_name }}</a><br />
                   {{ candidate.we_vote_id }}
                     {% if candidate.politician_we_vote_id %}
@@ -491,7 +491,7 @@
                 {% endif %}
                 <td>
                   {% if candidate.office %}
-                    <a href="{% url 'office:office_summary' candidate.office.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">{{ candidate.office.office_name }}
+                    <a href="{% url 'office:office_summary' candidate.office.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&page={{ current_page_number }}">{{ candidate.office.office_name }}
                     {% if candidate.office.district_id %}
                         - District {{ candidate.office.district_id }}
                     {% endif %}


### PR DESCRIPTION
resolves wevote/WeVoteServer/issues/869
Changes at Facebook made screen scraping very impractical.
In admin_tools/views.py, fixed a typo in a status message.
In candidate/views_admin.py, pass around the number of the page we came
from so we can go back there after viewing a candidate detail edit page.
In import_export_facebook/controllers.py change the screen scraper to an
api based method.
In candidate/urls.py, rename the scrape method to "get" from GraphAPI
In candidate/views_admin.py, rename the scrape method to "get" from
GraphAPI and fix the status message to display success/failure.
In templates/candidate/candidate_edit.html and candidate_list.html,
pass around the number of the page we came from.