### PR TITLE
Rewrote sign in for Facebook

### DIFF
--- a/aws/management/commands/runsqsworker.py
+++ b/aws/management/commands/runsqsworker.py
@@ -68,7 +68,7 @@ def process_request(function, body, message):
         voter_id = body['voter_id']
         facebook_auth_response_id = body['facebook_auth_response_id']
 
-        voter_cache_facebook_images_process(voter_id, facebook_auth_response_id)
+        voter_cache_facebook_images_process(voter_id, facebook_auth_response_id, False)
     else:
         logger.error(f"SQS Job references unknown function [{function}], deleting.")
 


### PR DESCRIPTION
There were a number of problems

For many months or years, loading of new images from Facebook was not working on successive logins, where the image had changed -- this now works. 

The source of the biggest problem is that facebook returns a download link for a new voter image, that we (confusingly) call facebook_profile_image_url_https -- this is not an image url, it is a link to download an image, and it contains a hash number which we were using to determine uniqueness of the source image.  But facebook reuses that hash number for the same user with different pictures ... possibly only on the same day. 

We process the new images (Now in a new and simplified way) after a facebook login that requires a redirect to FB's login page, and then we store them in S3.   We also process them a second time, when the FB JavaScript api returns new images on the confirmation of sign in.  This is wasteful after a redirect login, and valuable after a no-redirect login.  But some part of that processing of the second sign in is necessary after a redirect login and so I left that in.

Since the processing of images is done in SQS Jobs in separate processes, there is no time penalty for processing them twice. 

Someday as S3 storage grows, we should look into removing old, no longer current images that we "cache" in S3.  This would not be too hard, given we keep a link to old images in the wevoteimage table.