### PR TITLE
Try removing AppleOAuth2 from list of AUTHENTICATION_BACKENDS

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -166,7 +166,6 @@ MIDDLEWARE = [
 ]
 
 AUTHENTICATION_BACKENDS = (
-    'AppleOAuth2',
     'social_core.backends.facebook.FacebookOAuth2',
     'social_core.backends.google.GoogleOAuth2',
     'social_core.backends.twitter.TwitterOAuth',


### PR DESCRIPTION
to avoid twitter/facebook signin to api server crash