### PR TITLE
Show the cumulative chip ins on the /campaign/.../supporters template page

### DIFF
--- a/apis_v1/views/views_donation.py
+++ b/apis_v1/views/views_donation.py
@@ -38,7 +38,7 @@ def donation_with_stripe_view(request):  # donationWithStripe
     is_monthly_donation = positive_value_exists(request.GET.get('is_monthly_donation', False))
     is_premium_plan = positive_value_exists(request.GET.get('is_premium_plan', False))
     client_ip = request.GET.get('client_ip', '')
-    campaignx_wevote_id = request.GET.get('campaignx_we_vote_id', '')
+    campaignx_we_vote_id = request.GET.get('campaignx_we_vote_id', '')
     payment_method_id = request.GET.get('payment_method_id', '')
     coupon_code = request.GET.get('coupon_code', '')
     premium_plan_type_enum = request.GET.get('premium_plan_type_enum', '')
@@ -57,7 +57,7 @@ def donation_with_stripe_view(request):  # donationWithStripe
     if positive_value_exists(token):
         results = donation_with_stripe_for_api(request, token, email, donation_amount,
                                                is_chip_in, is_monthly_donation, is_premium_plan,
-                                               client_ip, campaignx_wevote_id, payment_method_id, coupon_code,
+                                               client_ip, campaignx_we_vote_id, payment_method_id, coupon_code,
                                                premium_plan_type_enum,
                                                voter_we_vote_id, linked_organization_we_vote_id )
 

--- a/campaign/models.py
+++ b/campaign/models.py
@@ -4,9 +4,11 @@
 
 import json
 import string
+
 from django.db import models
 from django.db.models import Q
 from django.utils.text import slugify
+
 import wevote_functions.admin
 from exception.models import handle_record_found_more_than_one_exception, \
     handle_record_not_found_exception
@@ -1551,7 +1553,7 @@ class CampaignXManager(models.Manager):
         }
         return results
 
-    def retrieve_campaignx_title(self, campaignx_we_vote_id='', read_only=False):
+    def retrieve_campaignx_title(campaignx_we_vote_id='', read_only=False):
         if campaignx_we_vote_id is None or len(campaignx_we_vote_id) == 0:
             return ''
         try:

--- a/campaign/views_admin.py
+++ b/campaign/views_admin.py
@@ -586,7 +586,7 @@ def campaign_list_view(request):
         campaignx.campaignx_owner_list = campaignx_manager.retrieve_campaignx_owner_list(
             campaignx_we_vote_id=campaignx.we_vote_id,
             viewer_is_owner=True)
-        campaignx.chip_in_total = StripeManager.retrieve_chip_in_total(campaignx.we_vote_id)
+        campaignx.chip_in_total = StripeManager.retrieve_chip_in_total('', campaignx.we_vote_id)
         modified_campaignx_list.append(campaignx)
 
     state_list = STATE_CODE_MAP
@@ -784,6 +784,11 @@ def campaign_supporters_list_view(request, campaignx_we_vote_id=""):
         supporters_list = supporters_query
     else:
         supporters_list = supporters_query[:200]
+
+    for supporter in supporters_list:
+        supporter.chip_in_total = StripeManager.retrieve_chip_in_total(supporter.voter_we_vote_id,
+                                                                       supporter.campaignx_we_vote_id)
+
 
     state_list = STATE_CODE_MAP
     sorted_state_list = sorted(state_list.items())

