### PR TITLE
Added more logging for Stripe webhooks so we can get more data on attacks

### DIFF
--- a/apis_v1/views/views_organization.py
+++ b/apis_v1/views/views_organization.py
@@ -1,33 +1,34 @@
 # apis_v1/views/views_organization.py
 # Brought to you by We Vote. Be good.
 # -*- coding: UTF-8 -*-
+import json
+import re
+
+import requests
+from django.http import HttpResponse
+from django.shortcuts import render
+from django.views.decorators.csrf import csrf_exempt
+from django_user_agents.utils import get_user_agent
+
+import wevote_functions.admin
+from apis_v1.controllers import organization_count, organization_follow, organization_follow_ignore, \
+    organization_stop_following, organization_stop_ignoring
+from config.base import get_environment_variable
+from donate.models import DonationManager
+from follow.controllers import organization_suggestion_tasks_for_api
 from follow.models import UPDATE_SUGGESTIONS_FROM_TWITTER_IDS_I_FOLLOW, UPDATE_SUGGESTIONS_FROM_WHAT_FRIENDS_FOLLOW, \
     UPDATE_SUGGESTIONS_FROM_WHAT_FRIENDS_FOLLOW_ON_TWITTER, UPDATE_SUGGESTIONS_FROM_WHAT_FRIEND_FOLLOWS, \
     UPDATE_SUGGESTIONS_FROM_WHAT_FRIEND_FOLLOWS_ON_TWITTER, UPDATE_SUGGESTIONS_ALL, \
     FOLLOW_SUGGESTIONS_FROM_FRIENDS_ON_TWITTER, FOLLOW_SUGGESTIONS_FROM_FRIENDS, \
     FOLLOW_SUGGESTIONS_FROM_TWITTER_IDS_I_FOLLOW
-from apis_v1.controllers import organization_count, organization_follow, organization_follow_ignore, \
-    organization_stop_following, organization_stop_ignoring
-from config.base import get_environment_variable
-from django.http import HttpResponse
-from django.shortcuts import render
-from django_user_agents.utils import get_user_agent
-from django.views.decorators.csrf import csrf_exempt
-from donate.models import DonationManager
-from follow.controllers import organization_suggestion_tasks_for_api
-import json
-import re
-import requests
 from organization.controllers import full_domain_string_available, organization_analytics_by_voter_for_api, \
     organization_retrieve_for_api, organization_photos_save_for_api, \
     organization_save_for_api, organization_search_for_api, organizations_followed_retrieve_for_api, \
     site_configuration_retrieve_for_api, subdomain_string_available
-from organization.models import CHOSEN_FAVICON_ALLOWED, CHOSEN_FULL_DOMAIN_ALLOWED, CHOSEN_GOOGLE_ANALYTICS_ALLOWED, \
-    CHOSEN_SOCIAL_SHARE_IMAGE_ALLOWED, CHOSEN_SOCIAL_SHARE_DESCRIPTION_ALLOWED, CHOSEN_PROMOTED_ORGANIZATIONS_ALLOWED, \
-    OrganizationManager
+from organization.models import CHOSEN_FAVICON_ALLOWED, CHOSEN_GOOGLE_ANALYTICS_ALLOWED, \
+    CHOSEN_SOCIAL_SHARE_IMAGE_ALLOWED, CHOSEN_SOCIAL_SHARE_DESCRIPTION_ALLOWED, OrganizationManager
 from voter.models import voter_has_authority, VoterManager
 from voter_guide.controllers_possibility import organizations_found_on_url
-import wevote_functions.admin
 from wevote_functions.functions import convert_to_int, extract_website_from_url, get_voter_device_id, \
     get_maximum_number_to_retrieve_from_request, is_url_valid, positive_value_exists
 

