### PR TITLE
Integrated PDF scanner into VG Possibility Scanner

### DIFF
--- a/admin_tools/views.py
+++ b/admin_tools/views.py
@@ -2,7 +2,7 @@
 # Brought to you by We Vote. Be good.
 # -*- coding: UTF-8 -*-
 
-from config.base import get_environment_variable, get_python_version, LOGIN_URL
+from config.base import get_environment_variable, get_node_version, get_python_version, LOGIN_URL
 from ballot.models import BallotReturned, VoterBallotSaved
 from candidate.models import CandidateCampaign, CandidateCampaignManager
 from candidate.controllers import candidates_import_from_sample_file
@@ -112,6 +112,7 @@ def admin_home_view(request):
     template_values = {
         'google_civic_election_id':         google_civic_election_id,
         'python_version':                   get_python_version(),
+        'node_version':                     get_node_version(),
         'shared_link_clicked_unique_sharer_count': shared_link_clicked_unique_sharer_count,
         'shared_link_clicked_unique_viewer_count': shared_link_clicked_unique_viewer_count,
         'shared_links_count':               shared_links_count,

--- a/apis_v1/views/views_extension.py
+++ b/apis_v1/views/views_extension.py
@@ -42,6 +42,12 @@ def pdf_to_html_retrieve_view(request):  # pdfToHtmlRetrieve
         }
         return HttpResponse(json.dumps(json_data), content_type='application/json')
 
+    json_data = process_pdf_to_html(pdf_url)
+
+    return HttpResponse(json.dumps(json_data), content_type='application/json')
+
+
+def process_pdf_to_html(pdf_url):
     file_name, headers = urllib.request.urlretrieve(pdf_url)
     pdf_name = os.path.basename(pdf_url)
     dirname, basename = os.path.split(file_name)
@@ -57,14 +63,13 @@ def pdf_to_html_retrieve_view(request):  # pdfToHtmlRetrieve
 
     # https://github.com/pdf2htmlEX/pdf2htmlEX  !Not the abandoned coolwanglu original branch!
     # https://github.com/pdf2htmlEX/pdf2htmlEX/wiki/Command-Line-Options
+    # In December 2020, we installed a docker image in AWS/EC2: https://hub.docker.com/r/cardboardci/pdf2htmlex
     # pdf2htmlEX -zoom 1.3 Cook-18-Primary-Web.pdf
     # Test cases:
     # https://www.iuoe399.org/media/filer_public/45/77/457700c9-dd70-4cfc-be49-a81cb3fba0a6/2020_lu399_primary_endorsement.pdf
     # http://www.local150.org/wp-content/uploads/2018/02/Cook-18-Primary-Web.pdf
     # http://www.sddemocrats.org/sites/sdcdp/files/pdf/Endorsements_Flyer_P2020b.pdf
     # https://crpa.org/wp-content/uploads/2020-CA-Primary-Candidate-Final.pdf
-    # TODO: Note there is some post processing of the html in fixupForPdf2htmlEX() in the chrome extension that will be
-    #  needed here, if we use this on the server and process the resulting HTML in Python
 
     process = subprocess.run(['pdf2htmlEX', '--dest-dir', dirname, temp_file_name])
     output = process.stdout
@@ -82,8 +87,7 @@ def pdf_to_html_retrieve_view(request):  # pdfToHtmlRetrieve
         'output_from_subprocess': output,
         's3_url_for_html': s3_url_for_html,
     }
-
-    return HttpResponse(json.dumps(json_data), content_type='application/json')
+    return json_data
 
 
 def store_temporary_html_file_to_aws(temp_file_name):

