### PR TITLE
Added siteConfigurationRetrieve API so we can activate configurations when voters visit client sites. Now importing ballotpedia_is_marquee value. Added is_battleground_race field to Office table to help Political Data team. Added MasterFeaturePackage donate table to centralize the features_provided_bitmap settings for each package (ex/ Professional vs. Enterprise) Showing number of offices in each state on office_list Admin page.

### DIFF
--- a/apis_v1/documentation_source/organization_save_doc.py
+++ b/apis_v1/documentation_source/organization_save_doc.py
@@ -55,9 +55,9 @@ def organization_save_doc_template_values(url_root):
                             'It is changed by a client in Settings section.',
         },
         {
-            'name':         'chosen_logo_displayed',
+            'name':         'chosen_hide_we_vote_logo',
             'value':        'boolean',  # boolean, integer, long, string
-            'description':  'The client wants to show their own logo instead of the default. '
+            'description':  'The client wants to hide the default logo. '
                             'It is changed by a client in Settings section.',
         },
         {

--- a/apis_v1/documentation_source/site_configuration_retrieve_doc.py
+++ b/apis_v1/documentation_source/site_configuration_retrieve_doc.py
@@ -1,0 +1,72 @@
+# apis_v1/documentation_source/site_configuration_retrieve_doc.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+
+
+def site_configuration_retrieve_doc_template_values(url_root):
+    """
+    Show documentation about siteConfigurationRetrieve
+    """
+    required_query_parameter_list = [
+        {
+            'name':         'api_key',
+            'value':        'string (from post, cookie, or get (in that order))',  # boolean, integer, long, string
+            'description':  'The unique key provided to any organization using the WeVoteServer APIs',
+        },
+        {
+            'name':         'hostname',
+            'value':        'string',  # boolean, integer, long, string
+            'description':  'The URL that the voter is visiting.',
+        },
+    ]
+    optional_query_parameter_list = [
+        # {
+        #     'name':         '',
+        #     'value':        '',  # boolean, integer, long, string
+        #     'description':  '',
+        # },
+    ]
+
+    potential_status_codes_list = [
+        {
+            'code':         'ORGANIZATION_FOUND_WITH_ID',
+            'description':  'The organization was found using the internal id',
+        },
+    ]
+    try_now_link_variables_dict = {
+        'hostname': 'localhost',
+    }
+
+    # Changes made here should also be made in organizations_followed_retrieved
+    api_response = '{\n' \
+                   '  "success": boolean,\n' \
+                   '  "status": string,\n' \
+                   '  "organization_description": string,\n' \
+                   '  "organization_email": string,\n' \
+                   '  "organization_facebook": string,\n' \
+                   '  "organization_id": integer (the id of the organization found),\n' \
+                   '  "organization_name": string (value from Google),\n' \
+                   '  "organization_photo_url_large": string,\n' \
+                   '  "organization_photo_url_medium": string,\n' \
+                   '  "organization_photo_url_tiny": string,\n' \
+                   '  "organization_twitter_handle": string (twitter address),\n' \
+                   '  "organization_we_vote_id": string (the organization identifier that moves server-to-server),\n' \
+                   '}'
+
+    template_values = {
+        'api_name': 'siteConfigurationRetrieve',
+        'api_slug': 'siteConfigurationRetrieve',
+        'api_introduction':
+            "Retrieve the private label settings as configured by this organization.",
+        'try_now_link': 'apis_v1:siteConfigurationRetrieveView',
+        'try_now_link_variables_dict': try_now_link_variables_dict,
+        'url_root': url_root,
+        'get_or_post': 'GET',
+        'required_query_parameter_list': required_query_parameter_list,
+        'optional_query_parameter_list': optional_query_parameter_list,
+        'api_response': api_response,
+        'api_response_notes':
+            "",
+        'potential_status_codes_list': potential_status_codes_list,
+    }
+    return template_values

--- a/apis_v1/documentation_source/site_configuration_retrieve_doc.py
+++ b/apis_v1/documentation_source/site_configuration_retrieve_doc.py
@@ -37,19 +37,13 @@ def site_configuration_retrieve_doc_template_values(url_root):
         'hostname': 'localhost',
     }
 
-    # Changes made here should also be made in organizations_followed_retrieved
     api_response = '{\n' \
                    '  "success": boolean,\n' \
                    '  "status": string,\n' \
-                   '  "organization_description": string,\n' \
-                   '  "organization_email": string,\n' \
-                   '  "organization_facebook": string,\n' \
-                   '  "organization_id": integer (the id of the organization found),\n' \
-                   '  "organization_name": string (value from Google),\n' \
-                   '  "organization_photo_url_large": string,\n' \
-                   '  "organization_photo_url_medium": string,\n' \
-                   '  "organization_photo_url_tiny": string,\n' \
-                   '  "organization_twitter_handle": string (twitter address),\n' \
+                   '  "chosen_hide_we_vote_logo": boolean,\n' \
+                   '  "chosen_logo_url_https": string,\n' \
+                   '  "features_provided_bitmap": integer,\n' \
+                   '  "hostname": string,\n' \
                    '  "organization_we_vote_id": string (the organization identifier that moves server-to-server),\n' \
                    '}'
 