--- a/image/controllers.py
+++ b/image/controllers.py
@@ -3338,6 +3338,7 @@ def cache_master_and_resized_image(
     :param wikipedia_profile_image_url:
     :return:
     """
+    # print('---------------- cache_master_and_resized_image ------------------')
     time0 = log_and_time_cache_action(True, 0, 'cache_master_and_resized_image')
     status = ''
     cached_ballotpedia_image_url_https = None

--- a/templates/stripe_donations/suspects_list.html
+++ b/templates/stripe_donations/suspects_list.html
@@ -36,6 +36,19 @@ tr, th, td {
 </div>
 
 <br />
+<div style="border: 1px solid #333; padding: 8px;margin: 20px;{% if not stripe_processing_enabled %}background-color: #ffc0c0;{% endif %}">
+    {% if stripe_processing_enabled %}
+        <span style="color: green;">Processing of Stripe Transactions is ENABLED</span>
+    {% else %}
+        <span style="color: black;">Processing of Stripe Transactions is DISABLED</span>
+    {% endif %}
+    <span style="padding: 16px">
+        <input type="checkbox" name="toggle_confirm_one" id="toggle_confirm_one" value="0" style="margin: 0 6px 0 32px"/>
+        <button id="toggle_stripe_state" style="">Click Both Checkboxes and Press This Button to Toggle Stripe Enabled State</button>
+        <input type="checkbox" name="toggle_confirm_two" id="toggle_confirm_two" value="0" style="margin: 0 0 0 6px"/>
+    </span>
+</div>
+<br />
 
 <div id="tabs">
     <ul>
@@ -171,6 +184,21 @@ tr, th, td {
     const dispute = {{ dispute|lower }};
     setDisplayedTab(dispute);
   })
+  $('#toggle_stripe_state').click(function(evt) {
+    let checked = $('#toggle_confirm_one').is(":checked") && $('#toggle_confirm_two').is(":checked")
+    if (checked) {
+      const enabled = {{ stripe_processing_enabled|yesno:"true,false" }};
+      let { href } = window.location;
+      const x = {{ stripe_processing_enabled|yesno:"true,false" }};
+      const newState = !x;
+      href += '?set_stripe_enabled=' + newState;
+      window.location.href = href;
+    }
+  })
+  // Inline for each page load, remove the old get param
+  if (window.location.href.includes('set_stripe_enabled=')) {
+    window.location.href = window.location.href.replace(/[?&]set_stripe_enabled=(false|true)/gm, '');
+  }
 </script>
 
 {% endblock %}

--- a/templates/stripe_donations/suspects_list.html
+++ b/templates/stripe_donations/suspects_list.html
@@ -44,7 +44,7 @@ tr, th, td {
     {% endif %}
     <span style="padding: 16px">
         <input type="checkbox" name="toggle_confirm_one" id="toggle_confirm_one" value="0" style="margin: 0 6px 0 32px"/>
-        <button id="toggle_stripe_state" style="">Click Both Checkboxes and Press This Button to Toggle Stripe Enabled State</button>
+        <button id="toggle_stripe_state" style="">Click Both Checkboxes and Press This Button to     {% if stripe_processing_enabled %}Disable{% else %}Enable{% endif %} Stripe </button>
         <input type="checkbox" name="toggle_confirm_two" id="toggle_confirm_two" value="0" style="margin: 0 0 0 6px"/>
     </span>
 </div>

--- a/templates/stripe_donations/suspects_list.html
+++ b/templates/stripe_donations/suspects_list.html
@@ -44,7 +44,7 @@ tr, th, td {
     {% endif %}
     <span style="padding: 16px">
         <input type="checkbox" name="toggle_confirm_one" id="toggle_confirm_one" value="0" style="margin: 0 6px 0 32px"/>
-        <button id="toggle_stripe_state" style="">Click Both Checkboxes and Press This Button to     {% if stripe_processing_enabled %}Disable{% else %}Enable{% endif %} Stripe </button>
+        <button id="toggle_stripe_state" style="">{% if stripe_processing_enabled %}Disable{% else %}Enable{% endif %} Stripe (both checkboxes need to be checked)</button>
         <input type="checkbox" name="toggle_confirm_two" id="toggle_confirm_two" value="0" style="margin: 0 0 0 6px"/>
     </span>
 </div>


### PR DESCRIPTION
So we can figure out how to preempt more of them.

Conditionally enabled donationWithStripe, does not 404 if fetch_stripe_processing_enabled_state() is true Added a column to wevote_settings in case we want to add a simple configuration page, in the meantime, added the new configuration to /stripe_donations/suspects_list/