### PR TITLE
Second change that should avoid a http 400 on Stripe /v1/plans

### DIFF
--- a/donate/models.py
+++ b/donate/models.py
@@ -276,6 +276,10 @@ class DonationManager(models.Model):
                 currency="usd",
                 nickname=recurring_donation_plan_id,
                 id=recurring_donation_plan_id,
+                product={
+                    "name": recurring_donation_plan_id,
+                    "type": "service"
+                },
             )
             if plan.id:
                 success = True


### PR DESCRIPTION
A dummy product field is now required.
No idea why this did not show up in the testing I did with the test api.