--- a/candidate/controllers.py
+++ b/candidate/controllers.py
@@ -2033,9 +2033,9 @@ def find_organization_endorsements_of_candidates_on_one_web_page(site_url, endor
     if site_url.lower().endswith(".pdf"):
         print("PDF Detected ", site_url)
         response = process_pdf_to_html(site_url)
-        if response.s3_url_for_html:
+        if positive_value_exists(response['s3_url_for_html']):
             # Overwrite the the site_url parameter, with a url to an html representation of the PDF file
-            site_url = response.s3_url_for_html
+            site_url = response['s3_url_for_html']
 
     urllib._urlopener = FakeFirefoxURLopener()
     headers = {

--- a/candidate/controllers.py
+++ b/candidate/controllers.py
@@ -1,15 +1,17 @@
 # candidate/controllers.py
 # Brought to you by We Vote. Be good.
 # -*- coding: UTF-8 -*-
-
-from .models import CandidateCampaignListManager, CandidateCampaign, CandidateCampaignManager, \
-    CANDIDATE_UNIQUE_IDENTIFIERS
+import datetime as the_other_datetime
+import json
+import urllib.request
+from socket import timeout
+from django.http import HttpResponse
+from django.utils.timezone import now
+import wevote_functions.admin
+from apis_v1.views.views_extension import process_pdf_to_html
 from ballot.models import CANDIDATE
 from bookmark.models import BookmarkItemList
 from config.base import get_environment_variable
-import datetime as the_other_datetime
-from django.http import HttpResponse
-from django.utils.timezone import now
 from election.models import ElectionManager
 from exception.models import handle_exception
 from image.controllers import retrieve_all_images_for_one_candidate, cache_master_and_resized_image, \
@@ -17,20 +19,17 @@ from image.controllers import retrieve_all_images_for_one_candidate, cache_maste
     LINKEDIN, TWITTER, WIKIPEDIA, FACEBOOK
 from import_export_vote_smart.controllers import retrieve_and_match_candidate_from_vote_smart, \
     retrieve_candidate_photo_from_vote_smart
-import json
 from office.models import ContestOfficeManager
 from politician.models import PoliticianManager
 from position.controllers import move_positions_to_another_candidate, update_all_position_details_from_candidate
-import re
-from socket import timeout
 from twitter.models import TwitterUserManager
-import urllib.request
-import wevote_functions.admin
 from wevote_functions.functions import add_period_to_middle_name_initial, add_period_to_name_prefix_and_suffix, \
     convert_date_to_we_vote_date_string, \
-    convert_to_political_party_constant, positive_value_exists, process_request_from_master, convert_to_int, \
+    convert_to_political_party_constant, positive_value_exists, process_request_from_master, \
     extract_twitter_handle_from_text_string, extract_website_from_url, \
     remove_period_from_middle_name_initial, remove_period_from_name_prefix_and_suffix
+from .models import CandidateCampaignListManager, CandidateCampaign, CandidateCampaignManager, \
+    CANDIDATE_UNIQUE_IDENTIFIERS
 
 logger = wevote_functions.admin.get_logger(__name__)
 
@@ -2030,6 +2029,13 @@ def find_organization_endorsements_of_candidates_on_one_web_page(site_url, endor
             'endorsement_list_light':           endorsement_list_light_modified,
         }
         return results
+
+    if site_url.lower().endswith(".pdf"):
+        print("PDF Detected ", site_url)
+        response = process_pdf_to_html(site_url)
+        if response.s3_url_for_html:
+            # Overwrite the the site_url parameter, with a url to an html representation of the PDF file
+            site_url = response.s3_url_for_html
 
     urllib._urlopener = FakeFirefoxURLopener()
     headers = {

--- a/config/base.py
+++ b/config/base.py
@@ -54,8 +54,14 @@ def get_environment_variable_default(var_name, default_value):
 
 
 def get_python_version():
-    version = os.popen('python --version').read()
+    version = os.popen('python --version').read().strip()
     print(version)    # Something like 'Python 3.7.2'
+    return version
+
+
+def get_node_version():
+    version = "Node " + os.popen('node -v').read().strip()
+    print(version)    # Something like 'v14.15.1'
     return version
 
 

--- a/docs/README_API_INSTALL_PYTHON_MAC.md
+++ b/docs/README_API_INSTALL_PYTHON_MAC.md
@@ -1,4 +1,5 @@
-# README for API Installation: 3a. Installing Python/Django on Mac
+# README for API Installation: 3a. Installing 
+Python/Django on Mac
 
 [Back to Install Table of Contents](README_API_INSTALL.md)
 

--- a/templates/admin_tools/index.html
+++ b/templates/admin_tools/index.html
@@ -183,7 +183,8 @@
 {# ################## #}
 <h4>Technical Information</h4>
 <p>
-    Running: {{ python_version }}
+    Running: {{ python_version }}<br>
+    Running: {{ node_version }}
 </p>
 
 {%  endblock %}


### PR DESCRIPTION
The [http://localhost:8000/apis/v1/docs/pdfToHtmlRetrieve/](http://localhost:8000/apis/v1/docs/pdfToHtmlRetrieve/ ) api still works after the change.
When I override possibilites_found in voter_guide/views_admin.py at line 898, the code is
invoked and creates perfect looking output like
https://wevote-temporary.s3.amazonaws.com/Endorsements2020G.html
and at line 2033 in candidate/controllers.py the new html page is substituted for the PDF and that
should work, but I don't have data in my local to test it, or know how I would do it on the live server.
Now reports Node version running on the EC2 instance at bottom of the /admin/ page.


Should address wevote/WeVoteServer/issues/1254