### PR TITLE
Preventing adding the same Twitter handle already used by another organization when editing an organization. Fixed problem where empty Twitter descriptions were not removing old Twitter descriptions on update. Fixed bug with "merge two organizations".

### DIFF
--- a/candidate/models.py
+++ b/candidate/models.py
@@ -2925,11 +2925,11 @@ class CandidateCampaignManager(models.Model):
                 candidate.we_vote_hosted_profile_image_url_tiny = we_vote_hosted_profile_image_url_tiny
                 values_changed = True
 
-            if 'description' in twitter_json and positive_value_exists(twitter_json['description']):
+            if 'description' in twitter_json:  # No value required to update description (so we can clear out)
                 if twitter_json['description'] != candidate.twitter_description:
                     candidate.twitter_description = twitter_json['description']
                     values_changed = True
-            if 'location' in twitter_json and positive_value_exists(twitter_json['location']):
+            if 'location' in twitter_json:  # No value required to update location (so we can clear out)
                 if twitter_json['location'] != candidate.twitter_location:
                     candidate.twitter_location = twitter_json['location']
                     values_changed = True

--- a/elected_official/models.py
+++ b/elected_official/models.py
@@ -1579,11 +1579,11 @@ class ElectedOfficialManager(models.Model):
                 elected_official.we_vote_hosted_profile_image_url_tiny = we_vote_hosted_profile_image_url_tiny
                 values_changed = True
 
-            if 'description' in twitter_json and positive_value_exists(twitter_json['description']):
+            if 'description' in twitter_json:  # No value required to update description (so we can clear out)
                 if twitter_json['description'] != elected_official.twitter_description:
                     elected_official.twitter_description = twitter_json['description']
                     values_changed = True
-            if 'location' in twitter_json and positive_value_exists(twitter_json['location']):
+            if 'location' in twitter_json:  # No value required to update location (so we can clear out)
                 if twitter_json['location'] != elected_official.twitter_location:
                     elected_official.twitter_location = twitter_json['location']
                     values_changed = True

--- a/organization/models.py
+++ b/organization/models.py
@@ -1880,11 +1880,11 @@ class OrganizationManager(models.Manager):
                 organization.we_vote_hosted_profile_image_url_tiny = we_vote_hosted_profile_image_url_tiny
                 values_changed = True
 
-            if 'description' in twitter_json and positive_value_exists(twitter_json['description']):
+            if 'description' in twitter_json:  # No value required to update description (so we can clear out)
                 if twitter_json['description'] != organization.twitter_description:
                     organization.twitter_description = twitter_json['description']
                     values_changed = True
-            if 'location' in twitter_json and positive_value_exists(twitter_json['location']):
+            if 'location' in twitter_json:  # No value required to update location (so we can clear out)
                 if twitter_json['location'] != organization.twitter_location:
                     organization.twitter_location = twitter_json['location']
                     values_changed = True

--- a/templates/organization/organization_edit.html
+++ b/templates/organization/organization_edit.html
@@ -102,7 +102,10 @@ span.nobr { white-space: nowrap; }
 
 <div class="form-group">
     <label for="organization_twitter_handle_id" class="col-sm-3 control-label">
+    <span {% if twitter_handle_mismatch %}style="color: red;"{% endif %}>
         Twitter Handle
+        {% if twitter_handle_mismatch %} MISMATCH WITH TWITTER LINK ('{{ twitter_link_to_organization_handle }}' expected){% endif %}
+    </span>
         {% if organization.organization_twitter_handle %}
         <a href="https://twitter.com/{{ organization.organization_twitter_handle }}"
                    target="_blank"

--- a/templates/organization/organization_position_list.html
+++ b/templates/organization/organization_position_list.html
@@ -51,10 +51,14 @@
                 </tr>
                 {% endif %}
                 <tr>
-                    <th>Twitter Handle:</th>
+                    <th>Twitter Link To Organization:&nbsp;</th>
+                    <td>{% if twitter_link_to_organization and twitter_link_to_organization.twitter_id %}{{ twitter_link_to_organization.fetch_twitter_handle_locally_or_remotely|default_if_none:"" }}{% else %}no link{% endif %}</td>
+                </tr>
+                <tr>
+                    <th><span {% if twitter_handle_mismatch %}style="color: red;"{% endif %}>Twitter Handle{% if twitter_handle_mismatch %} (MISMATCH WITH TWITTER LINK){% endif %}:</span></th>
                     <td>
+                    {{ organization.organization_twitter_handle|default_if_none:"" }}
                     {% if organization.generate_twitter_link %}
-                        {{ organization.organization_twitter_handle }}
                         {% if organization.organization_twitter_handle %}
                             <a href="{{ organization.generate_twitter_link }}"
                                target="_blank"
