### PR TITLE
Update twitterIdentityRetrieve so we can show new voter guides even if they haven't been imported from Twitter previously. Updated twitter_process_deferred_images_for_api to work with organizations not attached to voters. We no longer want to automatically return the previous election for this voter.

### DIFF
--- a/apis_v1/views/views_twitter.py
+++ b/apis_v1/views/views_twitter.py
@@ -53,7 +53,6 @@ def twitter_identity_retrieve_view(request):  # twitterIdentityRetrieve
         'owner_we_vote_id':                         results['owner_we_vote_id'],
         'owner_id':                                 results['owner_id'],
         'google_civic_election_id':                 results['google_civic_election_id'],
-        # These values only returned if kind_of_owner == TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE
         'twitter_description':                      results['twitter_description'],
         'twitter_followers_count':                  results['twitter_followers_count'],
         'twitter_photo_url':                        results['twitter_photo_url'],
@@ -62,6 +61,7 @@ def twitter_identity_retrieve_view(request):  # twitterIdentityRetrieve
         'we_vote_hosted_profile_image_url_tiny':    results['we_vote_hosted_profile_image_url_tiny'],
         'twitter_profile_banner_url_https':         results['twitter_profile_banner_url_https'],
         'twitter_user_website':                     results['twitter_user_website'],
+        'twitter_id':                               results['twitter_id'],
         'twitter_name':                             results['twitter_name'],
         }
     return HttpResponse(json.dumps(json_data), content_type='application/json')