--- a/apis_v1/urls.py
+++ b/apis_v1/urls.py
@@ -133,6 +133,8 @@ urlpatterns = [
         views_position.position_support_count_for_ballot_item_view, name='positionSupportCountForBallotItemView'),
     url(r'^quickInfoRetrieve/', views_misc.quick_info_retrieve_view, name='quickInfoRetrieveView'),
     url(r'^retrieveIssuesToFollow/', retrieve_issues_to_follow_view, name='retrieveIssuesToFollowView'),
+    url(r'^siteConfigurationRetrieve/',
+        views_organization.site_configuration_retrieve_view, name='siteConfigurationRetrieveView'),
     url(r'^saveAnalyticsAction/', views_analytics.save_analytics_action_view, name='saveAnalyticsActionView'),
     url(r'^searchAll/', views_misc.search_all_view, name='searchAllView'),
 
@@ -353,6 +355,8 @@ urlpatterns = [
         name='retrieveIssuesToFollowDocs'),
     url(r'^docs/saveAnalyticsAction/$',
         views_docs.save_analytics_action_doc_view, name='saveAnalyticsActionDocs'),
+    url(r'^docs/siteConfigurationRetrieve/$',
+        views_docs.site_configuration_retrieve_doc_view, name='siteConfigurationRetrieveDocs'),
     url(r'^docs/searchAll/$',
         views_docs.search_all_doc_view, name='searchAllDocs'),
     url(r'^docs/twitterIdentityRetrieve/$',

--- a/apis_v1/views/views_docs.py
+++ b/apis_v1/views/views_docs.py
@@ -29,7 +29,7 @@ from apis_v1.documentation_source import all_ballot_items_retrieve_doc, ballot_i
     position_public_support_count_for_ballot_item_doc, position_support_count_for_ballot_item_doc, \
     positions_count_for_all_ballot_items_doc, positions_count_for_one_ballot_item_doc, \
     quick_info_retrieve_doc, retrieve_issues_to_follow_doc, \
-    save_analytics_action_doc, search_all_doc, twitter_identity_retrieve_doc, \
+    save_analytics_action_doc, search_all_doc, site_configuration_retrieve_doc, twitter_identity_retrieve_doc, \
     twitter_sign_in_request_access_token_doc, twitter_sign_in_request_voter_info_doc, twitter_sign_in_retrieve_doc, \
     twitter_sign_in_start_doc, twitter_retrieve_ids_i_follow_doc, voter_address_retrieve_doc, voter_address_save_doc, \
     voter_all_positions_retrieve_doc, voter_all_bookmarks_status_retrieve_doc, \
@@ -728,6 +728,16 @@ def search_all_doc_view(request):
     url_root = WE_VOTE_SERVER_ROOT_URL
     template_values = search_all_doc.\
         search_all_doc_template_values(url_root)
+    template_values['voter_api_device_id'] = get_voter_api_device_id(request)
+    return render(request, 'apis_v1/api_doc_page.html', template_values)
+
+
+def site_configuration_retrieve_doc_view(request):
+    """
+    Show documentation about siteConfigurationRetrieve
+    """
+    url_root = WE_VOTE_SERVER_ROOT_URL
+    template_values = site_configuration_retrieve_doc.site_configuration_retrieve_doc_template_values(url_root)
     template_values['voter_api_device_id'] = get_voter_api_device_id(request)
     return render(request, 'apis_v1/api_doc_page.html', template_values)
 

--- a/apis_v1/views/views_donation.py
+++ b/apis_v1/views/views_donation.py
@@ -268,6 +268,7 @@ def create_new_plan_for_api_view(request):
     monthly_price_stripe = monthly_price_stripe if monthly_price_stripe != '' else 0
     annual_price_stripe = request.GET.get('annualPriceStripe')
     annual_price_stripe = annual_price_stripe if annual_price_stripe != '' else 0
+    master_feature_package = request.GET.get('masterFeatureType')
     features_provided_bitmap = request.GET.get('featuresProvidedBitmap')
     coupon_expires_date = request.GET.get('couponExpiresDate', None)
     if len(coupon_expires_date) is 0:
@@ -285,6 +286,7 @@ def create_new_plan_for_api_view(request):
             coupon_applied_message=coupon_applied_message,
             monthly_price_stripe=monthly_price_stripe,
             annual_price_stripe=annual_price_stripe,
+            master_feature_package=master_feature_package,
             features_provided_bitmap=features_provided_bitmap,
             coupon_expires_date=coupon_expires_date)
         status = "create_new_plan_for_api_view succeeded"

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -233,18 +233,22 @@ def candidate_list_view(request):
     state_code = request.GET.get('state_code', '')
     state_list = STATE_CODE_MAP
     state_list_modified = {}
