### PR TITLE
Created new "donation" routines specific to subscription payments. Now storing plan_type_enum and coupon_code directly in the DonationPlanDefinition table. Added active_paid_plan to some of the API responses, so we can see a summarized view of the active paid plan.

### DIFF
--- a/apis_v1/static/js/PlanDialog.js
+++ b/apis_v1/static/js/PlanDialog.js
@@ -1,3 +1,4 @@
+// WeVoteServer/apis_v1/static/js/planDialog.js
 $(function () {
   let dialog;
   let form;

--- a/apis_v1/static/js/TaskDialog.js
+++ b/apis_v1/static/js/TaskDialog.js
@@ -1,3 +1,4 @@
+// WeVoteServer/apis_v1/static/js/TaskDialog.js
 $(function () {
   let dialog; let
     form;

--- a/donate/views_admin.py
+++ b/donate/views_admin.py
@@ -24,6 +24,8 @@ def organization_subscription_list_view(request):
 
     plans_list = DonationManager.retrieve_subscription_plan_list()
     plans = []
+    monthly_price_stripe = ''
+    annual_price_stripe = ''
 
     for plan in plans_list['subscription_plan_list']:
         try:
@@ -53,7 +55,8 @@ def organization_subscription_list_view(request):
             'master_feature_package': plan.master_feature_package,
             'features_provided_bitmap': plan.features_provided_bitmap,
             'plan_created_at': nice_created_at,
-            'coupon_expires_date': nice_expires_dt
+            'coupon_expires_date': nice_expires_dt,
+            'is_archived': plan.is_archived,
         }
         plans.append(plan_dict)
 

--- a/templates/organization_plans/plan_list.html
+++ b/templates/organization_plans/plan_list.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 
 {% block js %}
+  {# planDialog is in WeVoteServer/apis_v1/static/js/planDialog.js #}
   <script src="{% static "js/PlanDialog.js" %}" type="text/javascript"></script>
 {% endblock %}
 {% block title %}Coupons{% endblock %}
@@ -40,6 +41,7 @@
           <th>Features</th>
           <th>Created</th>
           <th>Expires</th>
+          <th>Archived</th>
         </tr>
       </thead>
       {% for plan in plans %}
@@ -55,6 +57,7 @@
           <td style="width: 65px; text-align: center">{{ plan.features_provided_bitmap }}</td>
           <td style="width: 120px">{{ plan.plan_created_at }}</td>
           <td style="width: 85px" class="base-expire">{{ plan.coupon_expires_date }}</td>
+          <td style="width: 65px">{% if plan.is_archived %}{{ plan.is_archived }}{% endif %}</td>
         </tr>
       {% endfor %}
     </table>

--- a/voter_guide/controllers.py
+++ b/voter_guide/controllers.py
@@ -2442,7 +2442,7 @@ def voter_guides_to_follow_retrieve_for_api(voter_device_id,  # voterGuidesToFol
     results = is_voter_device_id_valid(voter_device_id)
     if not results['success']:
         json_data = {
-            'status': 'ERROR_GUIDES_TO_FOLLOW_NO_VOTER_DEVICE_ID',
+            'status': 'ERROR_GUIDES_TO_FOLLOW_NO_VOTER_DEVICE_ID ',
             'success': False,
             'voter_device_id': voter_device_id,
             'voter_guides': [],
@@ -2464,7 +2464,7 @@ def voter_guides_to_follow_retrieve_for_api(voter_device_id,  # voterGuidesToFol
     voter_id = fetch_voter_id_from_voter_device_link(voter_device_id)
     if not positive_value_exists(voter_id):
         json_data = {
-            'status': "ERROR_GUIDES_TO_FOLLOW_VOTER_NOT_FOUND_FROM_VOTER_DEVICE_ID",
+            'status': "ERROR_GUIDES_TO_FOLLOW_VOTER_NOT_FOUND_FROM_VOTER_DEVICE_ID ",
             'success': False,
             'voter_device_id': voter_device_id,
             'voter_guides': [],
@@ -2490,7 +2490,7 @@ def voter_guides_to_follow_retrieve_for_api(voter_device_id,  # voterGuidesToFol
         voter_we_vote_id = fetch_voter_we_vote_id_from_voter_device_link(voter_device_id)
         if not positive_value_exists(voter_we_vote_id):
             json_data = {
-                'status': "ERROR_GUIDES_TO_FOLLOW_VOTER_NOT_FOUND_FROM_VOTER_DEVICE_ID VOTER_WE_VOTE_ID_NOT_FOUND",
+                'status': "ERROR_GUIDES_TO_FOLLOW_VOTER_NOT_FOUND_FROM_VOTER_DEVICE_ID VOTER_WE_VOTE_ID_NOT_FOUND ",
                 'success': False,
                 'voter_device_id': voter_device_id,
                 'voter_guides': [],
@@ -2570,7 +2570,7 @@ def voter_guides_to_follow_retrieve_for_api(voter_device_id,  # voterGuidesToFol
 
     except Exception as e:
         status += 'FAILED voter_guides_to_follow_retrieve_for_api, retrieve_voter_guides_for_election ' \
-                 '{error} [type: {error_type}]'.format(error=str(e), error_type=type(e))
+                 '{error} [type: {error_type}] '.format(error=str(e), error_type=type(e))
         success = False
 
     if success:


### PR DESCRIPTION
Created new "donation" routines specific to subscription payments. Now storing plan_type_enum and coupon_code directly in the DonationPlanDefinition table. Added active_paid_plan to some of the API responses, so we can see a summarized view of the active paid plan.