@@ -245,6 +245,7 @@ def twitter_process_deferred_images_view(request):  # twitterProcessDeferredImag
     :return:
     """
     results = twitter_process_deferred_images_for_api(
+        organization_we_vote_id=request.GET.get('organization_we_vote_id'),
         status=request.GET.get('status'),
         success=request.GET.get('success'),
         twitter_id=request.GET.get('twitter_id'),

--- a/ballot/models.py
+++ b/ballot/models.py
@@ -2680,19 +2680,22 @@ class BallotReturnedManager(models.Manager):
                             else:
                                 more_elections_exist = False
                 else:
-                    past_google_civic_election_id = self.fetch_last_election_in_this_state(state_code)
-                    if positive_value_exists(past_google_civic_election_id):
-                        # Limit the search to the most recent election with ballot items
-                        ballot_returned_query = ballot_returned_query.filter(
-                            google_civic_election_id=past_google_civic_election_id)
-                    try:
-                        ballot = ballot_returned_query.first()
-                    except Exception as e:
-                        ballot = None
-                        status += "BALLOT_RETURNED_QUERY_FIRST_FAILED_HAS_PAST_GOOGLE_CIVIC_ID: " + str(e) + ' '
-                    # ballot_returned_list = list(ballot_returned_query)
-                    # if len(ballot_returned_list):
-                    #     ballot = ballot_returned_list[0]
+                    ballot = None
+                    status += "NOT_LOOKING_FOR_PREVIOUS_ELECTION "
+                    # We no longer want to automatically return the previous election for this voter
+                    # past_google_civic_election_id = self.fetch_last_election_in_this_state(state_code)
+                    # if positive_value_exists(past_google_civic_election_id):
+                    #     # Limit the search to the most recent election with ballot items
+                    #     ballot_returned_query = ballot_returned_query.filter(
+                    #         google_civic_election_id=past_google_civic_election_id)
+                    # try:
+                    #     ballot = ballot_returned_query.first()
+                    # except Exception as e:
+                    #     ballot = None
+                    #     status += "BALLOT_RETURNED_QUERY_FIRST_FAILED_HAS_PAST_GOOGLE_CIVIC_ID: " + str(e) + ' '
+                    # # ballot_returned_list = list(ballot_returned_query)
+                    # # if len(ballot_returned_list):
+                    # #     ballot = ballot_returned_list[0]
 
         if ballot is not None:
             ballot_returned = ballot

--- a/organization/models.py
+++ b/organization/models.py
@@ -321,6 +321,9 @@ class OrganizationManager(models.Manager):
             twitter_id='',
             organization_type='',
             state_served_code=None,
+            twitter_profile_background_image_url_https=None,
+            twitter_profile_banner_url_https=None,
+            twitter_profile_image_url_https=None,
             we_vote_hosted_profile_image_url_large='',
             we_vote_hosted_profile_image_url_medium='',
             we_vote_hosted_profile_image_url_tiny=''):
@@ -344,7 +347,7 @@ class OrganizationManager(models.Manager):
                 twitter_location = twitter_user.twitter_location
                 twitter_followers_count = twitter_user.twitter_followers_count if \
                     positive_value_exists(twitter_user.twitter_followers_count) else 0
-                twitter_profile_image_url_https = twitter_user.twitter_profile_background_image_url_https
+                twitter_profile_image_url_https = twitter_user.twitter_profile_image_url_https
                 twitter_profile_background_image_url_https = twitter_user.twitter_profile_background_image_url_https
                 twitter_profile_banner_url_https = twitter_user.twitter_profile_banner_url_https
                 twitter_description = twitter_user.twitter_description
@@ -384,6 +387,9 @@ class OrganizationManager(models.Manager):
                     organization_image=organization_image,
                     organization_type=organization_type,
                     state_served_code=state_served_code,
+                    twitter_profile_image_url_https=twitter_profile_image_url_https,
+                    twitter_profile_background_image_url_https=twitter_profile_background_image_url_https,
+                    twitter_profile_banner_url_https=twitter_profile_banner_url_https,
                     we_vote_hosted_profile_image_url_large=we_vote_hosted_profile_image_url_large,
                     we_vote_hosted_profile_image_url_medium=we_vote_hosted_profile_image_url_medium,
                     we_vote_hosted_profile_image_url_tiny=we_vote_hosted_profile_image_url_tiny

--- a/twitter/functions.py
+++ b/twitter/functions.py
@@ -62,20 +62,22 @@ def retrieve_twitter_user_info(twitter_user_id, twitter_handle=''):
 
     twitter_handle_found = False
     twitter_json = {}
+    from wevote_functions.functions import convert_to_int
+    twitter_user_id = convert_to_int(twitter_user_id)
     try:
-        if positive_value_exists(twitter_user_id):
-            twitter_user = api.get_user(user_id=twitter_user_id)
-            twitter_json = twitter_user._json
-            success = True
-            # status += 'TWITTER_USER_ID_SUCCESS-' + str(twitter_user_id) + " "
-            twitter_handle_found = True
-        elif positive_value_exists(twitter_handle):
+        if positive_value_exists(twitter_handle):
             twitter_user = api.get_user(screen_name=twitter_handle)
             twitter_json = twitter_user._json
             success = True
             # status += 'TWITTER_HANDLE_SUCCESS-' + str(twitter_handle) + " "
             twitter_handle_found = True
             twitter_user_id = twitter_user.id  # Integer value. id_str would be the String value
+        elif positive_value_exists(twitter_user_id):
+            twitter_user = api.get_user(user_id=twitter_user_id)
+            twitter_json = twitter_user._json
+            success = True
+            # status += 'TWITTER_USER_ID_SUCCESS-' + str(twitter_user_id) + " "
+            twitter_handle_found = True
         else:
             twitter_json = {}
             success = False

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -716,7 +716,10 @@ class TwitterUserManager(models.Manager):
         # Is this twitter_handle already stored locally? If so, return that
         twitter_results = self.retrieve_twitter_user(twitter_user_id, twitter_handle, read_only=read_only)
         if twitter_results['twitter_user_found']:
-            return twitter_results
+            twitter_user = twitter_results['twitter_user']
+            if positive_value_exists(twitter_user.twitter_profile_image_url_https):
+                # If we have sufficient values, stop here. Otherwise, retrieve from Twitter again.
+                return twitter_results
         else:
             status += "TWITTER_USER_NOT_FOUND_LOCALLY "
 
@@ -731,6 +734,7 @@ class TwitterUserManager(models.Manager):
                 twitter_second_results = self.retrieve_twitter_user(twitter_user.twitter_id,
                                                                     twitter_user.twitter_handle)
                 if twitter_second_results['twitter_user_found']:
+                    status += "TWITTER_USER_FOUND_LOCALLY2: " + twitter_second_results['status']
                     return twitter_second_results
                 else:
                     status += "TWITTER_USER_NOT_FOUND_LOCALLY2: " + twitter_second_results['status']


### PR DESCRIPTION
Update twitterIdentityRetrieve so we can show new voter guides even if they haven't been imported from Twitter previously. Updated twitter_process_deferred_images_for_api to work with organizations not attached to voters. We no longer want to automatically return the previous election for this voter.