--- a/stripe_donations/controllers.py
+++ b/stripe_donations/controllers.py
@@ -176,7 +176,7 @@ def donation_active_paid_plan_retrieve(linked_organization_we_vote_id, voter_we_
 
 def donation_with_stripe_for_api(request, token, email, donation_amount,
                                  is_chip_in, is_monthly_donation, is_premium_plan,
-                                 client_ip, campaignx_wevote_id, payment_method_id, coupon_code,
+                                 client_ip, campaignx_we_vote_id, payment_method_id, coupon_code,
                                  premium_plan_type_enum,
                                  voter_we_vote_id, linked_organization_we_vote_id):
     """
@@ -189,7 +189,7 @@ def donation_with_stripe_for_api(request, token, email, donation_amount,
     :param is_monthly_donation: (boolean) is this a monthly donation subscription
     :param is_premium_plan:  True for a premium organization plan, False for a donation (one time or donation subs.)
     :param client_ip: As reported by Stripe (i.e. outside looking in)
-    :param campaignx_wevote_id: To track Campaign "Chip In"s
+    :param campaignx_we_vote_id: To track Campaign "Chip In"s
     :param payment_method_id: payment method selected/created on the client CheckoutForm.jsx
     :param coupon_code: Our coupon codes for pricing and features that are looked up
            in the OrganizationSubscriptionPlans
@@ -363,7 +363,7 @@ def donation_with_stripe_for_api(request, token, email, donation_amount,
                         'is_chip_in': is_chip_in,
                         'is_monthly_donation': is_monthly_donation,
                         'is_premium_plan': is_premium_plan,
-                        'campaignx_wevote_id': campaignx_wevote_id,
+                        'campaignx_we_vote_id': campaignx_we_vote_id,
                     }
                 )
                 results['status'] += textwrap.shorten("STRIPE_CHARGE_SUCCESSFUL " + results['status'], width=255,
@@ -547,8 +547,8 @@ def donation_lists_for_a_voter(voter_we_vote_id):
                 'is_chip_in': payment_row.is_chip_in,
                 'is_monthly_donation': payment_row.is_monthly_donation,
                 'is_premium_plan': payment_row.is_premium_plan,
-                'campaignx_wevote_id': payment_row.campaignx_wevote_id,
-                'campaign_title': CampaignXManager.retrieve_campaignx_title(payment_row.campaignx_wevote_id),
+                'campaignx_we_vote_id': payment_row.campaignx_we_vote_id,
+                'campaign_title': CampaignXManager.retrieve_campaignx_title(payment_row.campaignx_we_vote_id),
                 'voter_we_vote_id': payment_row.voter_we_vote_id,
 
                 # 'is_premium_plan': positive_value_exists(payment_row.is_premium_plan),
@@ -669,7 +669,7 @@ def donation_process_charge(event):           # 'charge.succeeded' webhook
             'amount_refunded': charge['amount_refunded'],
             'api_version': event['api_version'],
             'brand': source['brand'],
-            'campaignx_wevote_id': metadata['campaignx_wevote_id'] if 'campaignx_wevote_id' in metadata else '',
+            'campaignx_we_vote_id': metadata['campaignx_we_vote_id'] if 'campaignx_we_vote_id' in metadata else '',
             'country': source['country'],
             'created': datetime.fromtimestamp(event['created'], timezone.utc),
             'currency': charge['currency'],

--- a/templates/campaign/campaignx_supporters_list.html
+++ b/templates/campaign/campaignx_supporters_list.html
@@ -105,6 +105,7 @@
             <th></th>
             <th>Supporter</th>
             <th>Endorsement</th>
+            <th>Chip Ins</th>
             <th>Supporter Wants Visibility</th>
             <th>Blocked by We Vote?</th>
             <th>Delete</th>
@@ -126,6 +127,7 @@
                 </div>
             </td>
             <td>{{ campaignx_supporter.supporter_endorsement|default_if_none:"" }}</td>
+            <td>{{ campaignx_supporter.chip_in_total }}</td>
             <td>
                 <input type="checkbox"
                        name="campaignx_supporter_visible_to_public_{{ campaignx_supporter.id }}"


### PR DESCRIPTION
I spent a number of hours trying to make a filter for chip in donations that worked with the other filters, which requires a join in django, and it didn't seem worth more effort.  If the supporter is displayed, their donation total will display.  I could have done this in SQL, but then it wouldn't have worked with the other filters.
The campaign name is now stored in the chip in donation records (going forward).
Progress towards wevote/WeVoteServer/issues/1658