### PR TITLE
Problem with query not getting executed at the right time, leading to non-distinct results. Removed polling_locations without a street address from being returned when updating ballot data from CTCL. Added measure_year and google_civic_election_id to the new measure form.

### DIFF
--- a/import_export_batches/controllers_batch_process.py
+++ b/import_export_batches/controllers_batch_process.py
@@ -2240,9 +2240,10 @@ def process_one_generate_voter_guides_batch_process(batch_process):
         Q(candidate_campaign_we_vote_id__in=candidate_we_vote_id_list))
     positions_exist_query = positions_exist_query.filter(
         Q(vote_smart_rating__isnull=True) | Q(vote_smart_rating=""))
+    # NOTE: There is a bug here to address -- this is not returning a list of distinct 'organization_we_vote_id' values
     positions_exist_query = positions_exist_query.values_list('organization_we_vote_id', flat=True).distinct()
     organization_we_vote_ids_with_positions = list(positions_exist_query)
-    status += str(organization_we_vote_ids_with_positions)
+    # status += str(organization_we_vote_ids_with_positions)
     # Add extra filter for safety while figuring out why distinct didn't work
     organization_we_vote_ids_with_positions_filtered = []
     for organization_we_vote_id in organization_we_vote_ids_with_positions:

--- a/import_export_batches/views_admin.py
+++ b/import_export_batches/views_admin.py
@@ -3462,6 +3462,10 @@ def retrieve_ballots_for_polling_locations_api_v4_internal_view(
                 polling_location_we_vote_id_list_to_retrieve[:refresh_or_retrieve_limit]
             polling_location_query = \
                 polling_location_query.filter(we_vote_id__in=polling_location_we_vote_id_list_to_retrieve_limited)
+            if positive_value_exists(use_ctcl):
+                # CTCL only supports full addresses, so don't bother trying to pass addresses without line1
+                polling_location_query = \
+                    polling_location_query.exclude(Q(line1__isnull=True) | Q(line1__exact=''))
             # We don't exclude the deleted map points because we need to know to delete the ballot returned entry
             # polling_location_query = polling_location_query.exclude(polling_location_deleted=True)
             polling_location_list = list(polling_location_query)
@@ -3483,8 +3487,12 @@ def retrieve_ballots_for_polling_locations_api_v4_internal_view(
             polling_location_query = \
                 polling_location_query.exclude(we_vote_id__in=polling_location_we_vote_id_list_to_exclude)
             polling_location_query = polling_location_query.exclude(polling_location_deleted=True)
+            if positive_value_exists(use_ctcl):
+                # CTCL only supports full addresses, so don't bother trying to pass addresses without line1
+                polling_location_query = \
+                    polling_location_query.exclude(Q(line1__isnull=True) | Q(line1__exact=''))
 
-            # Randomly change the sort order so we over time load different map points (before timeout)
+            # Randomly change the sort order, so we over time load different map points (before timeout)
             random_sorting = random.randint(1, 5)
             if random_sorting == 1:
                 # Ordering by "line1" creates a bit of (locational) random order

--- a/measure/controllers.py
+++ b/measure/controllers.py
@@ -375,6 +375,7 @@ def measures_import_from_structured_json(structured_json):  # Consumes measuresS
                 'measure_text': one_measure['measure_text'] if 'measure_text' in one_measure else '',
                 'measure_title': measure_title,
                 'measure_url': one_measure['measure_url'] if 'measure_url' in one_measure else '',
+                'measure_year': one_measure['measure_year'] if 'measure_year' in one_measure else '',
                 'ocd_division_id': one_measure['ocd_division_id'] if 'ocd_division_id' in one_measure else '',
                 'primary_party': one_measure['primary_party'] if 'primary_party' in one_measure else '',
                 'state_code': state_code,

--- a/measure/views_admin.py
+++ b/measure/views_admin.py
@@ -186,7 +186,7 @@ def measures_sync_out_view(request):  # measuresSyncOut
             'google_civic_measure_title', 'google_civic_measure_title2', 'google_civic_measure_title3',
             'google_civic_measure_title4', 'google_civic_measure_title5',
             'maplight_id',
-            'measure_subtitle', 'measure_text', 'measure_title', 'measure_url',
+            'measure_subtitle', 'measure_text', 'measure_title', 'measure_url', 'measure_year',
             'ocd_division_id',
             'primary_party', 'state_code',
             'vote_smart_id',
@@ -566,20 +566,20 @@ def measure_new_view(request):
 
     google_civic_election_id = request.GET.get('google_civic_election_id', 0)
 
-    try:
-        measure_list = ContestMeasure.objects.order_by('measure_title')
-        if positive_value_exists(google_civic_election_id):
-            measure_list = measure_list.filter(google_civic_election_id=google_civic_election_id)
-    except ContestMeasure.DoesNotExist:
-        # This is fine
-        measure_list = ContestMeasure()
-        pass
+    # try:
+    #     measure_list = ContestMeasure.objects.order_by('measure_title')
+    #     if positive_value_exists(google_civic_election_id):
+    #         measure_list = measure_list.filter(google_civic_election_id=google_civic_election_id)
+    # except ContestMeasure.DoesNotExist:
+    #     # This is fine
+    #     measure_list = ContestMeasure()
+    #     pass
 
     messages_on_stage = get_messages(request)
     template_values = {
         'messages_on_stage':        messages_on_stage,
         'google_civic_election_id': google_civic_election_id,
-        'measure_list':             measure_list,
+        # 'measure_list':             measure_list,
     }
     return render(request, 'measure/measure_edit.html', template_values)
 
@@ -664,17 +664,18 @@ def measure_edit_process_view(request):
     ballotpedia_measure_url = request.POST.get('ballotpedia_measure_url', False)
     ballotpedia_no_vote_description = request.POST.get('ballotpedia_no_vote_description', False)
     ballotpedia_yes_vote_description = request.POST.get('ballotpedia_yes_vote_description', False)
-    measure_id = convert_to_int(request.POST['measure_id'])
-    measure_title = request.POST.get('measure_title', False)
     google_civic_election_id = request.POST.get('google_civic_election_id', False)
     google_civic_measure_title = request.POST.get('google_civic_measure_title', False)
     google_civic_measure_title2 = request.POST.get('google_civic_measure_title2', False)
     google_civic_measure_title3 = request.POST.get('google_civic_measure_title3', False)
     google_civic_measure_title4 = request.POST.get('google_civic_measure_title4', False)
     google_civic_measure_title5 = request.POST.get('google_civic_measure_title5', False)
+    measure_id = convert_to_int(request.POST['measure_id'])
+    measure_title = request.POST.get('measure_title', False)
     measure_subtitle = request.POST.get('measure_subtitle', False)
     measure_text = request.POST.get('measure_text', False)
     measure_url = request.POST.get('measure_url', False)
+    measure_year = request.POST.get('measure_year', False)
     maplight_id = request.POST.get('maplight_id', False)
     vote_smart_id = request.POST.get('vote_smart_id', False)
     state_code = request.POST.get('state_code', False)
@@ -698,9 +699,15 @@ def measure_edit_process_view(request):
             if measure_on_stage_found:
                 # Update
                 if ballotpedia_district_id is not False:
-                    measure_on_stage.ballotpedia_district_id = ballotpedia_district_id
+                    if ballotpedia_district_id == '':
+                        measure_on_stage.ballotpedia_district_id = 0
+                    else:
+                        measure_on_stage.ballotpedia_district_id = ballotpedia_district_id
                 if ballotpedia_election_id is not False:
-                    measure_on_stage.ballotpedia_election_id = ballotpedia_election_id
+                    if ballotpedia_election_id == '':
+                        measure_on_stage.ballotpedia_election_id = 0
+                    else:
+                        measure_on_stage.ballotpedia_election_id = ballotpedia_election_id
                 if ballotpedia_measure_status is not False:
                     measure_on_stage.ballotpedia_measure_status = ballotpedia_measure_status
                 if ballotpedia_measure_url is not False:
@@ -729,6 +736,8 @@ def measure_edit_process_view(request):
                     measure_on_stage.measure_text = measure_text
                 if measure_url is not False:
                     measure_on_stage.measure_url = measure_url
+                if measure_year is not False:
+                    measure_on_stage.measure_year = measure_year
                 if maplight_id is not False:
                     measure_on_stage.maplight_id = maplight_id
                 if vote_smart_id is not False:
@@ -745,8 +754,6 @@ def measure_edit_process_view(request):
             else:
                 # Create new
                 measure_on_stage = ContestMeasure(
-                    ballotpedia_district_id=ballotpedia_district_id,
-                    ballotpedia_election_id=ballotpedia_election_id,
                     ballotpedia_measure_status=ballotpedia_measure_status,
                     ballotpedia_measure_url=ballotpedia_measure_url,
                     ballotpedia_no_vote_description=ballotpedia_no_vote_description,
@@ -761,14 +768,25 @@ def measure_edit_process_view(request):
                     measure_text=measure_text,
                     measure_title=measure_title,
                     measure_url=measure_url,
+                    measure_year=measure_year,
                     state_code=state_code,
                     maplight_id=maplight_id,
                     vote_smart_id=vote_smart_id,
                 )
+                if ballotpedia_district_id is not False:
+                    if ballotpedia_district_id == '':
+                        measure_on_stage.ballotpedia_district_id = 0
+                    else:
+                        measure_on_stage.ballotpedia_district_id = ballotpedia_district_id
+                if ballotpedia_election_id is not False:
+                    if ballotpedia_election_id == '':
+                        measure_on_stage.ballotpedia_election_id = 0
+                    else:
+                        measure_on_stage.ballotpedia_election_id = ballotpedia_election_id
                 measure_on_stage.save()
                 messages.add_message(request, messages.INFO, 'New measure saved.')
         except Exception as e:
-            messages.add_message(request, messages.ERROR, 'Could not save measure.')
+            messages.add_message(request, messages.ERROR, 'Could not save measure: ' + str(e))
 
     return HttpResponseRedirect(reverse('measure:measure_list', args=()) +
                                 "?google_civic_election_id=" + str(google_civic_election_id) +

--- a/templates/measure/measure_edit.html
+++ b/templates/measure/measure_edit.html
@@ -80,6 +80,14 @@
 </div>
 
 <div class="form-group">
+    <label for="measure_year_id" class="col-sm-3 control-label">Measure Year</label>
+    <div class="col-sm-8">
+        <input type="text" name="measure_year" id="measure_year_id" class="form-control"
+               value="{% if measure %}{{ measure.measure_year|default_if_none:"" }}{% else %}{{ measure_year|default_if_none:"" }}{% endif %}" />
+    </div>
+</div>
+
+<div class="form-group">
     <label for="ballotpedia_yes_vote_description_id" class="col-sm-3 control-label">A "yes" vote means...</label>
     <div class="col-sm-8">
         <textarea name="ballotpedia_yes_vote_description"
@@ -141,6 +149,9 @@
             {{ one_election.election_day_text }}: {{ one_election.election_name }} - {{ one_election.google_civic_election_id }}</option>
         {% endfor %}
     </select>
+    {% else %}
+        <input type="text" name="google_civic_election_id" id="google_civic_election_id" class="form-control"
+               value="{% if measure %}{{ measure.google_civic_election_id|default_if_none:"" }}{% else %}{{ google_civic_election_id|default_if_none:"" }}{% endif %}" />
     {% endif %}{# End of if election_list #}
     </div>
 </div>
@@ -242,7 +253,7 @@
     <br />
     <br />
 {% else %}
-    <p>(no measures found)</p>
+    <!-- <p>(no measures found)</p> //-->
 {% endif %}
 
 

--- a/templates/measure/measure_list.html
+++ b/templates/measure/measure_list.html
@@ -81,6 +81,7 @@
             <th>&nbsp;</th>
             <th>Measure Title</th>
             <th>State</th>
+            <th>Year / Election</th>
             <th>We Vote ID</th>
             <th>Ballotpedia ID</th>
             <th>Ballotpedia Status</th>
@@ -96,6 +97,7 @@
             <td>{{ forloop.counter }}</td>
             <td><a href="{% url 'measure:measure_summary' measure.id %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">{{ measure.measure_title }}</a></td>
             <td>{{ measure.state_code }}</td>
+            <td>{{ measure.measure_year }} / {{ measure.google_civic_election_id }}</td>
             <td>{{ measure.we_vote_id }}</td>
             <td>{{ measure.ballotpedia_measure_id }}</td>
             <td>{{ measure.ballotpedia_measure_status|default_if_none:"" }}</td>


### PR DESCRIPTION
Problem with query not getting executed at the right time, leading to non-distinct results. Removed polling_locations without a street address from being returned when updating ballot data from CTCL. Added measure_year and google_civic_election_id to the new measure form.