### PR TITLE
Facebook photos refresh fix

### DIFF
--- a/import_export_facebook/urls.py
+++ b/import_export_facebook/urls.py
@@ -9,7 +9,7 @@ from . import views, views_admin
 
 urlpatterns = [
     re_path(r'^bulk_retrieve_facebook_photos/$',
-        views_admin.bulk_retrieve_facebook_photos_view, name='bulk_retrieve_facebook_photos', ),
+            views_admin.bulk_retrieve_facebook_photos_view, name='bulk_retrieve_facebook_photos', ),
     re_path(r'^get_and_save_facebook_photo/$',
-        views_admin.get_and_save_facebook_photo_view, name='get_and_save_facebook_photo', ),
+            views_admin.get_and_save_facebook_photo_view, name='get_and_save_facebook_photo', ),
 ]

--- a/import_export_facebook/views_admin.py
+++ b/import_export_facebook/views_admin.py
@@ -235,7 +235,7 @@ def get_and_save_facebook_photo_view(request):
         we_vote_id = request.GET.get('organization_we_vote_id', "")
         reverse_path = 'organization:organization_position_list'
         msg_base = 'get_and_save_facebook_photo_view, Organization '
-        reverse_id = we_vote_id.split('org')[1]
+        reverse_id = ''
     if positive_value_exists(request.GET.get('reverse_path', "")):
         reverse_path = request.GET.get('reverse_path', "").replace('\'', '')
 
@@ -280,6 +280,8 @@ def get_and_save_facebook_photo_view(request):
                                     '&page=' + str(page)
                                     )
 
+    if not is_candidate:
+        reverse_id = one_entity.id
     return HttpResponseRedirect(reverse(reverse_path, args=(reverse_id,)) +
                                 '?google_civic_election_id=' + str(google_civic_election_id) +
                                 '&state_code=' + str(state_code) +

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -450,7 +450,9 @@ th, td {
         <input type="text" name="facebook_url" id="facebook_url_id" class="form-control"
                value="{% if candidate %}{{ candidate.facebook_url|default_if_none:"" }}{% else %}{{ facebook_url|default_if_none:"" }}{% endif %}" />
       {% if candidate.facebook_url %}
-      <a href="{% url 'import_export_facebook:get_and_save_facebook_photo' %}?candidate_we_vote_id={{ candidate.we_vote_id }}&google_civic_election_id={{ google_civic_election_id }}&page={{ page }}">
+      <a href="{% url 'import_export_facebook:get_and_save_facebook_photo' %}?candidate_we_vote_id={{ candidate.we_vote_id }}&google_civic_election_id={{ google_civic_election_id }}&page={{ page }}"
+         id="facebook_a_tag"
+      >
             Refresh Facebook Photo</a>
           {% if candidate.facebook_url_is_broken %}
             <b> &nbsp;&nbsp; The previous attempt at getting a photo from this link failed, it may be a broken link</b>
@@ -846,6 +848,15 @@ th, td {
         });
 
     }(window.$, window.autosize));
+
+  // when you change the facebook url disable the button
+  $(function() {
+    $('#facebook_url_id').change(function() {
+      console.log('txt fld changed');
+      $('#facebook_a_tag').removeAttr('href').attr('type', 'button').attr('disabled');
+      $('#facebook_a_tag').css('color', 'lightblue');
+    });
+  });
 </script>
 
 

--- a/templates/organization/organization_edit.html
+++ b/templates/organization/organization_edit.html
@@ -165,9 +165,12 @@
     <label for="organization_facebook_id" class="col-sm-3 control-label">Facebook URL</label>
     <div class="col-sm-8">
         <input type="text" name="organization_facebook" id="organization_facebook_id" class="form-control"
-               value="{% if organization %}{{ organization.organization_facebook|default_if_none:'' }}{% else %}{{ organization_facebook }}{% endif %}" />
+               value="{% if organization %}{{ organization.organization_facebook|default_if_none:'' }}{% else %}{{ organization_facebook }}{% endif %}"
+        />
         {% if organization.organization_facebook %}
-            <a href="{% url 'import_export_facebook:get_and_save_facebook_photo' %}?organization_we_vote_id={{ organization.we_vote_id }}&google_civic_election_id={{ google_civic_election_id }}&page={{ page }}">
+            <a href="{% url 'import_export_facebook:get_and_save_facebook_photo' %}?organization_we_vote_id={{ organization.we_vote_id }}&google_civic_election_id={{ google_civic_election_id }}&page={{ page }}&reverse_path='organization:organization_position_list'"
+               id="facebook_a_tag"
+            >
                 Refresh Facebook Photo</a>
         {% endif %}
     </div>
@@ -320,4 +323,21 @@
         Full size<br />
     {% endif %}
 {% endif %}
+<script>
+  // when you change the facebook url disable the button
+  $(function() {
+    $('#organization_facebook_id').change(function() {
+      console.log('txt fld changed');
+      $('#facebook_a_tag').removeAttr('href').attr('type', 'button').attr('disabled');
+      $('#facebook_a_tag').css('color', 'lightblue');
+    });
+    // When loading the page, setup the href for the button
+<!--    const rev = "{% url 'organization:organization_position_list' organization.id %}";  // django does this substitution when rendering the template serverside-->
+<!--    const revEncoded = encodeURIComponent(rev);-->
+<!--    const initial_href = $('#facebook_a_tag').attr('href');-->
+<!--    const new_href = initial_href + '&reverse_path=' + revEncoded;-->
+<!--    $('#facebook_a_tag').attr('href', new_href);-->
+  });
+</script>
 {% endblock %}
+


### PR DESCRIPTION
Refreshing facebook on the organization_edit page, now has a return url based on the organization sql row id, instead of the organization we_vote_id (and as a result, now returns to the correct page).
Disable the "Refresh Facebook Photo" button on the candidate_edit and the organization_edit page after you change the text of the URL, since otherwise, pressing the button would do a refresh based on the prior value (the "currently in postgres" value) of the url.