### PR TITLE
Facebook access tokens are now longer than 256 characters

### DIFF
--- a/apis_v1/documentation_source/voter_retrieve_doc.py
+++ b/apis_v1/documentation_source/voter_retrieve_doc.py
@@ -69,6 +69,7 @@ def voter_retrieve_doc_template_values(url_root):
                    '  "last_name": string,\n' \
                    '  "linked_organization_we_vote_id": string,\n' \
                    '  "notification_settings_flags": integer,\n' \
+                   '  "signed_in": boolean,\n' \
                    '  "signed_in_facebook": boolean,\n' \
                    '  "signed_in_google": boolean,\n' \
                    '  "signed_in_twitter": boolean,\n' \

--- a/docs/TestingFacebookLoginLocally.md
+++ b/docs/TestingFacebookLoginLocally.md
@@ -1,0 +1,28 @@
+# Testing Facebook Sign In with a Physical Tethered Phone in Cordova
+The phone can't access localhost, so we need to run ngrok, and configure the webapp to access the local Python Server voa ngrok
+
+In a terminal in PyCharm:
+
+    (PycharmEnvironments) stevepodell@Steves-MacBook-Pro-32GB-Oct-2109 ~ % cd /Users/stevepodell/WebstormProjects/ngrok
+    (PycharmEnvironments) stevepodell@Steves-MacBook-Pro-32GB-Oct-2109 ngrok % ./ngrok http 8000
+    
+    ngrok by @inconshreveable                                                                                                                                                 (Ctrl+C to quit)
+                                                                                                                                                                                              
+    Session Status                online                                                                                                                                                      
+    Account                       stevepodell37@gmail.com (Plan: Free)                                                                                                                        
+    Update                        update available (version 2.3.40, Ctrl-U to update)                                                                                                         
+    Version                       2.3.35                                                                                                                                                      
+    Region                        United States (us)                                                                                                                                          
+    Web Interface                 http://127.0.0.1:4040                                                                                                                                       
+    Forwarding                    http://d74f-2601-643-8400-5b80-7cad-2933-47a9-26ea.ngrok.io -> http://localhost:8000                                                                        
+    Forwarding                    https://d74f-2601-643-8400-5b80-7cad-2933-47a9-26ea.ngrok.io -> http://localhost:8000                                                                       
+                                                                                                                      
+
+In the WebApp config.js file:
+
+    WE_VOTE_SERVER_ROOT_URL: "http://d74f-2601-643-8400-5b80-7cad-2933-47a9-26ea.ngrok.io/",
+    WE_VOTE_SERVER_ADMIN_ROOT_URL: "http://d74f-2601-643-8400-5b80-7cad-2933-47a9-26ea.ngrok.io/admin/",
+    WE_VOTE_SERVER_API_ROOT_URL: "http://d74f-2601-643-8400-5b80-7cad-2933-47a9-26ea.ngrok.io/apis/v1/",
+    WE_VOTE_SERVER_API_CDN_ROOT_URL: "http://d74f-2601-643-8400-5b80-7cad-2933-47a9-26ea.ngrok.io/apis/v1/",
+
+Then you can debug WebApp code in Cordova on a physical iPhone with a local Python WeVoteServer.

--- a/import_export_facebook/models.py
+++ b/import_export_facebook/models.py
@@ -35,7 +35,7 @@ class FacebookAuthResponse(models.Model):
 
     # Comes from Facebook authResponse FACEBOOK_LOGGED_IN
     facebook_access_token = models.CharField(
-        verbose_name="accessToken from Facebook", max_length=255, null=True, blank=True, unique=False)
+        verbose_name="accessToken from Facebook", max_length=512, null=True, blank=True, unique=False)
     facebook_expires_in = models.IntegerField(verbose_name="expiresIn from Facebook", null=True, blank=True)
     facebook_signed_request = models.TextField(verbose_name="signedRequest from Facebook", null=True, blank=True)
     facebook_user_id = models.BigIntegerField(verbose_name="facebook big integer id", null=True, blank=True)

--- a/voter/controllers.py
+++ b/voter/controllers.py
@@ -3024,6 +3024,7 @@ def voter_retrieve_for_api(voter_device_id, state_code_from_ip_address='',
             'last_name':                        voter.last_name,
             'linked_organization_we_vote_id':   voter.linked_organization_we_vote_id,
             'notification_settings_flags':      voter.notification_settings_flags,
+            'signed_in':                        voter.is_signed_in(),            # Extra field for debugging the WebApp
             'signed_in_facebook':               voter.signed_in_facebook(),
             'signed_in_google':                 voter.signed_in_google(),
             'signed_in_twitter':                voter.signed_in_twitter(),


### PR DESCRIPTION
Must be nice to have too many quadrillions of sessions.
Also added a (redundant) "signed_in" field to voterRetrieve to aid in debugging -- all the signin state is in the same area in the response.