### PR TITLE
Possible fix to today's Django CSRF issue with /vg/create

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -285,6 +285,9 @@ CORS_ALLOW_CREDENTIALS = True
 # specify whether to replace the HTTP_REFERER header if CORS checks pass so that CSRF django middleware checks
 # will work with https
 CORS_REPLACE_HTTPS_REFERER = True
+CSRF_TRUSTED_ORIGINS = (
+    'api.wevoteusa.org'
+)
 
 # CORS_ORIGIN_WHITELIST = (
 #     'google.com',


### PR DESCRIPTION
This change should (at worst) be harmless, and hopefully will resolve this error (from Splunk):
[2019-03-15 14:59:12 -0700] [21901] [DEBUG] POST /vg/create_process/
Forbidden (Referer checking failed - https://api.wevoteusa.org/vg/create/?google_civic_election_id=0 does not match any trusted origins.): /vg/create_process/
host =	api-3