-    if positive_value_exists(google_civic_election_id):
-        candidate_campaign_list_manager = CandidateCampaignListManager()
-        for one_state_code, one_state_name in state_list.items():
-            count_result = candidate_campaign_list_manager.retrieve_candidate_count_for_election_and_state(
-                google_civic_election_id, one_state_code)
-            state_name_modified = one_state_name
-            if positive_value_exists(count_result['candidate_count']):
-                state_name_modified += " - " + str(count_result['candidate_count'])
+    candidate_campaign_list_manager = CandidateCampaignListManager()
+    for one_state_code, one_state_name in state_list.items():
+        count_result = candidate_campaign_list_manager.retrieve_candidate_count_for_election_and_state(
+            google_civic_election_id, one_state_code)
+        state_name_modified = one_state_name
+        if positive_value_exists(count_result['candidate_count']):
+            state_name_modified += " - " + str(count_result['candidate_count'])
             state_list_modified[one_state_code] = state_name_modified
-        sorted_state_list = sorted(state_list_modified.items())
-    else:
-        sorted_state_list = sorted(state_list.items())
+        else:
+            # Do not include state in drop-down if there aren't any candidates in that state
+            pass
+    sorted_state_list = sorted(state_list_modified.items())
+    # if positive_value_exists(google_civic_election_id):
+    #     pass
+    # else:
+    #     sorted_state_list = sorted(state_list.items())
 
     show_all = request.GET.get('show_all', False)
     show_all_elections = request.GET.get('show_all_elections', False)

--- a/donate/urls.py
+++ b/donate/urls.py
@@ -1,4 +1,4 @@
-# scheduled_tasks/urls.py
+# donate/urls.py
 # Brought to you by We Vote. Be good.
 # -*- coding: UTF-8 -*-
 

--- a/donate/views_admin.py
+++ b/donate/views_admin.py
@@ -1,4 +1,4 @@
-# scheduled_tasks/views_admin.py
+# donate/views_admin.py
 # Brought to you by We Vote. Be good.
 # -*- coding: UTF-8 -*-
 
@@ -50,6 +50,7 @@ def organization_subscription_list_view(request):
             'monthly_price_stripe': monthly_price_stripe,
             'annual_price_stripe': annual_price_stripe,
             'redemptions': plan.redemptions,
+            'master_feature_package': plan.master_feature_package,
             'features_provided_bitmap': plan.features_provided_bitmap,
             'plan_created_at': nice_created_at,
             'coupon_expires_date': nice_expires_dt