@@ -62,21 +66,25 @@
                         {% endif %}
 
                         ({{ organization.twitter_followers_count|intcomma }} Followers)
+                    {% endif %}
+                    {% if twitter_handle_mismatch %}
+                        (cannot refresh Twitter details with mismatch)
                     {% else %}
-                        {{ organization.organization_twitter_handle|default_if_none:"" }}
-                    {% endif %} (<a href="{% url 'import_export_twitter:refresh_twitter_organization_details' organization.id %}?google_civic_election_id={{ google_civic_election_id }}">refresh Twitter details</a>)
-                    (<a href="{% url 'import_export_twitter:delete_images_view'%}?organization_id={{ organization.id }}&google_civic_election_id={{ google_civic_election_id }}">Delete Cached Images</a>)</td>
+                        (<a href="{% url 'import_export_twitter:refresh_twitter_organization_details' organization.id %}?google_civic_election_id={{ google_civic_election_id }}">refresh Twitter details</a>)
+                    {% endif %}
+                    (<a href="{% url 'import_export_twitter:delete_images_view'%}?organization_id={{ organization.id }}&google_civic_election_id={{ google_civic_election_id }}">Delete Cached Images</a>)
+                    </td>
                 </tr>
                 <tr>
-                    <th>Twitter Descriptive Name:</th>
+                    <th><span {% if twitter_handle_mismatch %}style="color: red;"{% endif %}>Twitter Descriptive Name:</span></th>
                     <td>{{ organization.twitter_name|default_if_none:"" }}</td>
                 </tr>
                 <tr>
-                    <th>Twitter Description:</th>
+                    <th><span {% if twitter_handle_mismatch %}style="color: red;"{% endif %}>Twitter Description:</span></th>
                     <td>{{ organization.twitter_description|default_if_none:"" }}</td>
                 </tr>
                 <tr>
-                    <th>Twitter Location:</th>
+                    <th><span {% if twitter_handle_mismatch %}style="color: red;"{% endif %}>Twitter Location:</span></th>
                     <td>{{ organization.twitter_location|default_if_none:"" }}</td>
                 </tr>
                 <tr>

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -303,6 +303,16 @@ class TwitterUserManager(models.Model):
         }
         return results
 
+    def create_twitter_link_to_organization_from_twitter_handle(self, twitter_handle, organization_we_vote_id):
+        twitter_user_id = 0
+        results = self.retrieve_twitter_user_locally_or_remotely(twitter_user_id, twitter_handle, read_only=True)
+        if results['twitter_user_found']:
+            twitter_user = results['twitter_user']
+            twitter_user_id = twitter_user.twitter_id
+        return self.create_twitter_link_to_organization(
+            twitter_id=twitter_user_id,
+            organization_we_vote_id=organization_we_vote_id)
+
     def create_twitter_link_to_organization(self, twitter_id, organization_we_vote_id):
         if not positive_value_exists(twitter_id) or not \
                 positive_value_exists(organization_we_vote_id):
@@ -329,7 +339,7 @@ class TwitterUserManager(models.Model):
             twitter_link_to_organization_saved = False
             twitter_link_to_organization = TwitterLinkToOrganization()
             success = False
-            status = "TWITTER_LINK_TO_ORGANIZATION_NOT_CREATED"
+            status = "TWITTER_LINK_TO_ORGANIZATION_NOT_CREATED: " + str(e) + " "
 
         results = {
             'success':                              success,
@@ -507,7 +517,7 @@ class TwitterUserManager(models.Model):
         except Exception as e:
             twitter_link_to_organization_found = False
             success = False
-            status = 'FAILED retrieve_twitter_link_to_organization'
+            status = 'FAILED retrieve_twitter_link_to_organization: ' + str(e) + " "
 
         results = {
             'success':      success,
@@ -1127,11 +1137,11 @@ class TwitterUserManager(models.Model):
                 twitter_user.we_vote_hosted_profile_image_url_tiny = we_vote_hosted_profile_image_url_tiny
                 values_changed = True
 
-            if 'description' in twitter_json and positive_value_exists(twitter_json['description']):
+            if 'description' in twitter_json:  # No value required to update description (so we can clear out)
                 if twitter_json['description'] != twitter_user.twitter_description:
                     twitter_user.twitter_description = twitter_json['description']
                     values_changed = True
-            if 'location' in twitter_json and positive_value_exists(twitter_json['location']):
+            if 'location' in twitter_json:  # No value required to update location (so we can clear out)
                 if twitter_json['location'] != twitter_user.twitter_location:
                     twitter_user.twitter_location = twitter_json['location']
                     values_changed = True


### PR DESCRIPTION
Preventing adding the same Twitter handle already used by another organization when editing an organization. Fixed problem where empty Twitter descriptions were not removing old Twitter descriptions on update. Fixed bug with "merge two organizations".