### PR TITLE
Process incoming Facebook images in threads, to speed up save/retrieve queries for Facebook data

### DIFF
--- a/import_export_facebook/models.py
+++ b/import_export_facebook/models.py
@@ -493,7 +493,13 @@ class FacebookManager(models.Manager):
 
             facebook_user_list = list(facebook_user_query)
             for one_facebook_user in facebook_user_list:
-                logger.debug("DELETING one_facebook_user " + one_facebook_user.facebook_user_name)
+                name = one_facebook_user.facebook_user_name
+                if not name:
+                    name = one_facebook_user.facebook_user_first_name
+                if not name:
+                    name = "Entry does not contain a name"
+
+                logger.debug("DELETING one_facebook_user " + name)
                 one_facebook_user.delete()
                 facebook_users_deleted = facebook_users_deleted + 1
             success = True

--- a/voter/models.py
+++ b/voter/models.py
@@ -4302,6 +4302,7 @@ class VoterAddress(models.Model):
     # We are relying on built-in Python id field
 
     # The voter_id that owns this address
+    objects = None
     voter_id = models.BigIntegerField(
         verbose_name="voter unique identifier", null=False, blank=False, unique=False, db_index=True)
     address_type = models.CharField(

--- a/voter/views_admin.py
+++ b/voter/views_admin.py
@@ -2,6 +2,7 @@
 # Brought to you by We Vote. Be good.
 # -*- coding: UTF-8 -*-
 import string
+from datetime import timedelta
 
 from django.contrib import messages
 from django.contrib.auth import login
@@ -15,7 +16,6 @@ from django.utils.timezone import now
 
 import wevote_functions.admin
 from admin_tools.views import redirect_to_sign_in_page
-from datetime import timedelta
 from email_outbound.models import EmailAddress, EmailManager
 from exception.models import handle_record_found_more_than_one_exception, handle_record_not_found_exception, \
     handle_record_not_saved_exception, handle_exception
@@ -238,7 +238,8 @@ def voter_delete_process_view(request):
         if len(voter_query):
             voter_on_stage = voter_query[0]
             voter_on_stage_found = True
-            results = delete_all_voter_information_permanently(voter_to_delete=voter_on_stage)
+            results = delete_all_voter_information_permanently(voter_to_delete=voter_on_stage,
+                                                               user = request.user)
             status += results['status']
     except Exception as e:
         handle_record_not_found_exception(e, logger=logger)


### PR DESCRIPTION
Enhanced delete_all_voter_information_permanently to also delete facebook_users and facebook_link_to_voter so that processing Facebook images in threads can be fully tested for new users. 
Now delete_all_voter_information_permanently logs what voter was deleted, and who deleted them.