### PR TITLE
Added a slash to the "/apis/v1/candidateOrPoliticianRepairNames/" API…

### DIFF
--- a/templates/candidate/candidate_and_politician_name_fix_list.html
+++ b/templates/candidate/candidate_and_politician_name_fix_list.html
@@ -118,7 +118,7 @@
 
         $.ajax({
           type: "PUT",
-          url: window.location.origin + "/apis/v1/candidateOrPoliticianRepairNames",
+          url: window.location.origin + "/apis/v1/candidateOrPoliticianRepairNames/",
           contentType: 'application/json',
           data: JSON.stringify(data), // access in body
           beforeSend: function(xhr, settings) {


### PR DESCRIPTION
… call to remove an error that showed up on Dale's local.

Error:
RuntimeError: You called this URL via PUT, but the URL doesn't end in a slash and you have APPEND_SLASH set. Django can't redirect to the slash URL while maintaining PUT data. Change your form to point to localhost:8001/apis/v1/candidateOrPoliticianRepairNames/ (note the trailing slash), or set APPEND_SLASH=False in your Django settings.