### PR TITLE
Converted more fields from URLField to TextField to avoid crashes caused by photo URLs that are longer than 255 characters. Removing individuals from Partisan Analysis page. Turned required stylesheets back on in organization_index.html.

### DIFF
--- a/activity/models.py
+++ b/activity/models.py
@@ -16,6 +16,7 @@ NOTICE_FRIEND_ENDORSEMENTS_SEED = 'NOTICE_FRIEND_ENDORSEMENTS_SEED'
 # Kind of Notice
 NOTICE_FRIEND_ENDORSEMENTS = 'NOTICE_FRIEND_ENDORSEMENTS'
 
+
 class ActivityNotice(models.Model):
     """
     This is a notice for the notification drop-down menu, for one person
@@ -41,6 +42,8 @@ class ActivityNotice(models.Model):
     send_to_sms = models.BooleanField(default=False)
     scheduled_to_sms = models.BooleanField(default=False)
     sent_to_sms = models.BooleanField(default=False)
+    speaker_profile_image_url_medium = models.URLField(blank=True, null=True)
+    speaker_profile_image_url_tiny = models.URLField(blank=True, null=True)
 
 
 class ActivityNoticeSeed(models.Model):
@@ -60,6 +63,8 @@ class ActivityNoticeSeed(models.Model):
     speaker_name = models.CharField(max_length=255, default=None, null=True)
     speaker_organization_we_vote_id = models.CharField(max_length=255, default=None, null=True)
     speaker_voter_we_vote_id = models.CharField(max_length=255, default=None, null=True)
+    speaker_profile_image_url_medium = models.URLField(blank=True, null=True)
+    speaker_profile_image_url_tiny = models.URLField(blank=True, null=True)
 
 
 class ActivityTidbit(models.Model):
@@ -77,6 +82,8 @@ class ActivityTidbit(models.Model):
     speaker_twitter_followers_count = models.PositiveIntegerField(default=None, null=True)
     speaker_twitter_handle = models.CharField(max_length=255, default=None, null=True)
     speaker_voter_we_vote_id = models.CharField(max_length=255, default=None, null=True)
+    speaker_profile_image_url_medium = models.URLField(blank=True, null=True)
+    speaker_profile_image_url_tiny = models.URLField(blank=True, null=True)
 
 
 class ActivityManager(models.Manager):
@@ -272,7 +279,7 @@ class ActivityManager(models.Manager):
                 activity_notice_found = False
                 success = False
                 status += "RETRIEVE_RECENT_ACTIVITY_NOTICE_VARIABLES_MISSING "
-        except ActivityNoticeSeed.DoesNotExist:
+        except ActivityNotice.DoesNotExist:
             exception_does_not_exist = True
             success = True
             status += "RETRIEVE_RECENT_ACTIVITY_NOTICE_NOT_FOUND "

--- a/activity/models.py
+++ b/activity/models.py
@@ -42,8 +42,8 @@ class ActivityNotice(models.Model):
     send_to_sms = models.BooleanField(default=False)
     scheduled_to_sms = models.BooleanField(default=False)
     sent_to_sms = models.BooleanField(default=False)
-    speaker_profile_image_url_medium = models.URLField(blank=True, null=True)
-    speaker_profile_image_url_tiny = models.URLField(blank=True, null=True)
+    speaker_profile_image_url_medium = models.TextField(blank=True, null=True)
+    speaker_profile_image_url_tiny = models.TextField(blank=True, null=True)
 
 
 class ActivityNoticeSeed(models.Model):
@@ -63,8 +63,8 @@ class ActivityNoticeSeed(models.Model):
     speaker_name = models.CharField(max_length=255, default=None, null=True)
     speaker_organization_we_vote_id = models.CharField(max_length=255, default=None, null=True)
     speaker_voter_we_vote_id = models.CharField(max_length=255, default=None, null=True)
-    speaker_profile_image_url_medium = models.URLField(blank=True, null=True)
-    speaker_profile_image_url_tiny = models.URLField(blank=True, null=True)
+    speaker_profile_image_url_medium = models.TextField(blank=True, null=True)
+    speaker_profile_image_url_tiny = models.TextField(blank=True, null=True)
 
 
 class ActivityTidbit(models.Model):
@@ -82,8 +82,8 @@ class ActivityTidbit(models.Model):
     speaker_twitter_followers_count = models.PositiveIntegerField(default=None, null=True)
     speaker_twitter_handle = models.CharField(max_length=255, default=None, null=True)
     speaker_voter_we_vote_id = models.CharField(max_length=255, default=None, null=True)
-    speaker_profile_image_url_medium = models.URLField(blank=True, null=True)
-    speaker_profile_image_url_tiny = models.URLField(blank=True, null=True)
+    speaker_profile_image_url_medium = models.TextField(blank=True, null=True)
+    speaker_profile_image_url_tiny = models.TextField(blank=True, null=True)
 
 
 class ActivityManager(models.Manager):

--- a/candidate/models.py
+++ b/candidate/models.py
@@ -1480,7 +1480,7 @@ class CandidateCampaign(models.Model):
         verbose_name='url of wikipedia logo', blank=True, null=True)
     linkedin_url = models.CharField(
         verbose_name="linkedin url of candidate", max_length=255, null=True, blank=True)
-    linkedin_photo_url = models.URLField(verbose_name='url of linkedin logo', blank=True, null=True)
+    linkedin_photo_url = models.TextField(verbose_name='url of linkedin logo', blank=True, null=True)
 
     # other_source_url is the location (ex/ http://mywebsite.com/candidate1.html) where we find
     # the other_source_photo_url OR the original url of the photo before we store it locally
@@ -1494,13 +1494,13 @@ class CandidateCampaign(models.Model):
                                                   max_length=255, null=True, blank=True)
     ballotpedia_candidate_summary = models.TextField(verbose_name="candidate summary from ballotpedia",
                                                      null=True, blank=True, default=None)
-    ballotpedia_candidate_url = models.URLField(
-        verbose_name='url of candidate on ballotpedia', max_length=255, blank=True, null=True)
+    ballotpedia_candidate_url = models.TextField(
+        verbose_name='url of candidate on ballotpedia', blank=True, null=True)
     ballotpedia_election_id = models.PositiveIntegerField(verbose_name="ballotpedia election id", null=True, blank=True)
     # The id of the image for retrieval from Ballotpedia API
     ballotpedia_image_id = models.PositiveIntegerField(verbose_name="ballotpedia image id", null=True, blank=True)
-    ballotpedia_profile_image_url_https = models.URLField(
-        verbose_name='locally cached candidate profile image from ballotpedia', max_length=255, blank=True, null=True)
+    ballotpedia_profile_image_url_https = models.TextField(
+        verbose_name='locally cached candidate profile image from ballotpedia', blank=True, null=True)
     # Equivalent to Elected Office
     ballotpedia_office_id = models.PositiveIntegerField(
         verbose_name="ballotpedia elected office integer id", null=True, blank=True)

--- a/issue/views_admin.py
+++ b/issue/views_admin.py
@@ -18,7 +18,7 @@ from election.models import ElectionManager
 from exception.models import handle_record_found_more_than_one_exception
 from image.controllers import cache_issue_image_master, cache_resized_image_locally, delete_cached_images_for_issue
 from image.models import WeVoteImageManager
-from organization.models import OrganizationManager, OrganizationListManager
+from organization.models import INDIVIDUAL, OrganizationManager, OrganizationListManager
 from voter.models import fetch_voter_from_request, voter_has_authority
 from voter_guide.models import VoterGuideListManager
 import wevote_functions.admin
@@ -830,7 +830,9 @@ def issue_partisan_analysis_view(request):
     organization_manager = OrganizationManager()
     organization_issues_lists = {}
     organization_we_vote_id_has_at_least_one_issue = []
-    results = voter_guide_list_manager.retrieve_voter_guides_for_election(google_civic_election_id_list)
+    exclude_voter_guide_owner_type_list = [INDIVIDUAL]
+    results = voter_guide_list_manager.retrieve_voter_guides_for_election(
+        google_civic_election_id_list, exclude_voter_guide_owner_type_list)
     voter_guide_list = []
     if results['voter_guide_list_found']:
         voter_guide_list = results['voter_guide_list']

--- a/organization/models.py
+++ b/organization/models.py
@@ -2717,10 +2717,10 @@ class Organization(models.Model):
     facebook_email = models.EmailField(verbose_name='facebook email address', max_length=255, unique=False,
                                        null=True, blank=True)
     fb_username = models.CharField(unique=True, max_length=50, validators=[alphanumeric], null=True)
-    facebook_profile_image_url_https = models.URLField(verbose_name='url of image from facebook',
-                                                       blank=True, null=True)
-    facebook_background_image_url_https = models.URLField(verbose_name='url of cover image from facebook',
-                                                          blank=True, null=True)
+    facebook_profile_image_url_https = models.TextField(
+        verbose_name='url of image from facebook', blank=True, null=True)
+    facebook_background_image_url_https = models.TextField(
+        verbose_name='url of cover image from facebook', blank=True, null=True)
 
     # Twitter information
     twitter_user_id = models.BigIntegerField(verbose_name="twitter id", null=True, blank=True)
@@ -2732,12 +2732,12 @@ class Organization(models.Model):
         verbose_name="org location from twitter", max_length=255, null=True, blank=True)
     twitter_followers_count = models.IntegerField(verbose_name="number of twitter followers",
                                                   null=False, blank=True, default=0)
-    twitter_profile_image_url_https = models.URLField(verbose_name='url of user logo from twitter',
-                                                      blank=True, null=True)
-    twitter_profile_background_image_url_https = models.URLField(verbose_name='tile-able background from twitter',
-                                                                 blank=True, null=True)
-    twitter_profile_banner_url_https = models.URLField(verbose_name='profile banner image from twitter',
-                                                       blank=True, null=True)
+    twitter_profile_image_url_https = models.TextField(
+        verbose_name='url of user logo from twitter', blank=True, null=True)
+    twitter_profile_background_image_url_https = models.TextField(
+        verbose_name='tile-able background from twitter', blank=True, null=True)
+    twitter_profile_banner_url_https = models.TextField(
+        verbose_name='profile banner image from twitter', blank=True, null=True)
     twitter_description = models.CharField(verbose_name="Text description of this organization from twitter.",
                                            max_length=255, null=True, blank=True)
 
@@ -2745,27 +2745,27 @@ class Organization(models.Model):
     organization_instagram_handle = models.CharField(
         verbose_name='organization instagram screen_name', max_length=255, null=True, unique=False)
 
-    we_vote_hosted_profile_image_url_large = models.URLField(verbose_name='we vote hosted large image url',
-                                                              blank=True, null=True)
-    we_vote_hosted_profile_image_url_medium = models.URLField(verbose_name='we vote hosted medium image url',
-                                                              blank=True, null=True)
-    we_vote_hosted_profile_image_url_tiny = models.URLField(verbose_name='we vote hosted tiny image url',
-                                                            blank=True, null=True)
+    we_vote_hosted_profile_image_url_large = models.TextField(
+        verbose_name='we vote hosted large image url', blank=True, null=True)
+    we_vote_hosted_profile_image_url_medium = models.TextField(
+        verbose_name='we vote hosted medium image url', blank=True, null=True)
+    we_vote_hosted_profile_image_url_tiny = models.TextField(
+        verbose_name='we vote hosted tiny image url', blank=True, null=True)
 
     wikipedia_page_id = models.BigIntegerField(verbose_name="pageid", null=True, blank=True)
     wikipedia_page_title = models.CharField(
         verbose_name="Page title on Wikipedia", max_length=255, null=True, blank=True)
-    wikipedia_thumbnail_url = models.URLField(
-        verbose_name='url of wikipedia logo thumbnail', max_length=255, blank=True, null=True)
+    wikipedia_thumbnail_url = models.TextField(
+        verbose_name='url of wikipedia logo thumbnail', blank=True, null=True)
     wikipedia_thumbnail_width = models.IntegerField(verbose_name="width of photo", null=True, blank=True)
     wikipedia_thumbnail_height = models.IntegerField(verbose_name="height of photo", null=True, blank=True)
-    wikipedia_photo_url = models.URLField(
-        verbose_name='url of wikipedia logo', max_length=255, blank=True, null=True)
+    wikipedia_photo_url = models.TextField(
+        verbose_name='url of wikipedia logo', blank=True, null=True)
 
     ballotpedia_page_title = models.CharField(
         verbose_name="Page title on Ballotpedia", max_length=255, null=True, blank=True)
-    ballotpedia_photo_url = models.URLField(
-        verbose_name='url of ballotpedia logo', max_length=255, blank=True, null=True)
+    ballotpedia_photo_url = models.TextField(
+        verbose_name='url of ballotpedia logo', blank=True, null=True)
 
     issue_analysis_done = models.BooleanField(default=False)
     issue_analysis_admin_notes = models.TextField(verbose_name="we vote admin notes", null=True, blank=True)
@@ -2777,14 +2777,14 @@ class Organization(models.Model):
     # This is the domain name the client has configured for their We Vote configured site
     chosen_domain_string = models.CharField(
         verbose_name="client domain name for we vote site", max_length=255, null=True, blank=True)
-    chosen_favicon_url_https = models.URLField(
-        verbose_name='url of client favicon', max_length=255, blank=True, null=True)
+    chosen_favicon_url_https = models.TextField(
+        verbose_name='url of client favicon', blank=True, null=True)
     chosen_google_analytics_account_number = models.CharField(max_length=255, null=True, blank=True)
     chosen_html_verification_string = models.CharField(max_length=255, null=True, blank=True)
     # Set to True to hide We Vote logo
     chosen_hide_we_vote_logo = models.BooleanField(default=False)
-    chosen_logo_url_https = models.URLField(
-        verbose_name='url of client logo', max_length=255, blank=True, null=True)
+    chosen_logo_url_https = models.TextField(
+        verbose_name='url of client logo', blank=True, null=True)
     # Client chosen pass code that needs to be sent with organization-focused API calls
     chosen_organization_api_pass_code = models.TextField(null=True, blank=True)
     # For sites managed by 501c3 organizations, we need to prevent voters from sharing their opinions
@@ -2794,10 +2794,10 @@ class Organization(models.Model):
     chosen_ready_introduction_text = models.TextField(null=True, blank=True)
     # Client configured text that will show in index.html
     chosen_social_share_description = models.TextField(null=True, blank=True)
-    chosen_social_share_master_image_url_https = models.URLField(
-        verbose_name='url of client social share master image', max_length=255, blank=True, null=True)
-    chosen_social_share_image_256x256_url_https = models.URLField(
-        verbose_name='url of client social share image', max_length=255, blank=True, null=True)
+    chosen_social_share_master_image_url_https = models.TextField(
+        verbose_name='url of client social share master image', blank=True, null=True)
+    chosen_social_share_image_256x256_url_https = models.TextField(
+        verbose_name='url of client social share image', blank=True, null=True)
     # This is the subdomain the client has configured for yyy.WeVote.US
     chosen_subdomain_string = models.CharField(
         verbose_name="client we vote subdomain", max_length=255, null=True, blank=True)
@@ -2815,8 +2815,8 @@ class Organization(models.Model):
     # These get copied from features_provided_bitmap in MasterFeaturePackage table
     features_provided_bitmap = models.PositiveIntegerField(verbose_name="features that are active", default=0)
 
-    organization_endorsements_api_url = models.URLField(
-        verbose_name='endorsements importer url', max_length=255, blank=True, null=True)
+    organization_endorsements_api_url = models.TextField(
+        verbose_name='endorsements importer url', blank=True, null=True)
 
     def __unicode__(self):
         return str(self.organization_name)

--- a/support_oppose_deciding/controllers.py
+++ b/support_oppose_deciding/controllers.py
@@ -1194,7 +1194,7 @@ def voter_supporting_save_for_api(voter_device_id,  # voterSupportingSave
     results = is_voter_device_id_valid(voter_device_id)
     if not results['success']:
         json_data = {
-            'status': 'VALID_VOTER_DEVICE_ID_MISSING',
+            'status': 'VALID_VOTER_DEVICE_ID_MISSING ',
             'success': False,
             'ballot_item_id':           0,
             'ballot_item_we_vote_id':   '',
@@ -1205,7 +1205,7 @@ def voter_supporting_save_for_api(voter_device_id,  # voterSupportingSave
     voter_id = fetch_voter_id_from_voter_device_link(voter_device_id)
     if not positive_value_exists(voter_id):
         json_data = {
-            'status': "VALID_VOTER_ID_MISSING",
+            'status': "VALID_VOTER_ID_MISSING ",
             'success': False,
             'ballot_item_id':           0,
             'ballot_item_we_vote_id':   '',
@@ -1243,9 +1243,9 @@ def voter_supporting_save_for_api(voter_device_id,  # voterSupportingSave
         elif positive_value_exists(measure_we_vote_id):
             measure_id = contest_measure_manager.fetch_contest_measure_id_from_we_vote_id(measure_we_vote_id)
 
-        results = position_manager.toggle_on_voter_support_for_contest_measure(voter_id, measure_id,
-                                                                               user_agent_string, user_agent_object)
-        status += "SUPPORTING_MEASURE " + results['status'] + " "
+        results = position_manager.toggle_on_voter_support_for_contest_measure(
+            voter_id, measure_id, user_agent_string, user_agent_object)
+        status += "SUPPORTING_MEASURE: " + results['status'] + " "
         success = results['success']
 
         json_data = {
@@ -1257,7 +1257,7 @@ def voter_supporting_save_for_api(voter_device_id,  # voterSupportingSave
         }
         return HttpResponse(json.dumps(json_data), content_type='application/json')
     else:
-        status = 'UNABLE_TO_SAVE-CANDIDATE_ID_AND_MEASURE_ID_MISSING'
+        status += 'UNABLE_TO_SAVE-CANDIDATE_ID_AND_MEASURE_ID_MISSING '
         success = False
 
     json_data = {

--- a/templates/organization/organization_index.html
+++ b/templates/organization/organization_index.html
@@ -43,11 +43,9 @@
     <link rel="icon" sizes="48x48" href="/img/global/icons/favicon.ico" >
   {% endif %}
 
-<!-- These lines replaced below with injected HTML //-->
-<!--    <link rel="preload" onload="this.rel='stylesheet'" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css" as="style" crossOrigin="anonymous" integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" />-->
-<!--    <link rel="preload" as="style" onload="this.rel='stylesheet'" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css"/>-->
-<!--    <link rel="preload" as="style" onload="this.rel='stylesheet'" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick-theme.min.css" />-->
-<!--    <link rel="preload" as="style" onload="this.rel='stylesheet'" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-social/4.12.0/bootstrap-social.min.css" />-->
+    <link rel="preload" as="style" onload="this.rel='stylesheet'" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css"/>
+    <link rel="preload" as="style" onload="this.rel='stylesheet'" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick-theme.min.css" />
+    <link rel="preload" as="style" onload="this.rel='stylesheet'" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-social/4.12.0/bootstrap-social.min.css" />
 
     <!-- Google Analytics -->
     <script>

--- a/voter/models.py
+++ b/voter/models.py
@@ -2093,20 +2093,21 @@ class Voter(AbstractBaseUser):
     facebook_email = models.EmailField(verbose_name='facebook email address', max_length=255, unique=False,
                                        null=True, blank=True)
     fb_username = models.CharField(max_length=50, validators=[alphanumeric], null=True)
-    facebook_profile_image_url_https = models.URLField(verbose_name='url of image from facebook', blank=True, null=True)
+    facebook_profile_image_url_https = models.TextField(
+        verbose_name='url of image from facebook', blank=True, null=True)
 
     # Twitter session information
     twitter_id = models.BigIntegerField(verbose_name="twitter big integer id", null=True, blank=True)
     twitter_name = models.CharField(verbose_name="display name from twitter", max_length=255, null=True, blank=True)
-    twitter_screen_name = models.CharField(verbose_name='twitter screen name / handle',
-                                           max_length=255, null=True, unique=False)
-    twitter_profile_image_url_https = models.URLField(verbose_name='url of logo from twitter', blank=True, null=True)
-    we_vote_hosted_profile_image_url_large = models.URLField(verbose_name='we vote hosted large image url',
-                                                             blank=True, null=True)
-    we_vote_hosted_profile_image_url_medium = models.URLField(verbose_name='we vote hosted medium image url',
-                                                              blank=True, null=True)
-    we_vote_hosted_profile_image_url_tiny = models.URLField(verbose_name='we vote hosted tiny image url',
-                                                            blank=True, null=True)
+    twitter_screen_name = models.CharField(
+        verbose_name='twitter screen name / handle', max_length=255, null=True, unique=False)
+    twitter_profile_image_url_https = models.TextField(verbose_name='url of logo from twitter', blank=True, null=True)
+    we_vote_hosted_profile_image_url_large = models.TextField(
+        verbose_name='we vote hosted large image url', blank=True, null=True)
+    we_vote_hosted_profile_image_url_medium = models.TextField(
+        verbose_name='we vote hosted medium image url', blank=True, null=True)
+    we_vote_hosted_profile_image_url_tiny = models.TextField(
+        verbose_name='we vote hosted tiny image url', blank=True, null=True)
 
     twitter_request_token = models.TextField(verbose_name='twitter request token', null=True, blank=True)
     twitter_request_secret = models.TextField(verbose_name='twitter request secret', null=True, blank=True)

--- a/voter_guide/models.py
+++ b/voter_guide/models.py
@@ -1051,13 +1051,13 @@ class VoterGuide(models.Model):
     display_name = models.CharField(
         verbose_name="display title for this voter guide", max_length=255, null=True, blank=True, unique=False)
 
-    image_url = models.URLField(verbose_name='image url of logo/photo associated with voter guide',
-                                blank=True, null=True)
-    we_vote_hosted_profile_image_url_large = models.URLField(
+    image_url = models.TextField(
+        verbose_name='image url of logo/photo associated with voter guide', blank=True, null=True)
+    we_vote_hosted_profile_image_url_large = models.TextField(
         verbose_name='large version image url of logo/photo associated with voter guide', blank=True, null=True)
-    we_vote_hosted_profile_image_url_medium = models.URLField(
+    we_vote_hosted_profile_image_url_medium = models.TextField(
         verbose_name='medium version image url of logo/photo associated with voter guide', blank=True, null=True)
-    we_vote_hosted_profile_image_url_tiny = models.URLField(
+    we_vote_hosted_profile_image_url_tiny = models.TextField(
         verbose_name='tiny version image url of logo/photo associated with voter guide', blank=True, null=True)
 
     # Mapped directly from organization.organization_type
@@ -1188,7 +1188,8 @@ class VoterGuideListManager(models.Model):
     # NOTE: This is extremely simple way to retrieve voter guides, used by admin tools. Being replaced by:
     #  retrieve_voter_guides_by_ballot_item(ballot_item_we_vote_id) AND
     #  retrieve_voter_guides_by_election(google_civic_election_id)
-    def retrieve_voter_guides_for_election(self, google_civic_election_id_list):
+    def retrieve_voter_guides_for_election(
+            self, google_civic_election_id_list, exclude_voter_guide_owner_type_list=[]):
         voter_guide_list = []
         voter_guide_list_found = False
 
@@ -1196,9 +1197,12 @@ class VoterGuideListManager(models.Model):
             # voter_guide_query = VoterGuide.objects.order_by('-twitter_followers_count')
             voter_guide_query = VoterGuide.objects.order_by('display_name')
             voter_guide_query = voter_guide_query.exclude(vote_smart_ratings_only=True)
-            voter_guide_list = voter_guide_query.filter(
+            voter_guide_query = voter_guide_query.filter(
                 google_civic_election_id__in=google_civic_election_id_list)
-
+            if len(exclude_voter_guide_owner_type_list):
+                voter_guide_query = \
+                    voter_guide_query.exclude(voter_guide_owner_type__in=exclude_voter_guide_owner_type_list)
+            voter_guide_list = list(voter_guide_query)
             if len(voter_guide_list):
                 voter_guide_list_found = True
                 status = 'VOTER_GUIDE_FOUND'
@@ -2751,11 +2755,11 @@ class VoterGuidePossibility(models.Model):
     # We are relying on built-in Python id field
 
     # Where a volunteer thinks there is a voter guide
-    voter_guide_possibility_url = models.URLField(
-        verbose_name='url of possible voter guide', max_length=255, blank=True, null=True)
+    voter_guide_possibility_url = models.TextField(
+        verbose_name='url of possible voter guide', blank=True, null=True)
 
-    voter_guide_possibility_pdf_url = models.URLField(
-        verbose_name='url of possible voter guide which is a PDF', max_length=255, blank=True, null=True)
+    voter_guide_possibility_pdf_url = models.TextField(
+        verbose_name='url of possible voter guide which is a PDF', blank=True, null=True)
 
     # The unique id of the organization making the endorsements, if/when we know it
     organization_we_vote_id = models.CharField(
@@ -2878,8 +2882,8 @@ class VoterGuidePossibilityPosition(models.Model):
     google_civic_election_id = models.PositiveIntegerField(null=True)
     position_stance = models.CharField(max_length=15, choices=POSITION_CHOICES, default=SUPPORT)
     # A link to any location with more information about this position
-    more_info_url = models.URLField(
-        verbose_name='url with more info about this position', max_length=255, blank=True, null=True)
+    more_info_url = models.TextField(
+        verbose_name='url with more info about this position', blank=True, null=True)
     # We don't want to work with this possibility any more
     possibility_should_be_ignored = models.BooleanField(default=False,
                                                         verbose_name='Soft delete. Stop analyzing this entry.')


### PR DESCRIPTION
Converted more fields from URLField to TextField to avoid crashes caused by photo URLs that are longer than 255 characters. Removing individuals from Partisan Analysis page. Turned required stylesheets back on in organization_index.html.