### PR TITLE
Added multiple facebook_urls and politician_phone_numbers to minimize manual merge intervention. Made "show_related_candidates" on the politician page an optional setting so speed up loading of Politician listing admin page.

### DIFF
--- a/apis_v1/documentation_source/politicians_sync_out_doc.py
+++ b/apis_v1/documentation_source/politicians_sync_out_doc.py
@@ -65,6 +65,8 @@ def politicians_sync_out_doc_template_values(url_root):
                    '  "ctcl_uuid": string,\n' \
                    '  "politician_facebook_id": string,\n' \
                    '  "politician_phone_number": string,\n' \
+                   '  "politician_phone_number2": string,\n' \
+                   '  "politician_phone_number3": string,\n' \
                    '  "politician_googleplus_id": string,\n' \
                    '  "politician_youtube_id": string,\n' \
                    '  "politician_email_address": string DEPRECATING,\n' \

--- a/import_export_batches/controllers.py
+++ b/import_export_batches/controllers.py
@@ -1662,8 +1662,12 @@ def create_batch_row_action_politician(batch_description, batch_header_map, one_
     youtube_id = batch_manager.retrieve_value_from_batch_row("politician_youtube_id", batch_header_map, one_batch_row)
     googleplus_id = batch_manager.retrieve_value_from_batch_row("politician_googleplus_id", batch_header_map,
                                                                 one_batch_row)
-    phone_number = batch_manager.retrieve_value_from_batch_row("politician_phone_number", batch_header_map,
-                                                               one_batch_row)
+    politician_phone_number = batch_manager.retrieve_value_from_batch_row("politician_phone_number", batch_header_map,
+                                                                          one_batch_row)
+    politician_phone_number2 = batch_manager.retrieve_value_from_batch_row("politician_phone_number2", batch_header_map,
+                                                                           one_batch_row)
+    politician_phone_number3 = batch_manager.retrieve_value_from_batch_row("politician_phone_number3", batch_header_map,
+                                                                           one_batch_row)
 
     # extract twitter handle from politician_twitter_url
     politician_twitter_handle = extract_twitter_handle_from_text_string(politician_twitter_url)
@@ -1826,7 +1830,9 @@ def create_batch_row_action_politician(batch_description, batch_header_map, one_
         batch_row_action_politician.politician_email = politician_email
         batch_row_action_politician.politician_email2 = politician_email2
         batch_row_action_politician.politician_email3 = politician_email3
-        batch_row_action_politician.politician_phone_number = phone_number
+        batch_row_action_politician.politician_phone_number = politician_phone_number
+        batch_row_action_politician.politician_phone_number2 = politician_phone_number2
+        batch_row_action_politician.politician_phone_number3 = politician_phone_number3
         batch_row_action_politician.politician_twitter_handle = politician_twitter_handle
         batch_row_action_politician.politician_twitter_handle2 = politician_twitter_handle2
         batch_row_action_politician.politician_twitter_handle3 = politician_twitter_handle3
@@ -4646,6 +4652,8 @@ def import_politician_data_from_batch_row_actions(batch_header_id, batch_row_id,
         politician_email2 = one_batch_row_action.politician_email2
         politician_email3 = one_batch_row_action.politician_email3
         politician_phone_number = one_batch_row_action.politician_phone_number
+        politician_phone_number2 = one_batch_row_action.politician_phone_number2
+        politician_phone_number3 = one_batch_row_action.politician_phone_number3
         politician_twitter_handle = one_batch_row_action.politician_twitter_handle
         politician_twitter_handle2 = one_batch_row_action.politician_twitter_handle2
         politician_twitter_handle3 = one_batch_row_action.politician_twitter_handle3
@@ -4674,6 +4682,8 @@ def import_politician_data_from_batch_row_actions(batch_header_id, batch_row_id,
                     politician_email2=politician_email2,
                     politician_email3=politician_email3,
                     politician_phone_number=politician_phone_number,
+                    politician_phone_number2=politician_phone_number2,
+                    politician_phone_number3=politician_phone_number3,
                     politician_twitter_handle=politician_twitter_handle,
                     politician_twitter_handle2=politician_twitter_handle2,
                     politician_twitter_handle3=politician_twitter_handle3,
@@ -4714,6 +4724,8 @@ def import_politician_data_from_batch_row_actions(batch_header_id, batch_row_id,
                     politician_twitter_handle4=politician_twitter_handle4,
                     politician_twitter_handle5=politician_twitter_handle5,
                     politician_phone_number=politician_phone_number,
+                    politician_phone_number2=politician_phone_number2,
+                    politician_phone_number3=politician_phone_number3,
                     politician_facebook_id=politician_facebook_id,
                     politician_googleplus_id=politician_googleplus_id,
                     politician_youtube_id=politician_youtube_id,

--- a/import_export_batches/models.py
+++ b/import_export_batches/models.py
@@ -125,6 +125,8 @@ BATCH_IMPORT_KEYS_ACCEPTED_FOR_CANDIDATES = {
     'election_day': 'election_day',
     'email': 'vote_usa_candidate_email',
     'facebook_url': 'facebook_url',
+    'facebook_url2': 'facebook_url2',
+    'facebook_url3': 'facebook_url3',
     'facebook url': 'vote_usa_facebook_url',
     'google_civic_election_id': 'google_civic_election_id',
     'party': 'vote_usa_party_name',
@@ -481,6 +483,8 @@ BATCH_IMPORT_KEYS_ACCEPTED_FOR_POLITICIANS = {
     'politician_youtube_id': 'politician_youtube_id',
     'politician_googleplus_id': 'politician_googleplus_id',
     'politician_phone_number': 'politician_phone_number',
+    'politician_phone_number2': 'politician_phone_number2',
+    'politician_phone_number3': 'politician_phone_number3',
     'politician_batch_id': 'politician_batch_id',
 }
 
@@ -6047,8 +6051,10 @@ class BatchRowActionPolitician(models.Model):
     # The full name of the party the official belongs to.
     political_party = models.CharField(verbose_name="politician political party", max_length=255, null=True)
     state_code = models.CharField(verbose_name="politician home state", max_length=2, null=True)
-    politician_url = models.URLField(
-        verbose_name='latest website url of politician', max_length=255, blank=True, null=True)
+    facebook_url = models.TextField(blank=True, null=True)
+    facebook_url2 = models.TextField(blank=True, null=True)
+    facebook_url3 = models.TextField(blank=True, null=True)
+    politician_url = models.TextField(blank=True, null=True)
 
     politician_twitter_handle = models.CharField(max_length=255, null=True, unique=False)
     politician_twitter_handle2 = models.CharField(max_length=255, null=True, unique=False)
@@ -6064,8 +6070,9 @@ class BatchRowActionPolitician(models.Model):
     ctcl_uuid = models.CharField(verbose_name="ctcl uuid", max_length=36, null=True, blank=True)
     politician_facebook_id = models.CharField(verbose_name='politician facebook user name', max_length=255, null=True,
                                               unique=False)
-    politician_phone_number = models.CharField(verbose_name='politician phone number', max_length=255, null=True,
-                                               unique=False)
+    politician_phone_number = models.CharField(max_length=255, null=True, unique=False)
+    politician_phone_number2 = models.CharField(max_length=255, null=True, unique=False)
+    politician_phone_number3 = models.CharField(max_length=255, null=True, unique=False)
     politician_googleplus_id = models.CharField(verbose_name='politician googleplus profile name', max_length=255,
                                                 null=True, unique=False)
     politician_youtube_id = models.CharField(verbose_name='politician youtube profile name', max_length=255, null=True,

--- a/politician/models.py
+++ b/politician/models.py
@@ -37,8 +37,8 @@ POLITICIAN_UNIQUE_IDENTIFIERS = [
     'birth_date',
     'cspan_id',
     'ctcl_uuid',
-    'facebook_url',
-    'facebook_url_is_broken',
+    # 'facebook_url',  # We now have 3 options and merge them automatically
+    # 'facebook_url_is_broken',
     'fec_id',
     'first_name',
     'gender',
@@ -58,7 +58,7 @@ POLITICIAN_UNIQUE_IDENTIFIERS = [
     'politician_facebook_id',
     'politician_googleplus_id',
     'politician_name',
-    'politician_phone_number',
+    # 'politician_phone_number',  # We now have 3 options and merge them automatically
     # 'politician_url',  # We have 5 options now and merge them automatically
     'politician_youtube_id',
     'state_code',
@@ -102,7 +102,11 @@ class Politician(models.Model):
     politician_name = models.CharField(verbose_name="official full name",
                                        max_length=255, default=None, null=True, blank=True)
     facebook_url = models.TextField(verbose_name='facebook url of candidate', blank=True, null=True)
+    facebook_url2 = models.TextField(blank=True, null=True)
+    facebook_url3 = models.TextField(blank=True, null=True)
     facebook_url_is_broken = models.BooleanField(verbose_name="facebook url is broken", default=False)
+    facebook_url2_is_broken = models.BooleanField(default=False)
+    facebook_url3_is_broken = models.BooleanField(default=False)
     # This is the politician's name from GoogleCivicCandidateCampaign
     google_civic_candidate_name = models.CharField(
         verbose_name="full name from google civic", max_length=255, default=None, null=True, blank=True)
@@ -190,8 +194,9 @@ class Politician(models.Model):
     linkedin_url = models.TextField(null=True, blank=True)
     politician_facebook_id = models.CharField(
         verbose_name='politician facebook user name', max_length=255, null=True, unique=False)
-    politician_phone_number = models.CharField(
-        verbose_name='politician phone number', max_length=255, null=True, unique=False)
+    politician_phone_number = models.CharField(max_length=255, null=True, unique=False)
+    politician_phone_number2 = models.CharField(max_length=255, null=True, unique=False)
+    politician_phone_number3 = models.CharField(max_length=255, null=True, unique=False)
     politician_googleplus_id = models.CharField(
         verbose_name='politician googleplus profile name', max_length=255, null=True, unique=False)
     politician_youtube_id = models.CharField(
@@ -1149,6 +1154,8 @@ class PoliticianManager(models.Manager):
             politician_email2='',
             politician_email3='',
             politician_phone_number='',
+            politician_phone_number2='',
+            politician_phone_number3='',
             politician_twitter_handle='',
             politician_twitter_handle2='',
             politician_twitter_handle3='',
@@ -1170,6 +1177,8 @@ class PoliticianManager(models.Manager):
         :param politician_email2:
         :param politician_email3:
         :param politician_phone_number:
+        :param politician_phone_number2:
+        :param politician_phone_number3:
         :param politician_twitter_handle:
         :param politician_twitter_handle2:
         :param politician_twitter_handle3:
@@ -1198,6 +1207,8 @@ class PoliticianManager(models.Manager):
                 politician_email2=politician_email2,
                 politician_email3=politician_email3,
                 politician_phone_number=politician_phone_number,
+                politician_phone_number2=politician_phone_number2,
+                politician_phone_number3=politician_phone_number3,
                 politician_twitter_handle=politician_twitter_handle,
                 politician_twitter_handle2=politician_twitter_handle2,
                 politician_twitter_handle3=politician_twitter_handle3,
@@ -1247,6 +1258,8 @@ class PoliticianManager(models.Manager):
             politician_twitter_handle4='',
             politician_twitter_handle5='',
             politician_phone_number='',
+            politician_phone_number2='',
+            politician_phone_number3='',
             politician_facebook_id='',
             politician_googleplus_id='',
             politician_youtube_id='',
@@ -1269,6 +1282,8 @@ class PoliticianManager(models.Manager):
         :param politician_twitter_handle4:
         :param politician_twitter_handle5:
         :param politician_phone_number:
+        :param politician_phone_number2:
+        :param politician_phone_number3:
         :param politician_facebook_id:
         :param politician_googleplus_id:
         :param politician_youtube_id:
@@ -1297,6 +1312,8 @@ class PoliticianManager(models.Manager):
                 existing_politician_entry.politician_email2 = politician_email2
                 existing_politician_entry.politician_email3 = politician_email3
                 existing_politician_entry.politician_phone_number = politician_phone_number
+                existing_politician_entry.politician_phone_number2 = politician_phone_number2
+                existing_politician_entry.politician_phone_number3 = politician_phone_number3
                 existing_politician_entry.politician_twitter_handle = politician_twitter_handle
                 existing_politician_entry.politician_twitter_handle2 = politician_twitter_handle2
                 existing_politician_entry.politician_twitter_handle3 = politician_twitter_handle3

--- a/representative/controllers.py
+++ b/representative/controllers.py
@@ -1052,6 +1052,20 @@ def update_representative_from_politician(representative=None, politician=None):
             new_value_to_add=politician.politician_phone_number)
         if twitter_results['success']:
             representative = twitter_results['representative']
+    if positive_value_exists(politician.politician_phone_number2):
+        twitter_results = add_value_to_next_representative_spot(
+            field_name_base='representative_phone',
+            representative=representative,
+            new_value_to_add=politician.politician_phone_number2)
+        if twitter_results['success']:
+            representative = twitter_results['representative']
+    if positive_value_exists(politician.politician_phone_number3):
+        twitter_results = add_value_to_next_representative_spot(
+            field_name_base='representative_phone',
+            representative=representative,
+            new_value_to_add=politician.politician_phone_number3)
+        if twitter_results['success']:
+            representative = twitter_results['representative']
     if positive_value_exists(politician.politician_twitter_handle) and not politician.twitter_handle_updates_failing:
         twitter_results = add_value_to_next_representative_spot(
             field_name_base='representative_twitter_handle',

--- a/representative/views_admin.py
+++ b/representative/views_admin.py
@@ -344,6 +344,7 @@ def representative_list_view(request):
                 )
             else:
                 queryset = queryset.filter(state_code__iexact=state_code)
+
         if positive_value_exists(show_representatives_with_email):
             queryset = queryset.annotate(representative_email_length=Length('representative_email'))
             queryset = queryset.annotate(representative_email2_length=Length('representative_email2'))
@@ -364,10 +365,21 @@ def representative_list_view(request):
             for one_word in search_words:
                 filters = []
 
+                new_filter = (
+                    Q(representative_email__icontains=one_word) |
+                    Q(representative_email2__icontains=one_word) |
+                    Q(representative_email3__icontains=one_word)
+                )
+                filters.append(new_filter)
+
                 new_filter = Q(representative_name__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(representative_twitter_handle__icontains=one_word)
+                new_filter = (
+                    Q(representative_twitter_handle__icontains=one_word) |
+                    Q(representative_twitter_handle2__icontains=one_word) |
+                    Q(representative_twitter_handle3__icontains=one_word)
+                )
                 filters.append(new_filter)
 
                 new_filter = Q(political_party__icontains=one_word)

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -303,6 +303,32 @@
 </div>
 
 <div class="form-group">
+    <label for="facebook_url2_id" class="col-sm-3 control-label">
+        Facebook URL 2
+        {% if politician.facebook_url2 %}
+        <a href="{{ politician.facebook_url2 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+        {% endif %}
+    </label>
+    <div class="col-sm-8">
+        <input type="text" name="facebook_url2" id="facebook_url2_id" class="form-control"
+               value="{% if politician %}{{ politician.facebook_url2|default_if_none:"" }}{% else %}{{ facebook_url2|default_if_none:"" }}{% endif %}" />
+    </div>
+</div>
+
+<div class="form-group">
+    <label for="facebook_url3_id" class="col-sm-3 control-label">
+        Facebook URL 3
+        {% if politician.facebook_url3 %}
+        <a href="{{ politician.facebook_url3 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+        {% endif %}
+    </label>
+    <div class="col-sm-8">
+        <input type="text" name="facebook_url3" id="facebook_url3_id" class="form-control"
+               value="{% if politician %}{{ politician.facebook_url3|default_if_none:"" }}{% else %}{{ facebook_url3|default_if_none:"" }}{% endif %}" />
+    </div>
+</div>
+
+<div class="form-group">
     <label for="instagram_handle_id" class="col-sm-3 control-label">
         Instagram Handle
         {% if politician.instagram_handle %}
@@ -344,6 +370,22 @@
     <div class="col-sm-8">
         <input type="text" name="politician_phone_number" id="politician_phone_number_id" class="form-control"
                value="{% if politician %}{{ politician.politician_phone_number|default_if_none:"" }}{% else %}{{ politician_phone_number|default_if_none:"" }}{% endif %}" />
+    </div>
+</div>
+
+<div class="form-group">
+    <label for="politician_phone_number2_id" class="col-sm-3 control-label">Phone 2</label>
+    <div class="col-sm-8">
+        <input type="text" name="politician_phone_number2" id="politician_phone_number2_id" class="form-control"
+               value="{% if politician %}{{ politician.politician_phone_number2|default_if_none:"" }}{% else %}{{ politician_phone_number2|default_if_none:"" }}{% endif %}" />
+    </div>
+</div>
+
+<div class="form-group">
+    <label for="politician_phone_number3_id" class="col-sm-3 control-label">Phone 3</label>
+    <div class="col-sm-8">
+        <input type="text" name="politician_phone_number3" id="politician_phone_number3_id" class="form-control"
+               value="{% if politician %}{{ politician.politician_phone_number3|default_if_none:"" }}{% else %}{{ politician_phone_number3|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
 

--- a/templates/politician/politician_list.html
+++ b/templates/politician/politician_list.html
@@ -57,6 +57,11 @@
       <input type="checkbox" name="show_all" id="show_all_id" value="1"
              {% if show_all %}checked{% endif %} /> Show up to 200 politicians
     </label>
+    &nbsp;&nbsp;
+    <label for="show_related_candidates_id">
+      <input type="checkbox" name="show_related_candidates" id="show_related_candidates_id" value="1"
+             {% if show_related_candidates %}checked{% endif %} /> Show related candidates count
+    </label>
 </form>
 
 {% if politician_list %}
@@ -72,7 +77,9 @@
             <th>Email(s)</th>
             <th>Website(s)</th>
             <th>Candidates Linked</th>
+        {% if show_related_candidates %}
             <th>Related Candidates?</th>
+        {% endif %}
         </tr>
       </thead>
     {% for politician in politician_list %}
@@ -122,6 +129,9 @@
                 {% if politician.politician_email %}{{ politician.politician_email }}&nbsp;{% endif %}
                 {% if politician.politician_email2 %}{{ politician.politician_email2 }}&nbsp;{% endif %}
                 {% if politician.politician_email3 %}{{ politician.politician_email3 }}&nbsp;{% endif %}
+                {% if politician.politician_phone_number %}{{ politician.politician_phone_number }}&nbsp;{% endif %}
+                {% if politician.politician_phone_number2 %}{{ politician.politician_phone_number2 }}&nbsp;{% endif %}
+                {% if politician.politician_phone_number3 %}{{ politician.politician_phone_number3 }}&nbsp;{% endif %}
             </td>
             <td>
                 {% if politician.politician_url %}<a href="{{ politician.politician_url }}" target="_blank">{{ politician.politician_url }}</a>{% endif %}
@@ -129,9 +139,14 @@
                 {% if politician.politician_url3 %}<br /><a href="{{ politician.politician_url3 }}" target="_blank">{{ politician.politician_url3 }}</a>{% endif %}
                 {% if politician.politician_url4 %}<br /><a href="{{ politician.politician_url4 }}" target="_blank">{{ politician.politician_url4 }}</a>{% endif %}
                 {% if politician.politician_url5 %}<br /><a href="{{ politician.politician_url5 }}" target="_blank">{{ politician.politician_url5 }}</a>{% endif %}
+                {% if politician.facebook_url %}<a href="{{ politician.facebook_url }}" target="_blank">{{ politician.facebook_url }}</a>{% endif %}
+                {% if politician.facebook_url2 %}<br /><a href="{{ politician.facebook_url2 }}" target="_blank">{{ politician.facebook_url2 }}</a>{% endif %}
+                {% if politician.facebook_url3 %}<br /><a href="{{ politician.facebook_url3 }}" target="_blank">{{ politician.facebook_url3 }}</a>{% endif %}
             </td>
             <td>{% if politician.linked_candidate_list_count > 0 %}{{ politician.linked_candidate_list_count }}{% endif %}</td>
+        {% if show_related_candidates %}
             <td>{% if politician.related_candidate_list_count > 0 %}{{ politician.related_candidate_list_count }}{% endif %}</td>
+        {% endif %}
         </tr>
     {% endfor %}
     </table>
@@ -152,6 +167,11 @@
         });
         $(function() {
             $('#show_politicians_with_email_id').change(function() {
+                this.form.submit();
+            });
+        });
+        $(function() {
+            $('#show_related_candidates_id').change(function() {
                 this.form.submit();
             });
         });

--- a/templates/politician/politician_merge.html
+++ b/templates/politician/politician_merge.html
@@ -154,7 +154,27 @@
         </td>
     </tr>
 
-{% include "politician/politician_merge_one_field_decision.html" with field_name="politician_phone_number" field_label="Phone Number" conflict_status=conflict_values.politician_phone_number politician1_field_value=politician_option1.politician_phone_number politician2_field_value=politician_option2.politician_phone_number politician1=politician_option1 politician2=politician_option2 %}
+    <tr>
+        <td>Politician Phones</td>
+        <td>
+            {{ politician_option1.politician_phone_number|default_if_none:"" }}
+            {% if politician_option1.politician_phone_number2 %}
+                <br />{{ politician_option1.politician_phone_number2|default_if_none:"" }}
+            {% endif %}
+            {% if politician_option1.politician_phone_number3 %}
+                <br />{{ politician_option1.politician_phone_number3|default_if_none:"" }}
+            {% endif %}
+        </td>
+        <td>
+            {{ politician_option2.politician_phone_number|default_if_none:"" }}
+            {% if politician_option2.politician_phone_number2 %}
+                <br />{{ politician_option2.politician_phone_number2|default_if_none:"" }}
+            {% endif %}
+            {% if politician_option2.politician_phone_number3 %}
+                <br />{{ politician_option2.politician_phone_number3|default_if_none:"" }}
+            {% endif %}
+        </td>
+    </tr>
 
     <tr>
         <td>Politician Websites</td>
@@ -192,7 +212,28 @@
 
 {% include "politician/politician_merge_one_field_decision.html" with field_name="politician_contact_form_url" field_label="Politician Contact Form" conflict_status=conflict_values.politician_contact_form_url politician1_field_value=politician_option1.politician_contact_form_url politician2_field_value=politician_option2.politician_contact_form_url politician1=politician_option1 politician2=politician_option2 %}
 
-{% include "politician/politician_merge_one_field_decision.html" with field_name="facebook_url" field_label="Facebook" conflict_status=conflict_values.facebook_url politician1_field_value=politician_option1.facebook_url politician2_field_value=politician_option2.facebook_url politician1=politician_option1 politician2=politician_option2 %}
+
+    <tr>
+        <td>Facebook URLs</td>
+        <td>
+            {{ politician_option1.facebook_url|default_if_none:"" }}
+            {% if politician_option1.facebook_url2 %}
+                <br />{{ politician_option1.facebook_url2|default_if_none:"" }}
+            {% endif %}
+            {% if politician_option1.facebook_url3 %}
+                <br />{{ politician_option1.facebook_url3|default_if_none:"" }}
+            {% endif %}
+        </td>
+        <td>
+            {{ politician_option2.facebook_url|default_if_none:"" }}
+            {% if politician_option2.facebook_url2 %}
+                <br />{{ politician_option2.facebook_url2|default_if_none:"" }}
+            {% endif %}
+            {% if politician_option2.facebook_url3 %}
+                <br />{{ politician_option2.facebook_url3|default_if_none:"" }}
+            {% endif %}
+        </td>
+    </tr>
 
 {% include "politician/politician_merge_one_field_decision.html" with field_name="facebook_url_is_broken" field_label="Facebook URL Broken" conflict_status=conflict_values.facebook_url_is_broken politician1_field_value=politician_option1.facebook_url_is_broken politician2_field_value=politician_option2.facebook_url_is_broken politician1=politician_option1 politician2=politician_option2 %}
 


### PR DESCRIPTION
Added multiple facebook_urls and politician_phone_numbers to minimize manual merge intervention. Made "show_related_candidates" on the politician page an optional setting so speed up loading of Politician listing admin page.