### PR TITLE
New retrieveSQLTables API endpoint -- extract large tables by range to avoid out of memory crash in server

### DIFF
--- a/apis_v1/views/views_retrieve_tables.py
+++ b/apis_v1/views/views_retrieve_tables.py
@@ -19,8 +19,8 @@ def retrieve_sql_tables(request):  # retrieveSQLTables
     :return:
     """
     table = request.GET.get('table', '')
-    limit = request.GET.get('limit', '')
-    offset = request.GET.get('offset', '')
-    json_data = retrieve_sql_tables_as_csv(table, limit, offset)
+    begin = request.GET.get('begin', '')
+    end = request.GET.get('end', '')
+    json_data = retrieve_sql_tables_as_csv(table, begin, end)
     return HttpResponse(json.dumps(json_data), content_type='application/json')
 


### PR DESCRIPTION
Out of memory seems to fail silently, and does not have any reported error in Splunk.
This seems probable since the caught error in a try/except block in this code returns without the caught error appended to the output string.