### PR TITLE
Fix for one of the errors we are seeing on the create voter guide page. Removing this IMPORT_BALLOT_ITEM check for polling location allows us to batch import ballot items.

### DIFF
--- a/import_export_batches/views_admin.py
+++ b/import_export_batches/views_admin.py
@@ -230,18 +230,18 @@ def batch_list_process_view(request):
                                     "&batch_uri=" + batch_uri_encoded)
 
     # Make sure we have a polling_location_we_vote_id
-    if kind_of_batch in IMPORT_BALLOT_ITEM and not positive_value_exists(polling_location_we_vote_id):
-        messages.add_message(request, messages.ERROR, 'This kind_of_batch (\"{kind_of_batch}\") requires you '
-                                                      'to choose a polling location.'
-                                                      ''.format(kind_of_batch=kind_of_batch))
-        return HttpResponseRedirect(reverse('import_export_batches:batch_list', args=()) +
-                                    "?kind_of_batch=" + str(kind_of_batch) +
-                                    "&polling_location_we_vote_id=" + str(polling_location_we_vote_id) +
-                                    "&google_civic_election_id=" + str(google_civic_election_id) +
-                                    "&polling_location_city=" + str(polling_location_city) +
-                                    "&polling_location_zip=" + str(polling_location_zip) +
-                                    "&show_all_elections=" + str(show_all_elections) +
-                                    "&batch_uri=" + batch_uri_encoded)
+    # if kind_of_batch in IMPORT_BALLOT_ITEM and not positive_value_exists(polling_location_we_vote_id):
+    #     messages.add_message(request, messages.ERROR, 'This kind_of_batch (\"{kind_of_batch}\") requires you '
+    #                                                   'to choose a polling location.'
+    #                                                   ''.format(kind_of_batch=kind_of_batch))
+    #     return HttpResponseRedirect(reverse('import_export_batches:batch_list', args=()) +
+    #                                 "?kind_of_batch=" + str(kind_of_batch) +
+    #                                 "&polling_location_we_vote_id=" + str(polling_location_we_vote_id) +
+    #                                 "&google_civic_election_id=" + str(google_civic_election_id) +
+    #                                 "&polling_location_city=" + str(polling_location_city) +
+    #                                 "&polling_location_zip=" + str(polling_location_zip) +
+    #                                 "&show_all_elections=" + str(show_all_elections) +
+    #                                 "&batch_uri=" + batch_uri_encoded)
 
     election_name = ""  # For printing status
     if positive_value_exists(google_civic_election_id):

--- a/voter_guide/views_admin.py
+++ b/voter_guide/views_admin.py
@@ -220,7 +220,8 @@ def voter_guide_create_view(request):
 
     # Take in these values, even though they will be overwritten if we've stored a voter_guide_possibility
     ballot_items_raw = request.GET.get('ballot_items_raw', "")
-    candidates_missing_from_we_vote = request.GET.get('candidates_missing_from_we_vote', "")
+    candidates_missing_from_we_vote = request.GET.get('candidates_missing_from_we_vote', False)
+    candidates_missing_from_we_vote = positive_value_exists(candidates_missing_from_we_vote)
     cannot_find_endorsements = request.GET.get('cannot_find_endorsements', False)
     capture_detailed_comments = request.GET.get('capture_detailed_comments ', False)
     clear_organization_options = request.GET.get('clear_organization_options', False)
@@ -531,7 +532,8 @@ def voter_guide_create_process_view(request):
     all_done_with_entry = request.POST.get('all_done_with_entry', 0)
     ballot_items_raw = request.POST.get('ballot_items_raw', "")
     ballot_items_additional = request.POST.get('ballot_items_additional', "")
-    candidates_missing_from_we_vote = request.POST.get('candidates_missing_from_we_vote', "")
+    candidates_missing_from_we_vote = request.POST.get('candidates_missing_from_we_vote', False)
+    candidates_missing_from_we_vote = positive_value_exists(candidates_missing_from_we_vote)
     cannot_find_endorsements = request.POST.get('cannot_find_endorsements', False)
     capture_detailed_comments = request.POST.get('capture_detailed_comments', False)
     clear_organization_options = request.POST.get('clear_organization_options', 0)


### PR DESCRIPTION
Fix for one of the errors we are seeing on the create voter guide page. Removing this IMPORT_BALLOT_ITEM check for polling location allows us to batch import ballot items.