### PR TITLE
Found a solution to these errors: AssertionError: Database queries to 'readonly' are not allowed in this test

### DIFF
--- a/apis_v1/tests/test_views_organization_retrieve.py
+++ b/apis_v1/tests/test_views_organization_retrieve.py
@@ -9,6 +9,7 @@ from organization.models import Organization
 
 
 class WeVoteAPIsV1TestsOrganizationRetrieve(TestCase):
+    databases = ["default", "readonly"]
 
     def setUp(self):
         self.generate_voter_device_id_url = reverse("apis_v1:deviceIdGenerateView")

--- a/apis_v1/tests/test_views_voter_address_retrieve.py
+++ b/apis_v1/tests/test_views_voter_address_retrieve.py
@@ -8,6 +8,7 @@ import json
 
 
 class WeVoteAPIsV1TestsVoterAddressRetrieve(TestCase):
+    databases = ["default", "readonly"]
 
     def setUp(self):
         self.generate_voter_device_id_url = reverse("apis_v1:deviceIdGenerateView")

--- a/apis_v1/tests/test_views_voter_address_save.py
+++ b/apis_v1/tests/test_views_voter_address_save.py
@@ -8,6 +8,8 @@ from django.test import TestCase
 
 
 class WeVoteAPIsV1TestsVoterAddressSave(TestCase):
+    databases = ["default", "readonly"]
+
     def setUp(self):
         self.generate_voter_device_id_url = reverse("apis_v1:deviceIdGenerateView")
         self.voter_create_url = reverse("apis_v1:voterCreateView")

--- a/apis_v1/tests/test_views_voter_guides_to_follow_retrieve.py
+++ b/apis_v1/tests/test_views_voter_guides_to_follow_retrieve.py
@@ -9,6 +9,7 @@ from organization.models import Organization
 
 
 class WeVoteAPIsV1TestsVoterGuidesToFollowRetrieve(TestCase):
+    databases = ["default", "readonly"]
 
     def setUp(self):
         self.generate_voter_device_id_url = reverse("apis_v1:deviceIdGenerateView")

--- a/ballot/tests.py
+++ b/ballot/tests.py
@@ -10,6 +10,7 @@ Location = namedtuple('Location', ['address', 'latitude', 'longitude'])
 
 
 class BallotTestCase(TestCase):
+    databases = ["default", "readonly"]
 
     def setUp(self):
         BallotReturned.objects.create(**{'google_civic_election_id': 4184,

--- a/issue/controllers.py
+++ b/issue/controllers.py
@@ -788,9 +788,9 @@ def retrieve_issues_under_ballot_items_list(all_issue_we_vote_ids, google_civic_
     return results
 
 
-def retrieve_issues_to_follow_for_api(voter_device_id, sort_formula):  # retrieveIssuesToFollow
+def retrieve_issues_to_follow_for_api(voter_device_id, sort_formula):  # retrieveIssuesToFollow # DEPRECATED
     """
-
+    Instead of this function, please use issuesFollowedRetrieve
     :param voter_device_id:
     :param sort_formula:
     :return:


### PR DESCRIPTION
Found a solution to these errors: 
AssertionError: Database queries to 'readonly' are not allowed in this test. Add 'readonly' to apis_v1.tests.test_views_voter_guides_to_follow_retrieve.WeVoteAPIsV1TestsVoterGuidesToFollowRetrieve.databases to ensure proper test isolation and silence this failure.