### PR TITLE
Added issueOrganizationsRetrieve API to return information about organizations categorized under one issue. Meant to be called through CDN, and only called once per issue (as needed) in each session. It is too much information to be included in issueDescriptionsRetrieve.

### DIFF
--- a/apis_v1/documentation_source/issue_descriptions_retrieve_doc.py
+++ b/apis_v1/documentation_source/issue_descriptions_retrieve_doc.py
@@ -21,12 +21,24 @@ def issue_descriptions_retrieve_doc_template_values(url_root):
                    '  "status": string,\n' \
                    '  "issue_list": list\n' \
                    '   [\n' \
+                   '     "considered_left": boolean,\n' \
+                   '     "considered_right": boolean,\n' \
                    '     "issue_we_vote_id": string,\n' \
                    '     "issue_name": string,\n' \
                    '     "issue_description": string,\n' \
+                   '     "issue_followers_count": number,\n' \
                    '     "issue_icon_local_path": string,\n' \
-                   '     "issue_image_url": string,\n' \
-                   '     "issue_photo_url_large": string,\n' \
+                   '     "linked_organization_count": number,\n' \
+                   '     "linked_organization_preview_list": list' \
+                   '      [{\n' \
+                   '        "organization_name": string,\n' \
+                   '        "organization_we_vote_id": string,\n' \
+                   '        "twitter_description": string,\n' \
+                   '        "twitter_followers_count": number,\n' \
+                   '        "organization_twitter_handle": string,\n' \
+                   '        "we_vote_hosted_profile_image_url_medium": string,\n' \
+                   '        "we_vote_hosted_profile_image_url_tiny": string,\n' \
+                   '      }],\n' \
                    '     "issue_photo_url_medium": string,\n' \
                    '     "issue_photo_url_tiny": string,\n' \
                    '   ],\n' \

--- a/apis_v1/documentation_source/issue_organizations_retrieve_doc.py
+++ b/apis_v1/documentation_source/issue_organizations_retrieve_doc.py
@@ -1,0 +1,57 @@
+# apis_v1/documentation_source/issue_organizations_retrieve_doc.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+
+
+def issue_organizations_retrieve_doc_template_values(url_root):
+    """
+    Show documentation about issueOrganizationsRetrieve
+    """
+    optional_query_parameter_list = [
+    ]
+
+    potential_status_codes_list = [
+    ]
+
+    try_now_link_variables_dict = {
+    }
+
+    api_response = '[{\n' \
+                   '  "success": boolean,\n' \
+                   '  "status": string,\n' \
+                   '  "issue_list": list\n' \
+                   '   [\n' \
+                   '     "issue_we_vote_id": string,\n' \
+                   '     "linked_organization_we_vote_id_list": list\n' \
+                   '      [\n' \
+                   '         organization_we_vote_id,\n' \
+                   '      ],\n' \
+                   '   ],\n' \
+                   '  "organization_list": list\n' \
+                   '   [{\n' \
+                   '     "organization_name": string,\n' \
+                   '     "organization_we_vote_id": string,\n' \
+                   '     "twitter_description": string,\n' \
+                   '     "twitter_followers_count": number,\n' \
+                   '     "organization_twitter_handle": string,\n' \
+                   '     "we_vote_hosted_profile_image_url_medium": string,\n' \
+                   '     "we_vote_hosted_profile_image_url_tiny": string,\n' \
+                   '   }],\n' \
+                   '}]'
+
+    template_values = {
+        'api_name': 'issueOrganizationsRetrieve',
+        'api_slug': 'issueOrganizationsRetrieve',
+        'api_introduction':
+            "",
+        'try_now_link': 'apis_v1:issueOrganizationsRetrieveView',
+        'try_now_link_variables_dict': try_now_link_variables_dict,
+        'url_root': url_root,
+        'get_or_post': 'GET',
+        'optional_query_parameter_list': optional_query_parameter_list,
+        'api_response': api_response,
+        'api_response_notes':
+            "",
+        'potential_status_codes_list': potential_status_codes_list,
+    }
+    return template_values

--- a/apis_v1/urls.py
+++ b/apis_v1/urls.py
@@ -22,7 +22,8 @@ from analytics.views_admin import analytics_action_sync_out_view, organization_d
 from ballot.views_admin import ballot_items_sync_out_view, ballot_returned_sync_out_view
 from candidate.views_admin import candidates_sync_out_view, candidate_to_office_link_sync_out_view
 from issue.views_admin import issue_descriptions_retrieve_view, issues_followed_retrieve_view, \
-    issues_sync_out_view, issues_retrieve_view, issues_under_ballot_items_retrieve_view, \
+    issue_organizations_retrieve_view, issues_sync_out_view, issues_retrieve_view, \
+    issues_under_ballot_items_retrieve_view, \
     retrieve_issues_to_follow_view, organization_link_to_issue_sync_out_view, test_real_time_update
 from measure.views_admin import measures_sync_out_view
 from office.views_admin import offices_sync_out_view
