### PR TITLE
Updated notice_friend_endorsement_send to use activity_tidbit_we_vote_id for News page instead of directing voter to friend's voter guide. Fixed bug where position comments were not being saved and without date_entered value.

### DIFF
--- a/activity/models.py
+++ b/activity/models.py
@@ -72,6 +72,7 @@ class ActivityManager(models.Manager):
     def create_activity_notice(
             self,
             activity_notice_seed_id=0,
+            activity_tidbit_we_vote_id='',
             date_of_notice=None,
             kind_of_notice=None,
             kind_of_seed=None,
@@ -103,6 +104,7 @@ class ActivityManager(models.Manager):
                 new_positions_entered_count += len(position_we_vote_id_list)
             activity_notice = ActivityNotice.objects.create(
                 activity_notice_seed_id=activity_notice_seed_id,
+                activity_tidbit_we_vote_id=activity_tidbit_we_vote_id,
                 date_of_notice=date_of_notice,
                 kind_of_notice=kind_of_notice,
                 kind_of_seed=kind_of_seed,
@@ -573,10 +575,14 @@ class ActivityManager(models.Manager):
         }
         return results
 
-    def retrieve_activity_notice_seed_list_for_recipient(self, recipient_voter_we_vote_id=''):
+    def retrieve_activity_notice_seed_list_for_recipient(
+            self,
+            recipient_voter_we_vote_id='',
+            limit_to_activity_tidbit_we_vote_id_list=[]):
         """
 
         :param recipient_voter_we_vote_id:
+        :param limit_to_activity_tidbit_we_vote_id_list:
         :return:
         """
         status = ""
@@ -608,6 +614,8 @@ class ActivityManager(models.Manager):
                 speaker_voter_we_vote_id__in=voter_friend_we_vote_id_list,
                 deleted=False
             )
+            if limit_to_activity_tidbit_we_vote_id_list and len(limit_to_activity_tidbit_we_vote_id_list) > 0:
+                queryset = queryset.filter(we_vote_id__in=limit_to_activity_tidbit_we_vote_id_list)
             queryset = queryset.exclude(
                 Q(speaker_voter_we_vote_id=None) | Q(speaker_voter_we_vote_id=""))
             queryset = queryset.order_by('-id')  # Put most recent at top of list
@@ -693,10 +701,12 @@ class ActivityManager(models.Manager):
     def retrieve_activity_post_list_for_recipient(
             self,
             recipient_voter_we_vote_id='',
+            limit_to_activity_tidbit_we_vote_id_list=[],
             voter_friend_we_vote_id_list=[]):
         """
 
         :param recipient_voter_we_vote_id:
+        :param limit_to_activity_tidbit_we_vote_id_list:
         :param voter_friend_we_vote_id_list:
         :return:
         """
@@ -729,6 +739,8 @@ class ActivityManager(models.Manager):
                 speaker_voter_we_vote_id__in=voter_friend_we_vote_id_list,
                 deleted=False
             )
+            if limit_to_activity_tidbit_we_vote_id_list and len(limit_to_activity_tidbit_we_vote_id_list) > 0:
+                queryset = queryset.filter(we_vote_id__in=limit_to_activity_tidbit_we_vote_id_list)
             queryset = queryset.exclude(
                 Q(speaker_voter_we_vote_id=None) | Q(speaker_voter_we_vote_id=""))
             queryset = queryset.order_by('-id')  # Put most recent ActivityPost at top of list
