### PR TITLE
Fixed Twitter API banner retrieve

### DIFF
--- a/twitter/functions.py
+++ b/twitter/functions.py
@@ -70,6 +70,11 @@ def retrieve_twitter_user_info(twitter_user_id, twitter_handle=''):
                 status += '[' + one_error['message'] + '] '
         handle_exception(error_instance, logger=logger, exception_message=status)
 
+    if positive_value_exists(twitter_json.get('profile_banner_url')):
+        # Dec 2019, https://developer.twitter.com/en/docs/accounts-and-users/user-profile-images-and-banners
+        banner = twitter_json.get('profile_banner_url') + '/1500x500'
+        twitter_json['profile_banner_url'] = banner
+
     results = {
         'status':               status,
         'success':              success,


### PR DESCRIPTION
Partial for wevote/WeVoteServer/issues/1158
Still need to confirm voter photos are loading correctly, although it looks like
they are server side -- it could just have been an unhandled exception on the
loading of the banner, that messed up the voter photos.  Will test tomorrow,
but this fix stands by itself.