@@ -142,6 +143,8 @@ urlpatterns = [
       re_path(r'^issueDescriptionsRetrieve/', issue_descriptions_retrieve_view,
               name='issueDescriptionsRetrieveView'),
       re_path(r'^issueFollow/', views_voter.voter_issue_follow_view, name='issueFollowView'),
+      re_path(r'^issueOrganizationsRetrieve/', issue_organizations_retrieve_view,
+              name='issueOrganizationsRetrieveView'),
       re_path(r'^issuesLinkedToOrganization/',
               views_issues.issues_linked_to_organization_view, name='issuesLinkedToOrganizationView'),
       re_path(r'^issuesToLinkToForOrganization/',
@@ -514,6 +517,8 @@ urlpatterns = [
       re_path(r'^docs/issueDescriptionsRetrieve/$',
               views_docs.issue_descriptions_retrieve_doc_view, name='issueDescriptionsRetrieveDocs'),
       re_path(r'^docs/issueFollow/$', views_docs.issue_follow_doc_view, name='issueFollowDocs'),
+      re_path(r'^docs/issueOrganizationsRetrieve/$',
+              views_docs.issue_organizations_retrieve_doc_view, name='issueOrganizationsRetrieveDocs'),
       re_path(r'^docs/issuesFollowedRetrieve/$',
               views_docs.issues_followed_retrieve_doc_view, name='issuesFollowedRetrieveDocs'),
       re_path(r'^docs/issuesRetrieve/$', views_docs.issues_retrieve_doc_view, name='issuesRetrieveDocs'),

--- a/apis_v1/views/views_docs.py
+++ b/apis_v1/views/views_docs.py
@@ -21,7 +21,7 @@ from apis_v1.documentation_source import \
     friend_invitation_by_facebook_send_doc, friend_invitation_by_facebook_verify_doc, \
     friend_invitation_information_doc, \
     friend_invite_response_doc, friend_list_doc, friend_lists_all_doc, \
-    issue_descriptions_retrieve_doc, issue_follow_doc, \
+    issue_descriptions_retrieve_doc, issue_follow_doc, issue_organizations_retrieve_doc, \
     issues_followed_retrieve_doc, issues_retrieve_doc, issues_under_ballot_items_retrieve_doc, issues_sync_out_doc, \
     issues_linked_to_organization_doc, issues_to_link_to_for_organization_doc, \
     measure_retrieve_doc, measures_sync_out_doc, measure_list_for_upcoming_elections_retrieve_doc, \
@@ -569,6 +569,16 @@ def issue_descriptions_retrieve_doc_view(request):
     """
     url_root = WE_VOTE_SERVER_ROOT_URL
     template_values = issue_descriptions_retrieve_doc.issue_descriptions_retrieve_doc_template_values(url_root)
+    template_values['voter_api_device_id'] = get_voter_api_device_id(request)
+    return render(request, 'apis_v1/api_doc_page.html', template_values)
+
+
+def issue_organizations_retrieve_doc_view(request):
+    """
+    Show documentation about issueOrganizationsRetrieve
+    """
+    url_root = WE_VOTE_SERVER_ROOT_URL
+    template_values = issue_organizations_retrieve_doc.issue_organizations_retrieve_doc_template_values(url_root)
     template_values['voter_api_device_id'] = get_voter_api_device_id(request)
     return render(request, 'apis_v1/api_doc_page.html', template_values)
 

--- a/issue/views_admin.py
+++ b/issue/views_admin.py
@@ -85,6 +85,12 @@ def issue_descriptions_retrieve_view(request):  # issueDescriptionsRetrieve
     return http_response
 
 
+def issue_organizations_retrieve_view(request):  # issueOrganizationsRetrieve
+    issue_we_vote_id = request.GET.get('issue_we_vote_id', '')
+    http_response = issue_organizations_retrieve_for_api(issue_we_vote_id=issue_we_vote_id)
+    return http_response
+
+
 def issues_followed_retrieve_view(request):  # issuesFollowedRetrieve
     voter_device_id = get_voter_device_id(request)  # We standardize how we take in the voter_device_id
     http_response = issues_followed_retrieve_for_api(voter_device_id)

--- a/templates/analytics/sitewide_daily_metrics_table.html
+++ b/templates/analytics/sitewide_daily_metrics_table.html
@@ -47,8 +47,8 @@
     {# Sharing #}
         <td>
             {% if one_row.shared_items_clicked_today %}<span class="u-no-break">links clicked: {{ one_row.shared_items_clicked_today|intcomma }}</span><br />{% endif %}
-            {% if one_row.shared_link_clicked_unique_viewers_today %}<span class="u-no-break">unique viewers: {{ one_row.shared_link_clicked_unique_viewers_today|intcomma }}</span>{% endif %}
-            {% if one_row.shared_link_clicked_count_today %}<span class="u-no-break">total clicks: {{ one_row.shared_link_clicked_count_today|intcomma }}</span><br />{% endif %}
+            {% if one_row.shared_link_clicked_unique_viewers_today %}<span class="u-no-break">unique viewers: {{ one_row.shared_link_clicked_unique_viewers_today|intcomma }}</span><br />{% endif %}
+            {% if one_row.shared_link_clicked_count_today %}<span class="u-no-break">total clicks: {{ one_row.shared_link_clicked_count_today|intcomma }}</span>{% endif %}
         </td>
         <td>{% if one_row.ballot_views_today %}{{ one_row.ballot_views_today|intcomma }}{% endif %}</td>
         <td>

--- a/templates/apis_v1/apis_index.html
+++ b/templates/apis_v1/apis_index.html
@@ -875,6 +875,11 @@
           <td>Retrieve complete listing of the descriptions for all issues.</td>
         </tr>
         <tr>
+          <td><a href="{% url 'apis_v1:issueOrganizationsRetrieveDocs' %}">issueOrganizationsRetrieve</a></td>
+          <td>c3</td>
+          <td>Retrieve complete listing of the organizations attached to all issues.</td>
+        </tr>
+        <tr>
           <td><a href="{% url 'apis_v1:issueFollowDocs' %}">issueFollow</a></td>
           <td></td>
           <td>Allow a voter to follow one issue.</td>


### PR DESCRIPTION
Added issueOrganizationsRetrieve API to return information about organizations categorized under one issue. Meant to be called through CDN, and only called once per issue (as needed) in each session. It is too much information to be included in issueDescriptionsRetrieve.