@@ -1050,6 +1062,7 @@ class ActivityNotice(models.Model):
     This is a notice for the notification drop-down menu, for one person
     """
     activity_notice_seed_id = models.PositiveIntegerField(default=None, null=True)
+    activity_tidbit_we_vote_id = models.CharField(max_length=255, default=None, null=True)  # subject of notice
     date_of_notice = models.DateTimeField(null=True)
     date_last_changed = models.DateTimeField(null=True, auto_now=True)
     activity_notice_clicked = models.BooleanField(default=False)

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -88,6 +88,7 @@ ACTION_SEARCH_OPINIONS = 70
 ACTION_UNSUBSCRIBE_EMAIL_PAGE = 71
 ACTION_UNSUBSCRIBE_SMS_PAGE = 72
 ACTION_MEASURE = 73
+ACTION_NEWS = 74
 
 ACTIONS_THAT_REQUIRE_ORGANIZATION_IDS = \
     [ACTION_ORGANIZATION_AUTO_FOLLOW,
@@ -1946,6 +1947,8 @@ def display_action_constant_human_readable(action_constant):
         return "MODAL_VOTER_PLAN"
     if action_constant == ACTION_NETWORK:
         return "NETWORK"
+    if action_constant == ACTION_NEWS:
+        return "NEWS"
     if action_constant == ACTION_OFFICE:
         return "OFFICE"
     if action_constant == ACTION_ORGANIZATION_AUTO_FOLLOW:
@@ -2188,4 +2191,6 @@ def fetch_action_constant_number_from_constant_string(action_constant_string):
         return 72
     if action_constant_string in 'ACTION_MEASURE':
         return 73
+    if action_constant_string in 'ACTION_NEWS':
+        return 74
     return 0

--- a/apis_v1/views/views_activity.py
+++ b/apis_v1/views/views_activity.py
@@ -145,6 +145,8 @@ def activity_list_retrieve_view(request):  # activityListRetrieve
     voter_device_id = get_voter_device_id(request)  # We standardize how we take in the voter_device_id
     voter_friend_we_vote_id_list = []
     voter_we_vote_id = ''
+    activity_tidbit_we_vote_id_list = request.GET.getlist('activity_tidbit_we_vote_id_list[]')
+    activity_tidbit_we_vote_id_list = list(filter(None, activity_tidbit_we_vote_id_list))
 
     if positive_value_exists(voter_device_id):
         voter_we_vote_id = fetch_voter_we_vote_id_from_voter_device_link(voter_device_id)
@@ -159,7 +161,8 @@ def activity_list_retrieve_view(request):  # activityListRetrieve
         return HttpResponse(json.dumps(json_data), content_type='application/json')
 
     results = activity_manager.retrieve_activity_notice_seed_list_for_recipient(
-        recipient_voter_we_vote_id=voter_we_vote_id)
+        recipient_voter_we_vote_id=voter_we_vote_id,
+        limit_to_activity_tidbit_we_vote_id_list=activity_tidbit_we_vote_id_list)
     if results['success']:
         activity_notice_seed_list = results['activity_notice_seed_list']
         voter_friend_we_vote_id_list = results['voter_friend_we_vote_id_list']
@@ -206,6 +209,7 @@ def activity_list_retrieve_view(request):  # activityListRetrieve
     # Retrieve entries directly in the ActivityPost table
     results = activity_manager.retrieve_activity_post_list_for_recipient(
         recipient_voter_we_vote_id=voter_we_vote_id,
+        limit_to_activity_tidbit_we_vote_id_list=activity_tidbit_we_vote_id_list,
         voter_friend_we_vote_id_list=voter_friend_we_vote_id_list)
     if results['success']:
         activity_post_list = results['activity_post_list']
@@ -376,6 +380,7 @@ def activity_notice_list_retrieve_view(request):  # activityNoticeListRetrieve
             activity_notice_dict = {
                 'activity_notice_clicked':          activity_notice.activity_notice_clicked,
                 'activity_notice_seen':             activity_notice.activity_notice_seen,
+                'activity_tidbit_we_vote_id':       activity_notice.activity_tidbit_we_vote_id,
                 'date_last_changed':                activity_notice.date_last_changed.strftime('%Y-%m-%d %H:%M:%S'),
                 'date_of_notice':                   activity_notice.date_of_notice.strftime('%Y-%m-%d %H:%M:%S'),
                 'activity_notice_id':               activity_notice.id,


### PR DESCRIPTION
Updated notice_friend_endorsement_send to use activity_tidbit_we_vote_id for News page instead of directing voter to friend's voter guide. Fixed bug where position comments were not being saved and without date_entered value.