### PR TITLE
prefix link with http or https if necessary

### DIFF
--- a/templates/voter_guide/voter_guide_create.html
+++ b/templates/voter_guide/voter_guide_create.html
@@ -71,9 +71,35 @@
     <label for="voter_guide_possibility_url_id" class="col-sm-3 control-label">
     {% if voter_guide_possibility_url %}
         Link to voter guide&nbsp;
-        <a href="{{ voter_guide_possibility_url }}"
-           target="_blank"
-           class="u-no-break"><span class="glyphicon glyphicon-new-window"></span></a>
+        <a id="link_to_voter_guide"
+           class="u-no-break"><span class="glyphicon glyphicon-new-window" style="color: #337ab7"></span></a>
+
+        <script>
+        $(function() {
+            $('a#link_to_voter_guide').click(function() {
+                const url = "{{ voter_guide_possibility_url }}";
+                if (url.startsWith("http")) {
+                    window.open(url, '_blank');
+                    return;
+                }
+
+                const httpUrl = "http://" + url
+                $.ajax({
+                    type: "GET",
+                    url: httpUrl,
+                    data: "",
+                    success: function() {
+                        window.open(httpUrl, '_blank');
+                    },
+                    error: function(XMLHttpRequest, textStatus, errorThrown) {
+                        window.open("https://" + url, '_blank');
+                    }
+                });
+
+            });
+        });
+        </script>
+
     {% else %}
         Paste link to voter guide
     {% endif %}


### PR DESCRIPTION
Address https://github.com/wevote/WeVoteServer/issues/1049 by prefixing a url with http or https as necessary. The prefixing occurs after the voter guide link page has been created; another way to go might be to add the prefix when the voter guide link page is being created.

Tried to keep within the general stylistic approach of existing code, but please let me know if not.  Also removing the 'href' from the link changed the color of the glyph to black and I hard-coded it back to blue--not sure that was kosher.