### PR TITLE
Fix python requirements so deployment works

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ boto3==1.13.16
 cryptography==3.4.8
 dj-database-url==0.5.0
 dj-static==0.0.6
-django==3.2.12
+django==3.2.13
 django-background-tasks==1.2.5
 django-bootstrap3==15.0.0
 django-cors-headers==3.7.0
@@ -18,11 +18,11 @@ firebase_admin==4.5.3
 future==0.18.2
 geoip2==2.9.0
 geopy==2.2.0
-google-api-core==2.7.1
-google-api-python-client==2.43.0
-google-auth==2.6.3
-google-cloud-firestore==1.9.0
-google-cloud-storage==1.31.0
+google-api-core==1.31.5
+google-api-python-client==2.44.0
+google-auth==1.35.0
+google-cloud-firestore==2.4.0
+google-cloud-storage==2.3.0
 gunicorn==19.10.0
 httplib2==0.19.1
 oauth2client==4.1.3


### PR DESCRIPTION
Update the google package requirements with compatible versions. Code not tested (couldn't find any unit tests to run.)

Also update django, per recommendation (SQL vulnerability.)