### PR TITLE
new API pdfToHtmlRetrieve to convert PDFs in the Chrome Extension to HTML files in S3

### DIFF
--- a/apis_v1/documentation_source/pdf_to_html_doc.py
+++ b/apis_v1/documentation_source/pdf_to_html_doc.py
@@ -1,0 +1,62 @@
+# apis_v1/documentation_source/pdf_to_html_doc.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+
+
+def pdf_to_html_retrieve_view(url_root):
+    """
+    Show documentation about pdfToHtmlRetrieve
+    """
+    required_query_parameter_list = [
+        {
+            'name':         'voter_device_id',
+            'value':        'string',  # boolean, integer, long, string
+            'description':  'An 88 character unique identifier linked to a voter record on the server',
+        },
+        {
+            'name': 'pdf_url',
+            'value': 'string',  # boolean, integer, long, string
+            'description': 'The valid URL, from which to load the PDF to be converted',
+        },
+    ]
+    optional_query_parameter_list = [
+    ]
+
+    potential_status_codes_list = [
+        {
+            'code':         'PDF_URL_MISSING',
+            'description':  'The URL to the PDF is either missing or invalid.',
+        },
+        {
+            'code':         'PDF_URL_RETURNED',
+            'description':  'The API call has returned a URL to a new HTML page in S3',
+        },
+    ]
+
+    try_now_link_variables_dict = {
+    }
+
+    api_response = '{\n' \
+                   '  "status": string,\n' \
+                   '  "success": boolean,\n' \
+                   '  "output_from_subprocess": string,\n' \
+                   '  "s3_url_for_html": string (a public url to a new or reused HTML page in S3),\n' \
+                   '}'
+
+    template_values = {
+        'api_name': 'pdfToHtmlRetrieve',
+        'api_slug': 'pdfToHtmlRetrieve',
+        'api_introduction':
+            "Convert a PDF to an HTML file in S3, and return the URL",
+        'try_now_link': 'apis_v1:pdfToHtmlRetrieve',
+        'try_now_link_variables_dict': try_now_link_variables_dict,
+        'url_root': url_root,
+        'get_or_post': 'GET',
+        'required_query_parameter_list': required_query_parameter_list,
+        'optional_query_parameter_list': optional_query_parameter_list,
+        'api_response': api_response,
+        'api_response_notes':
+            "",
+        'potential_status_codes_list': potential_status_codes_list,
+    }
+    return template_values

--- a/apis_v1/urls.py
+++ b/apis_v1/urls.py
@@ -11,7 +11,7 @@ from django.conf.urls import url
 from django.conf.urls.static import static
 
 from apis_v1.views import views_docs, views_analytics, views_ballot, views_candidate, views_donation, \
-    views_election, views_facebook, views_friend, views_issues, views_measure, views_misc, views_organization, \
+    views_election, views_extension, views_facebook, views_friend, views_issues, views_measure, views_misc, views_organization, \
     views_pledge_to_vote, views_position, views_task, views_twitter, views_voter, views_voter_guide
 from ballot.views_admin import ballot_items_sync_out_view, ballot_returned_sync_out_view
 from candidate.views_admin import candidates_sync_out_view
