### PR TITLE
voterGuidePossibilityHighlightsRetrieve can now receive a google election id

### DIFF
--- a/apis_v1/documentation_source/voter_guide_possibility_highlights_retrieve_doc.py
+++ b/apis_v1/documentation_source/voter_guide_possibility_highlights_retrieve_doc.py
@@ -25,6 +25,11 @@ def voter_guide_possibility_highlights_retrieve_doc_template_values(url_root):
             'value':        'string',  # boolean, integer, long, string
             'description':  'The url of the list of endorsements that the voter is viewing.',
         },
+        {
+            'name':         'google_civic_election_id',
+            'value':        'integer',  # boolean, integer, long, string
+            'description':  'The Google civic election ID. Provide a value, only if you want data for a prior election.',
+        },
     ]
 
     potential_status_codes_list = [

--- a/apis_v1/views/views_voter_guide.py
+++ b/apis_v1/views/views_voter_guide.py
@@ -99,9 +99,11 @@ def voter_guide_possibility_highlights_retrieve_view(request):  # voterGuidePoss
     """
     voter_device_id = get_voter_device_id(request)  # We standardize how we take in the voter_device_id
     url_to_scan = request.GET.get('url_to_scan', '')
+    google_civic_election_id = request.GET.get('google_civic_election_id', 0)
     json_data = voter_guide_possibility_highlights_retrieve_for_api(
         voter_device_id=voter_device_id,
-        url_to_scan=url_to_scan)
+        url_to_scan=url_to_scan,
+        google_civic_election_id=google_civic_election_id)
     return HttpResponse(json.dumps(json_data), content_type='application/json')
 
 

--- a/voter_guide/controllers.py
+++ b/voter_guide/controllers.py
@@ -66,6 +66,10 @@ URLS_TO_NEVER_HIGHLIGHT = [
     'sketchviewer.com',
     '*.travis-ci.com',
     '*.travis-ci.org',
+    'blank',
+    'platform.twitter.com',
+    's7.addthis.com',
+    'vars.hotjar.com',
 ]
 
 
@@ -1824,7 +1828,7 @@ def voter_guide_possibility_retrieve_for_api(voter_device_id, voter_guide_possib
 
 
 def voter_guide_possibility_highlights_retrieve_for_api(  # voterGuidePossibilityHighlightsRetrieve
-        voter_device_id, url_to_scan):
+        voter_device_id, url_to_scan, google_civic_election_id):
     status = "VOTER_GUIDE_POSSIBILITY_HIGHLIGHTS_RETRIEVE "
     success = True
     highlight_list = []
@@ -1834,7 +1838,8 @@ def voter_guide_possibility_highlights_retrieve_for_api(  # voterGuidePossibilit
 
     # Once we know we have a voter_device_id to work with, get this working
     voter_guide_possibility_manager = VoterGuidePossibilityManager()
-    results = voter_guide_possibility_manager.retrieve_voter_guide_possibility_from_url(url_to_scan, voter_we_vote_id)
+    results = voter_guide_possibility_manager.retrieve_voter_guide_possibility_from_url(url_to_scan, voter_we_vote_id,
+                                                                                        google_civic_election_id)
     if results['voter_guide_possibility_found']:
         voter_guide_possibility_id = results['voter_guide_possibility_id']
         results = voter_guide_possibility_positions_retrieve_for_api(

--- a/voter_guide/models.py
+++ b/voter_guide/models.py
@@ -2048,9 +2048,9 @@ class VoterGuidePossibilityManager(models.Manager):
         }
         return results
 
-    def retrieve_voter_guide_possibility_from_url(self, voter_guide_possibility_url, voter_who_submitted_we_vote_id):
+    def retrieve_voter_guide_possibility_from_url(self, voter_guide_possibility_url, voter_who_submitted_we_vote_id,
+                                                  google_civic_election_id=0):
         voter_guide_possibility_id = 0
-        google_civic_election_id = 0
         return self.retrieve_voter_guide_possibility(
             voter_guide_possibility_id, google_civic_election_id,
             voter_guide_possibility_url, voter_who_submitted_we_vote_id=voter_who_submitted_we_vote_id)


### PR DESCRIPTION
This is needed in order to continue testing with a prior election.
I don't have the data on my local to confirm that this works, but the id value gets through to the internal method call that already had accepted an id, if that method works, the updated API call should work.