### PR TITLE
Added a clickable link to cumulative chip ins on the /campaign/.../supporters template page

### DIFF
--- a/templates/campaign/campaignx_list.html
+++ b/templates/campaign/campaignx_list.html
@@ -195,8 +195,9 @@
                 {% endif %}
             {% endif %}</td>
             <td style="text-align: right">
-                {{ campaignx.chip_in_total }}
-                <!--<pre> {% filter force_escape %} {% debug %} {% endfilter %} </pre>-->
+                <a href="{% url 'campaign:supporters_list' campaignx.we_vote_id %}?show_supporters_without_endorsements=1&show_supporters_not_visible_to_public=1" target="_blank">
+                    {{ campaignx.chip_in_total }}
+                </a>
             </td>
             <td>
                 {{ campaignx.campaign_description|default_if_none:""|truncatechars:250 }}


### PR DESCRIPTION
The link turns on the Include Supporters buttons initially, so you will see any supporters with chipins.