### PR TITLE
Updated create_new_voter_account process to auto-verify emails entered by admin. If an account already exists, simply update with new permissions. If a voter approves a friend request, but doesn't have a verified email address attached to their profile, heal the data and mark the email_ownership_is_verified as true.

### DIFF
--- a/email_outbound/models.py
+++ b/email_outbound/models.py
@@ -457,8 +457,11 @@ class EmailManager(models.Manager):
         }
         return results
 
-    def retrieve_email_address_object(self, normalized_email_address='', email_address_object_we_vote_id='',
-                                      voter_we_vote_id=''):
+    def retrieve_email_address_object(
+            self,
+            normalized_email_address='',
+            email_address_object_we_vote_id='',
+            voter_we_vote_id=''):
         """
         There are cases where we store multiple entries for the same normalized_email_address (prior to an email
         address being verified)
@@ -728,7 +731,7 @@ class EmailManager(models.Manager):
         }
         return results
 
-    def retrieve_primary_email_with_ownership_verified(self, voter_we_vote_id, normalized_email_address=''):
+    def retrieve_primary_email_with_ownership_verified(self, voter_we_vote_id='', normalized_email_address=''):
         status = ""
         email_address_list = []
         email_address_list_found = False


### PR DESCRIPTION
Updated create_new_voter_account process to auto-verify emails entered by admin. If an account already exists, simply update with new permissions. If a voter approves a friend request, but doesn't have a verified email address attached to their profile, heal the data and mark the email_ownership_is_verified as true.