@@ -276,6 +276,7 @@ urlpatterns = [
     url(r'^voterTwitterSaveToCurrentAccount/',
         views_voter.voter_twitter_save_to_current_account_view, name='voterTwitterSaveToCurrentAccountView'),
     url(r'^voterUpdate/', views_voter.voter_update_view, name='voterUpdateView'),
+    url(r'^pdfToHtmlRetrieve/', views_extension.pdf_to_html_retrieve_view, name='pdfToHtmlRetrieve'),
     url(r'^voterVerifySecretCode/', views_voter.voter_verify_secret_code_view, name='voterVerifySecretCodeView'),
 
     ##########################
@@ -520,6 +521,7 @@ urlpatterns = [
     url(r'^docs/voterTwitterSaveToCurrentAccount/$',
         views_docs.voter_twitter_save_to_current_account_doc_view, name='voterTwitterSaveToCurrentAccountDocs'),
     url(r'^docs/voterUpdate/$', views_docs.voter_update_doc_view, name='voterUpdateDocs'),
+    url(r'^docs/pdfToHtmlRetrieve/$', views_docs.pdf_to_html_retrieve_view, name='pdfToHtmlRetrieveDocs'),
     url(r'^docs/voterVerifySecretCode/$',
         views_docs.voter_verify_secret_code_doc_view, name='voterVerifySecretCodeDocs'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/apis_v1/views/views_docs.py
+++ b/apis_v1/views/views_docs.py
@@ -23,6 +23,7 @@ from apis_v1.documentation_source import all_ballot_items_retrieve_doc, ballot_i
     organization_stop_ignoring_doc, organization_photos_save_doc, \
     organization_retrieve_doc, organization_save_doc, organization_search_doc, organizations_sync_out_doc, \
     organization_suggestion_tasks_doc, \
+    pdf_to_html_doc, \
     pledge_to_vote_with_voter_guide_doc, politicians_sync_out_doc, polling_locations_sync_out_doc, \
     position_like_count_doc, position_list_for_ballot_item_doc, position_list_for_ballot_item_from_friends_doc, \
     position_list_for_opinion_maker_doc, \
@@ -1497,5 +1498,15 @@ def voter_update_doc_view(request):
     """
     url_root = WE_VOTE_SERVER_ROOT_URL
     template_values = voter_update_doc.voter_update_doc_template_values(url_root)
+    template_values['voter_api_device_id'] = get_voter_api_device_id(request)
+    return render(request, 'apis_v1/api_doc_page.html', template_values)
+
+
+def pdf_to_html_retrieve_view(request):
+    """
+    Show documentation about pdfToHtmlRetrieve
+    """
+    url_root = WE_VOTE_SERVER_ROOT_URL
+    template_values = pdf_to_html_doc.pdf_to_html_retrieve_view(url_root)
     template_values['voter_api_device_id'] = get_voter_api_device_id(request)
     return render(request, 'apis_v1/api_doc_page.html', template_values)

--- a/apis_v1/views/views_extension.py
+++ b/apis_v1/views/views_extension.py
@@ -5,13 +5,13 @@ import boto3
 import datetime
 import json
 import os
-import subprocess
 import urllib.request
 from django.http import HttpResponse
 import wevote_functions.admin
 from config.base import get_environment_variable
 from wevote_functions.functions import positive_value_exists, get_voter_device_id
 from exception.models import handle_exception
+from pdfminer_six import pdf2txt
 
 AWS_ACCESS_KEY_ID = get_environment_variable("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = get_environment_variable("AWS_SECRET_ACCESS_KEY")
@@ -44,8 +44,8 @@ def pdf_to_html_retrieve_view(request):  # pdfToHtmlRetrieve
 
     file_name, headers = urllib.request.urlretrieve(pdf_url)
     temp_file_name = file_name + '.html'
-    process = subprocess.run(['python', 'pdf2txt.py', '-o', temp_file_name, file_name])
-    output = process.stdout
+
+    pdf2txt.main(['-o', temp_file_name, file_name])
 
     s3_url_for_html = store_temporary_html_file_to_aws(temp_file_name)
     print("views_extension stored temp html file: ", temp_file_name, s3_url_for_html)
@@ -54,7 +54,7 @@ def pdf_to_html_retrieve_view(request):  # pdfToHtmlRetrieve
     json_data = {
         'status': status,
         'success': True,
-        'output_from_subprocess': output,
+        # 'output_from_subprocess': output,
         's3_url_for_html': s3_url_for_html,
     }
 

--- a/apis_v1/views/views_extension.py
+++ b/apis_v1/views/views_extension.py
@@ -1,0 +1,88 @@
+# apis_v1/views/views_extension.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+import boto3
+import datetime
+import json
+import os
+import subprocess
+import urllib.request
+from django.http import HttpResponse
+import wevote_functions.admin
+from config.base import get_environment_variable
+from wevote_functions.functions import positive_value_exists, get_voter_device_id
+from exception.models import handle_exception
+
+AWS_ACCESS_KEY_ID = get_environment_variable("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = get_environment_variable("AWS_SECRET_ACCESS_KEY")
+AWS_REGION_NAME = get_environment_variable("AWS_REGION_NAME")
+AWS_STORAGE_BUCKET_NAME = "wevote-temporary"
+AWS_STORAGE_SERVICE = "s3"
+
+logger = wevote_functions.admin.get_logger(__name__)
+
+WE_VOTE_SERVER_ROOT_URL = get_environment_variable("WE_VOTE_SERVER_ROOT_URL")
+
+
+def pdf_to_html_retrieve_view(request):  # pdfToHtmlRetrieve
+    """
+    return a URL to a s3 file that contains the html rough equivalent of the PDF
+    :param request:
+    :return:
+    """
+    voter_device_id = get_voter_device_id(request)  # We standardize how we take in the voter_device_id
+    pdf_url = request.GET.get('pdf_url', '')
+
+    if not positive_value_exists(pdf_url):
+        status = 'PDF_URL_MISSING'
+        json_data = {
+            'status':                   status,
+            'success':                  False,
+            's3_url_for_html':          '',
+        }
+        return HttpResponse(json.dumps(json_data), content_type='application/json')
+
+    file_name, headers = urllib.request.urlretrieve(pdf_url)
+    temp_file_name = file_name + '.html'
+    process = subprocess.run(['python', 'pdf2txt.py', '-o', temp_file_name, file_name])
+    output = process.stdout
+
+    s3_url_for_html = store_temporary_html_file_to_aws(temp_file_name)
+    print("views_extension stored temp html file: ", temp_file_name, s3_url_for_html)
+
+    status = 'PDF_URL_RETURNED'
+    json_data = {
+        'status': status,
+        'success': True,
+        'output_from_subprocess': output,
+        's3_url_for_html': s3_url_for_html,
+    }
+
+    return HttpResponse(json.dumps(json_data), content_type='application/json')
+
+
+def store_temporary_html_file_to_aws(temp_file_name):
+    """
+    Upload temporary_html_file directly to AWS
+    :param temp_file_name:
+    :return:
+    """
+    s3_html_url = ""
+    try:
+        head, tail = os.path.split(temp_file_name)
+        date_in_a_week = datetime.datetime.now() + + datetime.timedelta(days=7)
+        session = boto3.session.Session(region_name=AWS_REGION_NAME,
+                                        aws_access_key_id=AWS_ACCESS_KEY_ID,
+                                        aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+        s3 = session.resource(AWS_STORAGE_SERVICE)
+        s3.Bucket(AWS_STORAGE_BUCKET_NAME).upload_file(
+            temp_file_name, tail, ExtraArgs={'Expires': date_in_a_week, 'ContentType': 'text/html'})
+        s3_html_url = "https://{bucket_name}.s3.amazonaws.com/{file_location}" \
+                            "".format(bucket_name=AWS_STORAGE_BUCKET_NAME,
+                                      file_location=tail)
+    except Exception as e:
+        print(e)
+        exception_message = "store_temp_html_file_to_aws failed"
+        handle_exception(e, logger=logger, exception_message=exception_message)
+
+    return s3_html_url

--- a/docs/README_MAC_SIMPLIFIED_INSTALL.md
+++ b/docs/README_MAC_SIMPLIFIED_INSTALL.md
@@ -220,7 +220,7 @@ the following command:
     
     ```
     Collecting psycopg2 (from django-toolbelt==0.0.1->-r requirements.txt (line 11))
-  Using cached https://files.pythonhosted.org/packages/5c/1c/6997288da181277a0c29bc39a5f9143ff20b8c99f2a7d059cfb55163e165/psycopg2-2.8.3.tar.gz
+    Using cached https://files.pythonhosted.org/packages/5c/1c/6997288da181277a0c29bc39a5f9143ff20b8c99f2a7d059cfb55163e165/psycopg2-2.8.3.tar.gz
     ERROR: Complete output from command python setup.py egg_info:
     ERROR: running egg_info
     creating pip-egg-info/psycopg2.egg-info
@@ -231,7 +231,20 @@ the following command:
     
     Error: pg_config executable not found.
     ```
-    
+1. Install pdfminer.six command line utility for the Chrome Extension 
+    ```
+   pip install pdfminer.six
+   ```
+   Then in a terminal window, create a symlink to the executable script pdf2txt.py, and then test that the symlink
+   works by attempting to run the script without any files for it to convert (from PDFs to HTML files).
+   ```
+   (WeVoteServerPy3.7) WeVoteServer % ln -s ~/PycharmEnvironments/WeVoteServerPy3.7/bin/pdf2txt.py pdf2txt.py
+   (WeVoteServerPy3.7) WeVoteServer % python pdf2txt.py
+   usage: pdf2txt.py [-h] [--debug] [--disable-caching]
+      ...
+   pdf2txt.py: error: the following arguments are required: files
+   (WeVoteServerPy3.7) WeVoteServer % 
+   ```
      
 ## Install and set up PostgreSQL and pgAdmin4
 

--- a/docs/README_MAC_SIMPLIFIED_INSTALL.md
+++ b/docs/README_MAC_SIMPLIFIED_INSTALL.md
@@ -231,20 +231,6 @@ the following command:
     
     Error: pg_config executable not found.
     ```
-1. Install pdfminer.six command line utility for the Chrome Extension 
-    ```
-   pip install pdfminer.six
-   ```
-   Then in a terminal window, create a symlink to the executable script pdf2txt.py, and then test that the symlink
-   works by attempting to run the script without any files for it to convert (from PDFs to HTML files).
-   ```
-   (WeVoteServerPy3.7) WeVoteServer % ln -s ~/PycharmEnvironments/WeVoteServerPy3.7/bin/pdf2txt.py pdf2txt.py
-   (WeVoteServerPy3.7) WeVoteServer % python pdf2txt.py
-   usage: pdf2txt.py [-h] [--debug] [--disable-caching]
-      ...
-   pdf2txt.py: error: the following arguments are required: files
-   (WeVoteServerPy3.7) WeVoteServer % 
-   ```
      
 ## Install and set up PostgreSQL and pgAdmin4
 

--- a/pdfminer_six/pdf2txt.py
+++ b/pdfminer_six/pdf2txt.py
@@ -1,0 +1,193 @@
+"""A command line tool for extracting text and images from PDF and output it to plain text, html, xml or tags."""
+import argparse
+import logging
+import sys
+
+import pdfminer.high_level
+import pdfminer.layout
+
+logging.basicConfig()
+
+OUTPUT_TYPES = ((".htm", "html"),
+                (".html", "html"),
+                (".xml", "xml"),
+                (".tag", "tag"))
+
+
+def extract_text(files=[], outfile='-',
+                 no_laparams=False, all_texts=None, detect_vertical=None,
+                 word_margin=None, char_margin=None, line_margin=None,
+                 boxes_flow=None, output_type='text', codec='utf-8',
+                 strip_control=False, maxpages=0, page_numbers=None,
+                 password="", scale=1.0, rotation=0, layoutmode='normal',
+                 output_dir=None, debug=False, disable_caching=False,
+                 **kwargs):
+    if not files:
+        raise ValueError("Must provide files to work upon!")
+
+    # If any LAParams group arguments were passed,
+    # create an LAParams object and
+    # populate with given args. Otherwise, set it to None.
+    if not no_laparams:
+        laparams = pdfminer.layout.LAParams()
+        for param in ("all_texts", "detect_vertical", "word_margin",
+                      "char_margin", "line_margin", "boxes_flow"):
+            paramv = locals().get(param, None)
+            if paramv is not None:
+                setattr(laparams, param, paramv)
+    else:
+        laparams = None
+
+    if output_type == "text" and outfile != "-":
+        for override, alttype in OUTPUT_TYPES:
+            if outfile.endswith(override):
+                output_type = alttype
+
+    if outfile == "-":
+        outfp = sys.stdout
+        if outfp.encoding is not None:
+            codec = 'utf-8'
+    else:
+        outfp = open(outfile, "wb")
+
+    for fname in files:
+        with open(fname, "rb") as fp:
+            pdfminer.high_level.extract_text_to_fp(fp, **locals())
+    return outfp
+
+
+def maketheparser():
+    parser = argparse.ArgumentParser(description=__doc__, add_help=True)
+    parser.add_argument(
+        "files", type=str, default=None, nargs="+",
+        help="One or more paths to PDF files.")
+
+    parser.add_argument(
+        "--debug", "-d", default=False, action="store_true",
+        help="Use debug logging level.")
+    parser.add_argument(
+        "--disable-caching", "-C", default=False, action="store_true",
+        help="If caching or resources, such as fonts, should be disabled.")
+
+    parse_params = parser.add_argument_group(
+        'Parser', description='Used during PDF parsing')
+    parse_params.add_argument(
+        "--page-numbers", type=int, default=None, nargs="+",
+        help="A space-seperated list of page numbers to parse.")
+    parse_params.add_argument(
+        "--pagenos", "-p", type=str,
+        help="A comma-separated list of page numbers to parse. "
+             "Included for legacy applications, use --page-numbers "
+             "for more idiomatic argument entry.")
+    parse_params.add_argument(
+        "--maxpages", "-m", type=int, default=0,
+        help="The maximum number of pages to parse.")
+    parse_params.add_argument(
+        "--password", "-P", type=str, default="",
+        help="The password to use for decrypting PDF file.")
+    parse_params.add_argument(
+        "--rotation", "-R", default=0, type=int,
+        help="The number of degrees to rotate the PDF "
+             "before other types of processing.")
+
+    la_params = parser.add_argument_group(
+        'Layout analysis', description='Used during layout analysis.')
+    la_params.add_argument(
+        "--no-laparams", "-n", default=False, action="store_true",
+        help="If layout analysis parameters should be ignored.")
+    la_params.add_argument(
+        "--detect-vertical", "-V", default=False, action="store_true",
+        help="If vertical text should be considered during layout analysis")
+    la_params.add_argument(
+        "--char-margin", "-M", type=float, default=2.0,
+        help="If two characters are closer together than this margin they "
+             "are considered to be part of the same word. The margin is "
+             "specified relative to the width of the character.")
+    la_params.add_argument(
+        "--word-margin", "-W", type=float, default=0.1,
+        help="If two words are are closer together than this margin they "
+             "are considered to be part of the same line. A space is added "
+             "in between for readability. The margin is specified relative "
+             "to the width of the word.")
+    la_params.add_argument(
+        "--line-margin", "-L", type=float, default=0.5,
+        help="If two lines are are close together they are considered to "
+             "be part of the same paragraph. The margin is specified "
+             "relative to the height of a line.")
+    la_params.add_argument(
+        "--boxes-flow", "-F", type=float, default=0.5,
+        help="Specifies how much a horizontal and vertical position of a "
+             "text matters when determining the order of lines. The value "
+             "should be within the range of -1.0 (only horizontal position "
+             "matters) to +1.0 (only vertical position matters).")
+    la_params.add_argument(
+        "--all-texts", "-A", default=True, action="store_true",
+        help="If layout analysis should be performed on text in figures.")
+
+    output_params = parser.add_argument_group(
+        'Output', description='Used during output generation.')
+    output_params.add_argument(
+        "--outfile", "-o", type=str, default="-",
+        help="Path to file where output is written. "
+             "Or \"-\" (default) to write to stdout.")
+    output_params.add_argument(
+        "--output_type", "-t", type=str, default="text",
+        help="Type of output to generate {text,html,xml,tag}.")
+    output_params.add_argument(
+        "--codec", "-c", type=str, default="utf-8",
+        help="Text encoding to use in output file.")
+    output_params.add_argument(
+        "--output-dir", "-O", default=None,
+        help="The output directory to put extracted images in. If not given, "
+             "images are not extracted.")
+    output_params.add_argument(
+        "--layoutmode", "-Y", default="normal",
+        type=str, help="Type of layout to use when generating html "
+                       "{normal,exact,loose}. If normal,each line is"
+                       " positioned separately in the html. If exact"
+                       ", each character is positioned separately in"
+                       " the html. If loose, same result as normal "
+                       "but with an additional newline after each "
+                       "text line. Only used when output_type is html.")
+    output_params.add_argument(
+        "--scale", "-s", type=float, default=1.0,
+        help="The amount of zoom to use when generating html file. "
+             "Only used when output_type is html.")
+    output_params.add_argument(
+        "--strip-control", "-S", default=False, action="store_true",
+        help="Remove control statement from text. "
+             "Only used when output_type is xml.")
+    return parser
+
+
+# main
+
+
+def main(args=None):
+    # Begin WeVote Modification to pdf2txt.py copied from pdfminer.six==20200124 on March 29, 2020
+    # TODO: as we update pdfminer.six, we might need to update this forked file too
+    if __name__ == '__main__':
+        import sys
+        main(sys.argv[1:])
+    # End WeVote Modification
+
+    P = maketheparser()
+    A = P.parse_args(args=args)
+
+    if A.page_numbers:
+        A.page_numbers = {x-1 for x in A.page_numbers}
+    if A.pagenos:
+        A.page_numbers = {int(x)-1 for x in A.pagenos.split(",")}
+
+    if A.output_type == "text" and A.outfile != "-":
+        for override, alttype in OUTPUT_TYPES:
+            if A.outfile.endswith(override):
+                A.output_type = alttype
+
+    outfp = extract_text(**vars(A))
+    outfp.close()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pdfminer_six/readme_for_our_forked_pdf2txt.md
+++ b/pdfminer_six/readme_for_our_forked_pdf2txt.md
@@ -1,0 +1,28 @@
+**March 25, 2020**
+
+pdf2txt.py is from pdfminer.six==20200124
+
+https://github.com/pdfminer/pdfminer.six
+
+pdfminer.six is a command line tool, that we include through
+requirements.txt
+
+pdf2txt.py is the file that contains the main() for pdfminer.six
+and has been copied from pdfminer.six version 20200124.
+
+A small modification has been made to our forked version of pdf2txt.py
+at about line 167
+
+```
+def main(args=None):
+    # Begin WeVote Modification to pdf2txt.py copied from pdfminer.six==20200124 on March 29, 2020
+    # TODO: as we update pdfminer.six, we might need to update this forked file too
+    if __name__ == '__main__':
+        import sys
+        main(sys.argv[1:])
+    # End WeVote Modification
+
+```
+
+This change modifies the way the (previously) command line tool
+parses arguments, so it can be directly called from views_extension

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ oauthlib==3.1.0
 nameparser==1.0.5
 phonenumbers==8.11.2
 Pillow==6.2.2
+pdfminer.six==20200124
 psycopg2-binary==2.8.4
 pyasn1==0.4.8
 pyasn1-modules==0.2.8

--- a/templates/apis_v1/apis_index.html
+++ b/templates/apis_v1/apis_index.html
@@ -894,6 +894,19 @@
 
         {###  ###}
         <tr>
+          <td colspan="3"><strong>Extension Utils</strong></td>
+          <td></td>
+          <td></td>
+        </tr>
+         <tr>
+          <td><a href="{% url 'apis_v1:pdfToHtmlRetrieveDocs' %}">pdfToHtmlRetrieve</a></td>
+          <td></td>
+          <td>Convert a pdf into a html page in S3, and return that URL.
+          </td>
+        </tr>
+
+        {###  ###}
+        <tr>
           <td colspan="3"><strong>Voter Language</strong></td>
           <td></td>
           <td></td>


### PR DESCRIPTION
Reads in the PDF by URL, applies it to pdf2Text.py by calling the Python tool https://github.com/pdfminer/pdfminer.six  (There are many other forks of pdfminer in Github, but the one we use is pdfminer.six, not plain pdfminer!)
Files in s3 are set to expire in 1 week
A good test URL:
https://www.iuoe399.org/media/filer_public/45/77/457700c9-dd70-4cfc-be49-a81cb3fba0a6/2020_lu399_primary_endorsement.pdf
Becomes:
https://wevote-temporary.s3.amazonaws.com/tmprts8w5ub.html