### PR TITLE
Speed up twitter sign-in (initially only in the WebApp)

### DIFF
--- a/WeVoteServerCheatSheet.md
+++ b/WeVoteServerCheatSheet.md
@@ -71,8 +71,8 @@ You have to terminate all the backend connections before this will work:
 
 Then in pgAdmin 4,
 1) Select the WeVoteServerDB and right-click and drop
-2) Then select Databases and right-click create ‘WeVoteServerDB’
-3) Then in Terminal, recreate the database (it will be empty)
+2) Then in pgAdmin select Databases and right-click to recreate an empty‘WeVoteServerDB’
+3) Then in Terminal, initialize the newly created database with 'migrate'
 ```
 (WeVoteServer3.6) Steves-MacBook-Pro-2017:WeVoteServer stevepodell$ python manage.py migrate
 ```

--- a/apis_v1/documentation_source/twitter_sign_in_retrieve_doc.py
+++ b/apis_v1/documentation_source/twitter_sign_in_retrieve_doc.py
@@ -20,6 +20,13 @@ def twitter_sign_in_retrieve_doc_template_values(url_root):
         },
     ]
     optional_query_parameter_list = [
+        {
+            'name': 'image_load_deferred',
+            'value': 'boolean',  # boolean, integer, long, string
+            'description': 'Process new images from twitter asynchronously with ' \
+                           'twitter_process_deferred_images_for_api.  If false process images inline (adds many '
+                           'seconds to sign in with twitter)',
+        }
     ]
 
     potential_status_codes_list = [
@@ -39,20 +46,21 @@ def twitter_sign_in_retrieve_doc_template_values(url_root):
     api_response = '{\n' \
                    '  "status": string,\n' \
                    '  "success": boolean,\n' \
-                   '  "voter_device_id": string (88 characters long),\n' \
-                   '  "voter_we_vote_id_attached_to_twitter": string,\n' \
-                   '  "voter_we_vote_id_attached_to_twitter_email": string,\n' \
+                   '  "twitter_access_token": string,\n' \
+                   '  "twitter_email": string,\n' \
+                   '  "twitter_first_name": string,\n' \
+                   '  "twitter_image_load_info: object,\n' \
+                   '  "twitter_last_name": string,\n' \
+                   '  "twitter_middle_name": string,\n' \
+                   '  "twitter_profile_image_url_https": string,\n' \
                    '  "twitter_retrieve_attempted": boolean,\n' \
                    '  "twitter_sign_in_found": boolean,\n' \
                    '  "twitter_sign_in_verified": boolean,\n' \
-                   '  "twitter_access_token": string,\n' \
                    '  "twitter_signed_request": string,\n' \
                    '  "twitter_user_id": string,\n' \
-                   '  "twitter_email": string,\n' \
-                   '  "twitter_first_name": string,\n' \
-                   '  "twitter_middle_name": string,\n' \
-                   '  "twitter_last_name": string,\n' \
-                   '  "twitter_profile_image_url_https": string,\n' \
+                   '  "voter_device_id": string (88 characters long),\n' \
+                   '  "voter_we_vote_id_attached_to_twitter": string,\n' \
+                   '  "voter_we_vote_id_attached_to_twitter_email": string,\n' \
                    '  "we_vote_hosted_profile_image_url_large": string,\n' \
                    '  "we_vote_hosted_profile_image_url_medium": string,\n' \
                    '  "we_vote_hosted_profile_image_url_tny": string,\n' \

--- a/apis_v1/urls.py
+++ b/apis_v1/urls.py
@@ -274,6 +274,8 @@ urlpatterns = [
       #     views_twitter.twitter_sign_in_request_voter_info_view, name='twitterSignInRequestVoterInfoView'),
       re_path(r'^twitterSignInStart/', views_twitter.twitter_sign_in_start_view,
               name='twitterSignInStartView'),
+      re_path(r'^twitterProcessDeferredImages/', views_twitter.twitter_process_deferred_images_view,
+              name='twitterProcessDeferredImages'),
       re_path(r'^twitterSignInRetrieve/', views_twitter.twitter_sign_in_retrieve_view,
               name='twitterSignInRetrieveView'),
       re_path(r'^twitterRetrieveIdsIFollow/',

--- a/docs/README_API_INSTALL_POSTGRES_MAC.md
+++ b/docs/README_API_INSTALL_POSTGRES_MAC.md
@@ -38,10 +38,10 @@ ALTER USER  postgres  WITH PASSWORD '<your-password-here>';
 Now you are ready to install pgAdmin4. Run:
 
 ```
-brew cask install pgadmin4
+brew install pgadmin4
 ```
 
-Now open pgAdmin by clicking on the icon in your applications folder. From here on, you may follow the instructions in the `Setup - Install pgAdmin 4` section of this README starting from step 1: Right-click on "Servers" and choose "Create > Server".
+Now open pgAdmin by clicking on the icon in your Applications folder. From here on, you may follow the instructions in the `Setup - Install pgAdmin 4` section of this README starting from step 1: Right-click on "Servers" and choose "Create > Server".
 
 Note that you may terminate your PostgreSQL once done with:
 

--- a/docs/README_MAC_SIMPLIFIED_INSTALL.md
+++ b/docs/README_MAC_SIMPLIFIED_INSTALL.md
@@ -273,7 +273,7 @@ this step.  To see if postgres is already running, check with lsof in a terminal
      stevepodell | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
     
    postgres-#
-   postgres=# create database WeVoteServerDb;
+   postgres=# create database WeVoteServerDB;
    CREATE DATABASE
    postgres=# grant all privileges on database WeVoteServerDB to postgres;
    GRANT

--- a/voter/controllers.py
+++ b/voter/controllers.py
@@ -1905,27 +1905,30 @@ def voter_merge_two_accounts_for_api(  # voterMergeTwoAccounts
                 }
                 return error_results
 
+        # Dec 2021 Steve: Removed a redundant cache_master_and_resized_image call for the merged voter.
+        # Did we ever need this, or was it a "just in case" (This added 5 seconds to each twitter signin in the WebApp)
+        # If it needs to be revived, please revive it for just the most specific case
         # Cache original and resized images
-        cache_results = cache_master_and_resized_image(
-            voter_we_vote_id=twitter_owner_voter.we_vote_id,
-            twitter_id=twitter_auth_response.twitter_id,
-            twitter_screen_name=twitter_auth_response.twitter_screen_name,
-            twitter_profile_image_url_https=twitter_auth_response.twitter_profile_image_url_https,
-            image_source=TWITTER)
-        cached_twitter_profile_image_url_https = cache_results['cached_twitter_profile_image_url_https']
-        we_vote_hosted_profile_image_url_large = cache_results['we_vote_hosted_profile_image_url_large']
-        we_vote_hosted_profile_image_url_medium = cache_results['we_vote_hosted_profile_image_url_medium']
-        we_vote_hosted_profile_image_url_tiny = cache_results['we_vote_hosted_profile_image_url_tiny']
-
+        # cache_results = cache_master_and_resized_image(
+        #     voter_we_vote_id=twitter_owner_voter.we_vote_id,
+        #     twitter_id=twitter_auth_response.twitter_id,
+        #     twitter_screen_name=twitter_auth_response.twitter_screen_name,
+        #     twitter_profile_image_url_https=twitter_auth_response.twitter_profile_image_url_https,
+        #     image_source=TWITTER)
+        # cached_twitter_profile_image_url_https = cache_results['cached_twitter_profile_image_url_https']
+        # we_vote_hosted_profile_image_url_large = cache_results['we_vote_hosted_profile_image_url_large']
+        # we_vote_hosted_profile_image_url_medium = cache_results['we_vote_hosted_profile_image_url_medium']
+        # we_vote_hosted_profile_image_url_tiny = cache_results['we_vote_hosted_profile_image_url_tiny']
+        #
         # Update the Twitter photo in the voter
-        save_twitter_results = voter_manager.save_twitter_user_values_from_twitter_auth_response(
-            twitter_owner_voter, twitter_auth_response,
-            cached_twitter_profile_image_url_https=cached_twitter_profile_image_url_https,
-            we_vote_hosted_profile_image_url_large=we_vote_hosted_profile_image_url_large,
-            we_vote_hosted_profile_image_url_medium=we_vote_hosted_profile_image_url_medium,
-            we_vote_hosted_profile_image_url_tiny=we_vote_hosted_profile_image_url_tiny)
-        status += " " + save_twitter_results['status']
-        twitter_owner_voter = save_twitter_results['voter']
+        # save_twitter_results = voter_manager.save_twitter_user_values_from_twitter_auth_response(
+        #     twitter_owner_voter, twitter_auth_response,
+        #     cached_twitter_profile_image_url_https=cached_twitter_profile_image_url_https,
+        #     we_vote_hosted_profile_image_url_large=we_vote_hosted_profile_image_url_large,
+        #     we_vote_hosted_profile_image_url_medium=we_vote_hosted_profile_image_url_medium,
+        #     we_vote_hosted_profile_image_url_tiny=we_vote_hosted_profile_image_url_tiny)
+        # status += " " + save_twitter_results['status']
+        # twitter_owner_voter = save_twitter_results['voter']
 
         # Make sure we have a twitter_link_to_organization entry for the destination voter
         if positive_value_exists(twitter_owner_voter.linked_organization_we_vote_id):
@@ -2037,9 +2040,6 @@ def voter_merge_two_accounts_for_api(  # voterMergeTwoAccounts
                     organization_name=twitter_owner_voter.get_full_name(),
                     organization_image=twitter_owner_voter.voter_photo_url(),
                     organization_type=INDIVIDUAL,
-                    we_vote_hosted_profile_image_url_large=twitter_owner_voter.we_vote_hosted_profile_image_url_large,
-                    we_vote_hosted_profile_image_url_medium=twitter_owner_voter.we_vote_hosted_profile_image_url_medium,
-                    we_vote_hosted_profile_image_url_tiny=twitter_owner_voter.we_vote_hosted_profile_image_url_tiny
                 )
                 if create_results['organization_created']:
                     # Add value to twitter_owner_voter.linked_organization_we_vote_id when done.
@@ -2999,6 +2999,8 @@ def voter_retrieve_for_api(voter_device_id, state_code_from_ip_address='',
         for team_member in team_member_list:
             can_edit_campaignx_owned_by_organization_list.append(team_member.organization_we_vote_id)
 
+        # print('voterRetrieve status', status, ', voter.email ', voter.email, ', full name ', voter.get_full_name(), ',
+        #   voter_photo_url_medium', we_vote_hosted_profile_image_url_medium )
         json_data = {
             'status':                           status,
             'success':                          True,

--- a/wevote_settings/models.py
+++ b/wevote_settings/models.py
@@ -32,6 +32,9 @@ class WeVoteSetting(models.Model):
     """
     Settings needed for the operation of this site
     """
+    DoesNotExist = None
+    MultipleObjectsReturned = None
+    objects = None
     name = models.CharField(verbose_name='setting name', blank=True, null=True, max_length=255)
 
     # We store in the settings database values of many different kind of data types
@@ -486,6 +489,7 @@ class RemoteRequestHistory(models.Model):
     Keep a log of events when reaching out to Remote servers with requests
     """
     # The data and time we reached out to the Remote server
+    objects = None
     datetime_of_action = models.DateTimeField(verbose_name='date and time of action', auto_now=True)
     # If a 'ballot' entry, store the election this is for
     google_civic_election_id = models.PositiveIntegerField(verbose_name="google civic election id", null=True)


### PR DESCRIPTION
Broke the twitter signin that used to take 15 seconds or more, the first part twitter_sign_in_retrieve_for_api no longer caches the images, and allows the user to signin in about 3 seconds.  The second part, twitter_process_deferred_images_for_api is fired by the WebApp as soon as the twitter sign in completes, which then processes the images asynchronously.  Then about 15 seconds after the sign in, Ballot fires off a voterRetrieve to replace the anonymous icon with the voter's twitter photo.