### PR TITLE
Fixed the TypeError referenced in comment views/views_campaign.py. Added unit test for campaignListRetrieve.

### DIFF
--- a/apis_v1/tests/test_views_campaign_list_retrieve.py
+++ b/apis_v1/tests/test_views_campaign_list_retrieve.py
@@ -1,0 +1,42 @@
+# apis_v1/test_views_campaign_list_retrieve.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+
+from admin_tools.controllers import import_data_for_tests
+from django.urls import reverse
+from django.test import TestCase
+import json
+from office.models import ContestOffice, ContestOfficeManager
+
+
+class WeVoteAPIsV1TestsCampaignListRetrieve(TestCase):
+    databases = ["default", "readonly"]
+
+    def setUp(self):
+        self.generate_voter_device_id_url = reverse("apis_v1:deviceIdGenerateView")
+        self.organization_count_url = reverse("apis_v1:organizationCountView")
+        self.voter_create_url = reverse("apis_v1:voterCreateView")
+        self.campaign_list_retrieve_url = reverse("apis_v1:campaignListRetrieveView")
+
+    def test_retrieve_with_no_voter_device_id(self):
+        #######################################
+        # Without a cookie or required variables, we don't expect valid response
+        response = self.client.get(self.campaign_list_retrieve_url)
+        json_data = json.loads(response.content.decode())
+        # print(json_data)
+
+        self.assertEqual('status' in json_data, True,
+                         "status expected in the json response, and not found")
+        self.assertEqual('success' in json_data, True,
+                         "success expected in the json response, and not found")
+        self.assertEqual(len(json_data['campaignx_list']), 0,
+                         "Expected campaignx_list to have length 0, "
+                         "actual length = {length}".format(length=len(json_data['campaignx_list'])))
+        self.assertEqual(json_data['status'], 'VOTER_WE_VOTE_ID_COULD_NOT_BE_FETCHED ',
+        "status: {status} (VOTER_WE_VOTE_ID_COULD_NOT_BE_FETCHED expected), ".format(
+            status=json_data['status']))
+        self.assertEqual(json_data['success'], False, "success: {success} (success 'False' expected), ".format(
+                success=json_data['success']))
+        self.assertListEqual(json_data['campaignx_list'], [],
+                             "campaignx_list: {campaignx_list} (Empty list expected), ".format(
+                campaignx_list=json_data['campaignx_list']))

--- a/campaign/controllers.py
+++ b/campaign/controllers.py
@@ -52,7 +52,8 @@ def campaignx_list_retrieve_for_api(voter_device_id, hostname=''):  # campaignLi
             'success': False,
             'campaignx_list': [],
         }
-        return HttpResponse(json.dumps(json_data), content_type='application/json')
+        # return HttpResponse(json.dumps(json_data), content_type='application/json')
+        return json_data
     voter = voter_results['voter']
     voter_signed_in_with_email = voter.signed_in_with_email()
     voter_we_vote_id = voter.we_vote_id


### PR DESCRIPTION
While creating a unit test for campaignListRetrieve for Issue #1611, we ran into a type error referenced in a comment on line 30 of "views/views_campaign.py" (see below).  
```
json_string = ''
    try:
        # March 24, 2021: Throwing "TypeError: Object of type 'HttpResponse' is not JSON serializable"
        json_string = json.dumps(json_data)
    except Exception as e:
        status = "Caught error for voter_device_id " + voter_device_id
        handle_exception(e, logger=logger, exception_message=status)

    return HttpResponse(json_string, content_type='application/json')
```

We believe this error was being caused by the API endpoint in "campaign/controllers.py" returning an HttpsResponse rather than the raw JSON data when an invalid voter_device_id was passed into the GET request. This only happened when the branch for an invalid voter_device_id was passed. See the code block below.
```
if not positive_value_exists(voter_results['voter_found']):
        status += 'VOTER_WE_VOTE_ID_COULD_NOT_BE_FETCHED '
        json_data = {
            'status': status,
            'success': False,
            'campaignx_list': [],
        }
        return HttpResponse(json.dumps(json_data), content_type='application/json')
```

We solved this error by replacing  `return HttpResponse(json.dumps(json_data), content_type='application/json')`  with `return json_data`.

After resolving this error, we were able to create a unit test for campaignListRetrieve in "apis_v1/tests/test_views_campaign_list_retrieve.py".

This was worked on by @ranadeepmitra21 and @patkeish 