### PR TITLE
Changed facebook image processing timing logs to "error" so I can see them in CloudWatch

### DIFF
--- a/import_export_facebook/controllers.py
+++ b/import_export_facebook/controllers.py
@@ -411,9 +411,9 @@ def caching_facebook_images_for_retrieve_process(*args, **kwargs):
                                         facebook_profile_image_url_https,
                                         facebook_background_image_url_https)
     dtc = time() - t0
-    logger.info('Processing the facebook images for a RETRIEVE in a thread for voter %s %s (%s) took %.3f seconds' %
-                (facebook_auth_response.facebook_first_name, facebook_auth_response.facebook_last_name,
-                 voter_we_vote_id_for_cache, dtc))
+    logger.error('(Not an error) Processing the facebook images for a RETRIEVE in a thread for voter %s %s (%s) took %.3f seconds' %
+                 (facebook_auth_response.facebook_first_name, facebook_auth_response.facebook_last_name,
+                  voter_we_vote_id_for_cache, dtc))
     logger.debug('caching_facebook_images_for_retrieve_process status: ' + status)
 
 

--- a/voter/controllers.py
+++ b/voter/controllers.py
@@ -1763,8 +1763,8 @@ def voter_cache_facebook_images_process(*args, **kwargs):
         we_vote_hosted_profile_image_url_tiny)
     dtc = time() - t0
     # 12/20/22: takes 1.2 seconds on my local postgres, leave this logger in for a few months, so we can gather data
-    logger.info('Processing the facebook images in a thread for voter %s %s (%s) took %.3f seconds' %
-          (voter.first_name, voter.last_name, voter.we_vote_id, dtc))
+    logger.error('(Not an error) Processing the facebook images in a thread for voter %s %s (%s) took %.3f seconds' %
+                 (voter.first_name, voter.last_name, voter.we_vote_id, dtc))
     # print("process finished")
 
 

--- a/voter/models.py
+++ b/voter/models.py
@@ -675,7 +675,7 @@ class VoterManager(BaseUserManager):
             voter_created = True
         except IntegrityError as e:
             handle_record_not_saved_exception(e, logger=logger)
-            logger.debug("create_voter IntegrityError exception (#1): " + str(e))
+            logger.error("create_voter IntegrityError exception (#1): " + str(e))
             try:
                 # Trying to save again will increment the 'we_vote_id_last_voter_integer'
                 # by calling 'fetch_next_we_vote_id_voter_integer'
@@ -686,10 +686,10 @@ class VoterManager(BaseUserManager):
                 voter_created = True
             except IntegrityError as e:
                 handle_record_not_saved_exception(e, logger=logger)
-                logger.debug("create_voter IntegrityError exception (#2): " + str(e))
+                logger.error("create_voter IntegrityError exception (#2): " + str(e))
             except Exception as e:
                 handle_record_not_saved_exception(e, logger=logger)
-                logger.debug("create_voter general exception (#1): " + str(e))
+                logger.error("create_voter general exception (#1): " + str(e))
 
 
         except Exception as e:


### PR DESCRIPTION
Also promoted some info logging to errors in voter.save() case to see why saving errors are being logged to CloudWatch with insufficient info to diagnose.