--- a/import_export_ballotpedia/controllers.py
+++ b/import_export_ballotpedia/controllers.py
@@ -1225,6 +1225,7 @@ def groom_ballotpedia_data_for_processing(structured_json, google_civic_election
                             # Add our own key/value pairs
                             # root level
                             one_office_json['ballotpedia_race_id'] = one_office_json['id']
+                            one_office_json['ballotpedia_is_marquee'] = one_office_json['is_marquee']
                             # office
                             one_office_json['ballotpedia_district_id'] = inner_office_json['district']
                             one_office_json['ballotpedia_office_id'] = inner_office_json['id']

--- a/import_export_batches/controllers.py
+++ b/import_export_batches/controllers.py
@@ -937,6 +937,8 @@ def create_batch_row_action_contest_office(batch_description, batch_header_map, 
                                                                           one_batch_row)
     ballotpedia_election_id = batch_manager.retrieve_value_from_batch_row("ballotpedia_election_id", batch_header_map,
                                                                           one_batch_row)
+    ballotpedia_is_marquee = batch_manager.retrieve_value_from_batch_row("ballotpedia_is_marquee", batch_header_map,
+                                                                         one_batch_row)
     ballotpedia_office_id = batch_manager.retrieve_value_from_batch_row("ballotpedia_office_id", batch_header_map,
                                                                         one_batch_row)
     ballotpedia_office_name = batch_manager.retrieve_value_from_batch_row("ballotpedia_office_name", batch_header_map,
@@ -1130,6 +1132,7 @@ def create_batch_row_action_contest_office(batch_description, batch_header_map, 
         batch_row_action_contest_office.batch_set_id = batch_description.batch_set_id
         batch_row_action_contest_office.ballotpedia_district_id = convert_to_int(ballotpedia_district_id)
         batch_row_action_contest_office.ballotpedia_election_id = convert_to_int(ballotpedia_election_id)
+        batch_row_action_contest_office.ballotpedia_is_marquee = positive_value_exists(ballotpedia_is_marquee)
         batch_row_action_contest_office.ballotpedia_office_id = convert_to_int(ballotpedia_office_id)
         batch_row_action_contest_office.ballotpedia_office_name = ballotpedia_office_name
         batch_row_action_contest_office.ballotpedia_office_url = ballotpedia_office_url
@@ -3027,6 +3030,7 @@ def import_contest_office_data_from_batch_row_actions(
             'district_scope':                   one_batch_row_action.district_scope,
             'ballotpedia_district_id':          one_batch_row_action.ballotpedia_district_id,
             'ballotpedia_election_id':          one_batch_row_action.ballotpedia_election_id,
+            'ballotpedia_is_marquee':           one_batch_row_action.ballotpedia_is_marquee,
             'ballotpedia_office_id':            one_batch_row_action.ballotpedia_office_id,
             'ballotpedia_office_name':          one_batch_row_action.ballotpedia_office_name,
             'ballotpedia_office_url':           one_batch_row_action.ballotpedia_office_url,

--- a/import_export_batches/models.py
+++ b/import_export_batches/models.py
@@ -145,6 +145,7 @@ BATCH_IMPORT_KEYS_ACCEPTED_FOR_CONTEST_OFFICES = {
     'ballotpedia_candidate_id': 'ballotpedia_candidate_id *',  # For matching only
     'ballotpedia_district_id': 'ballotpedia_district_id',
     'ballotpedia_election_id': 'ballotpedia_election_id',
+    'ballotpedia_is_marquee': 'ballotpedia_is_marquee',
     'ballotpedia_office_id': 'ballotpedia_office_id',
     'ballotpedia_office_name': 'ballotpedia_office_name',
     'ballotpedia_office_url': 'ballotpedia_office_url',
@@ -185,6 +186,7 @@ BATCH_IMPORT_KEYS_ACCEPTED_FOR_CONTEST_OFFICES = {
 BATCH_HEADER_MAP_CONTEST_OFFICES_TO_BALLOTPEDIA_RACES = {
     'ballotpedia_district_id': 'ballotpedia_district_id',
     'ballotpedia_election_id': 'ballotpedia_election_id',
+    'ballotpedia_is_marquee': 'ballotpedia_is_marquee',
     'ballotpedia_office_id': 'ballotpedia_office_id',
     'ballotpedia_office_name': 'office_name',
     'ballotpedia_race_id': 'ballotpedia_race_id',
@@ -4543,6 +4545,7 @@ class BatchRowActionContestOffice(models.Model):
     ballotpedia_district_id = models.PositiveIntegerField(
         verbose_name="ballotpedia district id", null=True, blank=True)
     ballotpedia_election_id = models.PositiveIntegerField(verbose_name="ballotpedia election id", null=True, blank=True)
+    ballotpedia_is_marquee = models.NullBooleanField(default=None, null=True)
     is_ballotpedia_general_election = models.BooleanField(default=False)
     is_ballotpedia_general_runoff_election = models.BooleanField(default=False)
     is_ballotpedia_primary_election = models.BooleanField(default=False)

--- a/office/models.py
+++ b/office/models.py
@@ -89,6 +89,8 @@ class ContestOffice(models.Model):
     ballotpedia_id = models.CharField(
         verbose_name="ballotpedia unique identifier", max_length=255, null=True, blank=True)
     ballotpedia_election_id = models.PositiveIntegerField(verbose_name="ballotpedia election id", null=True, blank=True)
+    ballotpedia_is_marquee = models.NullBooleanField(default=None, null=True)
+    is_battleground_race = models.NullBooleanField(default=None, null=True)
 
     # Which kind of ballotpedia election "state" is this office in. Ex/ You can have an office in a primary be labeled
     #  general election if it is to decide on the final outcome, like for a mayor
@@ -782,6 +784,9 @@ class ContestOfficeManager(models.Model):
                     new_contest_office.ballotpedia_district_id = convert_to_int(defaults['ballotpedia_district_id'])
                 if 'ballotpedia_election_id' in defaults:
                     new_contest_office.ballotpedia_election_id = convert_to_int(defaults['ballotpedia_election_id'])
+                if 'ballotpedia_is_marquee' in defaults:
+                    new_contest_office.ballotpedia_is_marquee = \
+                        positive_value_exists(defaults['ballotpedia_is_marquee'])
                 if 'ballotpedia_office_id' in defaults:
                     new_contest_office.ballotpedia_office_id = convert_to_int(defaults['ballotpedia_office_id'])
                 if 'ballotpedia_office_name' in defaults:
@@ -872,6 +877,9 @@ class ContestOfficeManager(models.Model):
                     existing_office_entry.ballotpedia_district_id = convert_to_int(defaults['ballotpedia_district_id'])
                 if 'ballotpedia_election_id' in defaults:
                     existing_office_entry.ballotpedia_election_id = convert_to_int(defaults['ballotpedia_election_id'])
+                if 'ballotpedia_is_marquee' in defaults:
+                    existing_office_entry.ballotpedia_is_marquee = \
+                        positive_value_exists(defaults['ballotpedia_is_marquee'])
                 if 'ballotpedia_office_id' in defaults:
                     existing_office_entry.ballotpedia_office_id = convert_to_int(defaults['ballotpedia_office_id'])
                 if 'ballotpedia_office_name' in defaults:

--- a/organization/controllers.py
+++ b/organization/controllers.py
@@ -1158,7 +1158,7 @@ def organizations_import_from_structured_json(structured_json):
     return organizations_results
 
 
-def organization_retrieve_for_api(organization_id, organization_we_vote_id, voter_device_id):  #
+def organization_retrieve_for_api(organization_id, organization_we_vote_id, voter_device_id):  # organizationRetrieve
     """
     Called from organizationRetrieve api
     :param organization_id:
@@ -1175,16 +1175,18 @@ def organization_retrieve_for_api(organization_id, organization_we_vote_id, vote
             'success':                          False,
             'chosen_domain_string':             '',
             'chosen_favicon_url_https':         '',
+            'chosen_feature_package':           '',
             'chosen_google_analytics_account_number': '',
             'chosen_html_verification_string':  '',
-            'chosen_logo_displayed':            '',
+            'chosen_hide_we_vote_logo':         '',
             'chosen_logo_url_https':            '',
             'chosen_social_share_description':  '',
             'chosen_social_share_image_256x256_url_https': '',
-            'chosen_sub_domain_string':          '',
+            'chosen_sub_domain_string':         '',
             'chosen_subscription_plan':         '',
             'subscription_plan_end_day_text':   '',
-            'subscription_plan_features_active': '',
+            'subscription_plan_features_active': '',  # Replace with features_provided_bitmap
+            'features_provided_bitmap':         '',
             'facebook_id':                      0,
             'organization_banner_url':          '',
             'organization_description':         '',
@@ -1241,16 +1243,18 @@ def organization_retrieve_for_api(organization_id, organization_we_vote_id, vote
             'status': results['status'],
             'chosen_domain_string':             organization.chosen_domain_string,
             'chosen_favicon_url_https':         organization.chosen_favicon_url_https,
+            'chosen_feature_package':           organization.chosen_feature_package,
             'chosen_google_analytics_account_number': organization.chosen_google_analytics_account_number,
             'chosen_html_verification_string':  organization.chosen_html_verification_string,
-            'chosen_logo_displayed':            organization.chosen_logo_displayed,
+            'chosen_hide_we_vote_logo':            organization.chosen_hide_we_vote_logo,
             'chosen_logo_url_https':            organization.chosen_logo_url_https,
             'chosen_social_share_description':  organization.chosen_social_share_description,
             'chosen_social_share_image_256x256_url_https': organization.chosen_social_share_image_256x256_url_https,
             'chosen_sub_domain_string':          organization.chosen_sub_domain_string,
             'chosen_subscription_plan':         organization.chosen_subscription_plan,
             'subscription_plan_end_day_text':   organization.subscription_plan_end_day_text,
-            'subscription_plan_features_active': organization.subscription_plan_features_active,
+            'subscription_plan_features_active': organization.subscription_plan_features_active,  # Replace
+            'features_provided_bitmap':         organization.features_provided_bitmap,
             'organization_banner_url':          organization_banner_url,
             'organization_id':                  organization.id,
             'organization_we_vote_id':          organization.we_vote_id,  # this is the we_vote_id for this organization
@@ -1294,14 +1298,16 @@ def organization_retrieve_for_api(organization_id, organization_we_vote_id, vote
             'chosen_favicon_url_https':         '',
             'chosen_google_analytics_account_number': '',
             'chosen_html_verification_string':  '',
-            'chosen_logo_displayed':            '',
+            'chosen_hide_we_vote_logo':            '',
             'chosen_logo_url_https':            '',
             'chosen_social_share_description':  '',
             'chosen_social_share_image_256x256_url_https': '',
             'chosen_sub_domain_string':          '',
             'chosen_subscription_plan':         '',
             'subscription_plan_end_day_text':   '',
-            'subscription_plan_features_active': '',
+            'subscription_plan_features_active': '',  # Replace with features_provided_bitmap
+            'chosen_feature_package':              '',
+            'features_provided_bitmap':         '',
             'facebook_id':                      0,
             'organization_banner_url':          '',
             'organization_description':         '',
@@ -1331,7 +1337,8 @@ def organization_save_for_api(voter_device_id, organization_id, organization_we_
                               refresh_from_twitter,
                               facebook_id, facebook_email, facebook_profile_image_url_https,
                               chosen_domain_string, chosen_google_analytics_account_number,
-                              chosen_html_verification_string, chosen_logo_displayed, chosen_social_share_description,
+                              chosen_html_verification_string, chosen_hide_we_vote_logo,
+                              chosen_social_share_description,
                               chosen_sub_domain_string, chosen_subscription_plan):
     """
     We use this to store displayable organization data
@@ -1355,7 +1362,7 @@ def organization_save_for_api(voter_device_id, organization_id, organization_we_
     :param chosen_domain_string:
     :param chosen_google_analytics_account_number:
     :param chosen_html_verification_string:
-    :param chosen_logo_displayed:
+    :param chosen_hide_we_vote_logo:
     :param chosen_social_share_description:
     :param chosen_sub_domain_string:
     :param chosen_subscription_plan:
@@ -1382,18 +1389,19 @@ def organization_save_for_api(voter_device_id, organization_id, organization_we_
         results = {
             'status':                       "ORGANIZATION_REQUIRED_UNIQUE_IDENTIFIER_VARIABLES_MISSING",
             'success':                      False,
-            'chosen_domain_string':             chosen_domain_string,
+            'chosen_domain_string':         chosen_domain_string,
             'chosen_favicon_url_https':         '',
             'chosen_google_analytics_account_number': chosen_google_analytics_account_number,
             'chosen_html_verification_string':  chosen_html_verification_string,
-            'chosen_logo_displayed':            chosen_logo_displayed,
+            'chosen_hide_we_vote_logo':            chosen_hide_we_vote_logo,
             'chosen_logo_url_https':            '',
             'chosen_social_share_description':  chosen_social_share_description,
             'chosen_social_share_image_256x256_url_https': '',
             'chosen_sub_domain_string':          chosen_sub_domain_string,
             'chosen_subscription_plan':         chosen_subscription_plan,
-            'subscription_plan_end_day_text':   '',
-            'subscription_plan_features_active': '',
+            'subscription_plan_end_day_text':   '',  # Not something that can be saved directly from WebApp
+            'subscription_plan_features_active': '',  # Replace
+            'chosen_feature_package':       '',  # Not something that can be saved directly from WebApp
             'facebook_id':                  facebook_id,
             'new_organization_created':     False,
             'organization_description':     organization_description,
@@ -1420,14 +1428,16 @@ def organization_save_for_api(voter_device_id, organization_id, organization_we_
             'chosen_favicon_url_https':         '',
             'chosen_google_analytics_account_number': chosen_google_analytics_account_number,
             'chosen_html_verification_string':  chosen_html_verification_string,
-            'chosen_logo_displayed':            chosen_logo_displayed,
+            'chosen_hide_we_vote_logo':            chosen_hide_we_vote_logo,
             'chosen_logo_url_https':            '',
             'chosen_social_share_description':  chosen_social_share_description,
             'chosen_social_share_image_256x256_url_https': '',
             'chosen_sub_domain_string':          chosen_sub_domain_string,
             'chosen_subscription_plan':         chosen_subscription_plan,
-            'subscription_plan_end_day_text':   '',
-            'subscription_plan_features_active': '',
+            'subscription_plan_end_day_text':   '',  # Not something that can be saved directly from WebApp
+            'subscription_plan_features_active': '',  # Replace
+            'chosen_feature_package':       '',  # Not something that can be saved directly from WebApp
+            'features_provided_bitmap':     '',  # Not something that can be saved directly from WebApp
             'new_organization_created':     False,
             'organization_description':     organization_description,
             'organization_email':           organization_email,
@@ -1499,7 +1509,8 @@ def organization_save_for_api(voter_device_id, organization_id, organization_we_
         facebook_background_image_url_https=facebook_background_image_url_https,
         chosen_domain_string=chosen_domain_string,
         chosen_google_analytics_account_number=chosen_google_analytics_account_number,
-        chosen_html_verification_string=chosen_html_verification_string, chosen_logo_displayed=chosen_logo_displayed,
+        chosen_html_verification_string=chosen_html_verification_string,
+        chosen_hide_we_vote_logo=chosen_hide_we_vote_logo,
         chosen_social_share_description=chosen_social_share_description,
         chosen_sub_domain_string=chosen_sub_domain_string, chosen_subscription_plan=chosen_subscription_plan,
     )
@@ -1594,7 +1605,7 @@ def organization_save_for_api(voter_device_id, organization_id, organization_we_
             'chosen_favicon_url_https':         organization.chosen_favicon_url_https,
             'chosen_google_analytics_account_number': organization.chosen_google_analytics_account_number,
             'chosen_html_verification_string':  organization.chosen_html_verification_string,
-            'chosen_logo_displayed':            organization.chosen_logo_displayed,
+            'chosen_hide_we_vote_logo':            organization.chosen_hide_we_vote_logo,
             'chosen_logo_url_https':            organization.chosen_logo_url_https,
             'chosen_social_share_description':  organization.chosen_social_share_description,
             'chosen_social_share_image_256x256_url_https': organization.chosen_social_share_image_256x256_url_https,
@@ -1602,6 +1613,8 @@ def organization_save_for_api(voter_device_id, organization_id, organization_we_
             'chosen_subscription_plan':         organization.chosen_subscription_plan,
             'subscription_plan_end_day_text':   organization.subscription_plan_end_day_text,
             'subscription_plan_features_active': organization.subscription_plan_features_active,
+            'chosen_feature_package':       organization.chosen_feature_package,
+            'features_provided_bitmap':     organization.features_provided_bitmap,
             'organization_id':              organization.id,
             'organization_we_vote_id':      organization.we_vote_id,
             'new_organization_created':     save_results['new_organization_created'],
@@ -1646,7 +1659,7 @@ def organization_save_for_api(voter_device_id, organization_id, organization_we_
             'chosen_favicon_url_https':         '',
             'chosen_google_analytics_account_number': chosen_google_analytics_account_number,
             'chosen_html_verification_string':  chosen_html_verification_string,
-            'chosen_logo_displayed':            chosen_logo_displayed,
+            'chosen_hide_we_vote_logo':            chosen_hide_we_vote_logo,
             'chosen_logo_url_https':            '',
             'chosen_social_share_description':  chosen_social_share_description,
             'chosen_social_share_image_256x256_url_https': '',
@@ -1654,6 +1667,8 @@ def organization_save_for_api(voter_device_id, organization_id, organization_we_
             'chosen_subscription_plan':         chosen_subscription_plan,
             'subscription_plan_end_day_text':   '',
             'subscription_plan_features_active': '',
+            'chosen_feature_package':   '',
+            'features_provided_bitmap': '',
             'organization_id':          organization_id,
             'organization_we_vote_id':  organization_we_vote_id,
             'new_organization_created': save_results['new_organization_created'],
@@ -1949,6 +1964,47 @@ def retrieve_organization_list_for_all_upcoming_elections(limit_to_this_state_co
         'super_light_candidate_list':       super_light_organization_list,
     }
     return results
+
+
+def site_configuration_retrieve_for_api(hostname):
+    """
+    Called from siteConfigurationRetrieve api
+    :param hostname:
+    :return:
+    """
+    status = ""
+    success = True
+    organization = None
+    organization_found = False
+    if positive_value_exists(hostname):
+        hostname = hostname.strip().lower()
+        organization_manager = OrganizationManager()
+        results = organization_manager.retrieve_organization_from_incoming_hostname(hostname, read_only=True)
+        organization_found = results['organization_found']
+        organization = results['organization']
+        status += results['status']
+
+    if organization_found:
+        chosen_hide_we_vote_logo = organization.chosen_hide_we_vote_logo
+        chosen_logo_url_https = organization.chosen_logo_url_https
+        features_provided_bitmap = organization.features_provided_bitmap
+        organization_we_vote_id = organization.we_vote_id
+    else:
+        chosen_hide_we_vote_logo = False
+        chosen_logo_url_https = ''
+        features_provided_bitmap = 0
+        organization_we_vote_id = ''
+
+    json_data = {
+        'success':                  success,
+        'status':                   status,
+        'chosen_hide_we_vote_logo': chosen_hide_we_vote_logo,
+        'chosen_logo_url_https':    chosen_logo_url_https,
+        'features_provided_bitmap': features_provided_bitmap,
+        'hostname':                 hostname,
+        'organization_we_vote_id':  organization_we_vote_id,
+    }
+    return HttpResponse(json.dumps(json_data), content_type='application/json')
 
 
 def update_social_media_statistics_in_other_tables(organization):

--- a/templates/apis_v1/apis_index.html
+++ b/templates/apis_v1/apis_index.html
@@ -590,6 +590,11 @@
         <td>Save a new organization or update an existing organization.</td>
     </tr>
     <tr>
+        <td><a href="{% url 'apis_v1:siteConfigurationRetrieveDocs' %}">siteConfigurationRetrieve</a></td>
+        <td>static</td>
+        <td>Retrieve private label settings for an organization's site.</td>
+    </tr>
+    <tr>
         <td><a href="{% url 'apis_v1:organizationSearchDocs' %}">organizationSearch</a></td>
         <td>c3</td>
         <td>Search for organizations to find any organization that contains any of the search terms.</td>

--- a/templates/office/office_edit.html
+++ b/templates/office/office_edit.html
@@ -131,6 +131,22 @@
 </div>
 
 <div class="form-group">
+    <label for="ballotpedia_is_marquee_id" class="col-sm-3 control-label">Is Marquee</label>
+    <div class="col-sm-8">
+        <input type="checkbox" name="ballotpedia_is_marquee" id="ballotpedia_is_marquee_id" value="1"
+             {% if office.ballotpedia_is_marquee %}checked{% endif %} />
+    </div>
+</div>
+
+<div class="form-group">
+    <label for="is_battleground_race_id" class="col-sm-3 control-label">Is Battleground Race</label>
+    <div class="col-sm-8">
+        <input type="checkbox" name="is_battleground_race" id="is_battleground_race_id" value="1"
+             {% if office.is_battleground_race %}checked{% endif %} />
+    </div>
+</div>
+
+<div class="form-group">
     <label for="ballotpedia_race_office_level_id" class="col-sm-3 control-label">Ballotpedia Race Office Level</label>
     <div class="col-sm-8">
         <input type="radio" name="ballotpedia_race_office_level" value="Federal"{% if office.ballotpedia_race_office_level == "Federal" %} checked{% endif %} > Federal&nbsp;&nbsp;

--- a/templates/office/office_list.html
+++ b/templates/office/office_list.html
@@ -52,6 +52,13 @@
     </label>
     &nbsp;&nbsp;&nbsp;&nbsp;
 
+    {# Show elections which are either marquee or battleground #}
+    <label for="show_marquee_or_battleground_id">
+      <input type="checkbox" name="show_marquee_or_battleground" id="show_marquee_or_battleground_id" value="1"
+             {% if show_marquee_or_battleground %}checked{% endif %} /> Show Battleground Races
+    </label>
+    &nbsp;&nbsp;&nbsp;&nbsp;
+
     {% if state_list %}
         <select id="state_code_id" name="state_code">
             <option value="">
@@ -154,6 +161,11 @@
     });
     $(function() {
         $('#show_all_elections_id').change(function() {
+            this.form.submit();
+        });
+    });
+    $(function() {
+        $('#show_marquee_or_battleground_id').change(function() {
             this.form.submit();
         });
     });

--- a/templates/office/office_summary.html
+++ b/templates/office/office_summary.html
@@ -81,6 +81,10 @@
       <td><strong>{{ office.ballotpedia_district_id|default_if_none:"" }}</strong></td>
     </tr>
     <tr>
+      <td>Is Marquee? :: Is Battleground?</td>
+      <td><strong>{{ office.ballotpedia_is_marquee|default_if_none:"No" }} :: {{ office.is_battleground_race|default_if_none:"No" }}</strong></td>
+    </tr>
+    <tr>
       <td>Ballotpedia Office URL:</td>
       <td><strong>{{ office.ballotpedia_office_url }}</strong></td>
     </tr>
@@ -91,7 +95,7 @@
     </tr>
     {% endif %}
     <tr>
-      <td>Google ballotPlacement:</td>
+      <td>Google Ballot Placement:</td>
       <td><strong>{{ office.google_ballot_placement|default_if_none:"" }}</strong></td>
     </tr>
     <tr>

--- a/templates/organization/organization_edit_account.html
+++ b/templates/organization/organization_edit_account.html
@@ -22,14 +22,14 @@ span.nobr { white-space: nowrap; }
     <input type="hidden" name="organization_id" value="{{ organization.id }}">
 
 <div class="form-group">
-    <label for="chosen_logo_displayed_id" class="col-sm-3 control-label">Hide We Vote Logo?</label>
+    <label for="chosen_hide_we_vote_logo_id" class="col-sm-3 control-label">Hide We Vote Logo?</label>
     <div class="col-sm-8">
         <label for="show_we_vote_logo_id">
-            <input type="radio" name="chosen_logo_displayed" value="0"{% if organization.chosen_logo_displayed %}{% else %} checked{% endif %} id="show_we_vote_logo_id" >
+            <input type="radio" name="chosen_hide_we_vote_logo" value="0"{% if organization.chosen_hide_we_vote_logo %}{% else %} checked{% endif %} id="show_we_vote_logo_id" >
             Show We Vote Logo
         </label>
         <label for="hide_we_vote_logo_id">
-            <input type="radio" name="chosen_logo_displayed" value="1"{% if organization.chosen_logo_displayed %} checked{% endif %} id="hide_we_vote_logo_id" >
+            <input type="radio" name="chosen_hide_we_vote_logo" value="1"{% if organization.chosen_hide_we_vote_logo %} checked{% endif %} id="hide_we_vote_logo_id" >
             Hide We Vote Logo & Show Custom Logo
         </label>
     </div>
@@ -126,7 +126,23 @@ span.nobr { white-space: nowrap; }
     <label for="chosen_subscription_plan_id" class="col-sm-3 control-label">Subscription Plan</label>
     <div class="col-sm-8">
         <input type="text" name="chosen_subscription_plan" id="chosen_subscription_plan_id" class="form-control"
-               value="{{ organization.chosen_subscription_plan|default_if_none:"" }}" />
+               value="{{ organization.chosen_subscription_plan|default_if_none:"" }}"
+               disabled
+        />
+    </div>
+</div>
+
+
+<div class="form-group">
+    <label for="chosen_feature_package_id" class="col-sm-3 control-label">Feature Package</label>
+    <div class="col-sm-8">
+        <select id="chosen_feature_package_id" name="chosen_feature_package" class="form-control">
+        {% for feature_package in master_feature_package_list %}
+            <option value="{{ feature_package.master_feature_package }}"
+                    {% if feature_package.master_feature_package|slugify == organization.chosen_feature_package|slugify %} selected="selected"{% endif %}>
+                {{ feature_package.master_feature_package }} Plan</option>
+        {% endfor %}
+        </select>
     </div>
 </div>
 

--- a/templates/organization/organization_position_list.html
+++ b/templates/organization/organization_position_list.html
@@ -173,7 +173,7 @@
             <table>
                 <tr>
                     <th>Hide We Vote Logo:</th>
-                    <td>{{organization.chosen_logo_displayed|default_if_none:""}}</td>
+                    <td>{{organization.chosen_hide_we_vote_logo|default_if_none:""}}</td>
                 </tr>
                 <tr>
                     <th>Domain string:</th>
@@ -211,6 +211,10 @@
                 <tr>
                     <th>Subscription plan:</th>
                     <td>{{organization.chosen_subscription_plan|default_if_none:""}}</td>
+                </tr>
+                <tr>
+                    <th>Feature Package:</th>
+                    <td>{{organization.chosen_feature_package|default_if_none:""}}</td>
                 </tr>
                 <tr>
                     <td colspan="2"><a href="{% url 'organization:organization_edit_account' organization.id %}?google_civic_election_id={{ google_civic_election_id }}"


### PR DESCRIPTION
Added siteConfigurationRetrieve API so we can activate configurations when voters visit client sites. Now importing ballotpedia_is_marquee value. Added is_battleground_race field to Office table to help Political Data team. Added MasterFeaturePackage donate table to centralize the features_provided_bitmap settings for each package (ex/ Professional vs. Enterprise) Showing number of offices in each state on office_list Admin page.