### PR TITLE
Upgrading facebook-api library from v2.0 to v3.1

### DIFF
--- a/admin_tools/views.py
+++ b/admin_tools/views.py
@@ -1801,8 +1801,8 @@ def redirect_to_sign_in_page(request, authority_required={}):
             authority_required_text += ' or ' if len(authority_required_text) > 0 else ''
             authority_required_text += 'has Verified Volunteer rights'
     error_message = "You must sign in with account that {authority_required_text} to see that page. " \
-                    "<b>There is a known bug with this check, if you think this message is wrong, Sign Out and try " \
-                    "again.</b>".format(authority_required_text=authority_required_text)
+                    "-- NOTE: There is a known bug with this check, if you think this message is wrong, Sign Out and try " \
+                    "again".format(authority_required_text=authority_required_text)
 
     messages.add_message(request, messages.ERROR, error_message)
 

--- a/admin_tools/views.py
+++ b/admin_tools/views.py
@@ -2,7 +2,7 @@
 # Brought to you by We Vote. Be good.
 # -*- coding: UTF-8 -*-
 
-from config.base import get_environment_variable, LOGIN_URL
+from config.base import get_environment_variable, get_python_version, LOGIN_URL
 from ballot.models import BallotReturned, VoterBallotSaved
 from candidate.models import CandidateCampaign, CandidateCampaignManager
 from candidate.controllers import candidates_import_from_sample_file
@@ -91,6 +91,7 @@ def admin_home_view(request):
         'voter_email_accounts_count':       voter_email_accounts_count,
         'voter_address_basic_count':        voter_address_basic_count,
         'voter_address_full_address_count': voter_address_full_address_count,
+        'python_version':                   get_python_version(),
     }
     response = render(request, 'admin_tools/index.html', template_values)
 

--- a/config/base.py
+++ b/config/base.py
@@ -53,6 +53,12 @@ def get_environment_variable_default(var_name, default_value):
         return default_value
 
 
+def get_python_version():
+    version = os.popen('python --version').read()
+    print(version)    # Something like 'Python 3.7.2'
+    return version
+
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/image/controllers.py
+++ b/image/controllers.py
@@ -803,7 +803,7 @@ def retrieve_facebook_image_url(facebook_user_id):
     }
     facebook_manager = FacebookManager()
 
-    get_url = "https://graph.facebook.com/v2.8/{facebook_user_id}/picture?width=200&height=200"\
+    get_url = "https://graph.facebook.com/v3.1/{facebook_user_id}/picture?width=200&height=200"\
         .format(facebook_user_id=facebook_user_id)
     response = requests.get(get_url)
     if response.status_code == HTTP_OK:

--- a/import_export_facebook/models.py
+++ b/import_export_facebook/models.py
@@ -846,7 +846,7 @@ class FacebookManager(models.Model):
 
         facebook_auth_response = auth_response_results['facebook_auth_response']
         try:
-            facebook_graph = facebook.GraphAPI(facebook_auth_response.facebook_access_token, version='2.7')
+            facebook_graph = facebook.GraphAPI(facebook_auth_response.facebook_access_token, version='3.1')
             facebook_friends_api_details = facebook_graph.get_connections(id=facebook_auth_response.facebook_user_id,
                                                                           connection_name="friends",
                                                                           fields=facebook_api_fields)
@@ -1038,7 +1038,7 @@ class FacebookManager(models.Model):
 
         facebook_auth_response = auth_response_results['facebook_auth_response']
         try:
-            facebook_graph = facebook.GraphAPI(facebook_auth_response.facebook_access_token, version='2.7')
+            facebook_graph = facebook.GraphAPI(facebook_auth_response.facebook_access_token, version='3.1')
             facebook_user_api_details = facebook_graph.get_object(id=facebook_user_name,
                                                                   fields=facebook_api_fields)
             facebook_user_details_dict = self.extract_facebook_user_details(facebook_user_api_details)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-twitter-bootstrap==3.3.0
 django-user_agents==0.3.2
 djangorestframework==3.9.1
 elasticsearch>=1.0.0,<2.0.0
-facebook-sdk==2.0.0
+facebook-sdk==3.1.0
 future==0.16.0
 geoip2==2.9.0
 geopy==1.14.0

--- a/templates/admin_tools/index.html
+++ b/templates/admin_tools/index.html
@@ -65,4 +65,14 @@
             <a href="{% url 'logout_we_vote' %}?next={{ request.path }}">Logout</a>
     </p>
     {% endif %}
+
+<br>
+<br>
+<br>
+{# ################## #}
+<h4>Technical Information</h4>
+<p>
+    Running: {{ python_version }}
+</p>
+
 {%  endblock %}


### PR DESCRIPTION
The latest Facebook SDK on their API servers is 3.3, but a corresponding
Python facebook-api library is not yet in general release.