### PR TITLE
Added representativesQuery, so we can see all the cool data we've added. Created 'update_parallel_fields_with_years_in_related_objects' function to update all related fields when ContestOffice, OfficeHeld, Representative, Candidate or Politician are updated. Added filter checkbox on Politician, Representative and OfficeHeld pages to show Battleground races. Added OfficeHeld field for Twitter accounts for offices (as opposed to individual representatives.) Assorted refactoring during bug fixes. Fixed retrieve_twitter_user_info to return 'success' (and another 'not found' variable) when handle doesn't exist on Twitter.

### DIFF
--- a/apis_v1/documentation_source/representatives_query_doc.py
+++ b/apis_v1/documentation_source/representatives_query_doc.py
@@ -1,0 +1,97 @@
+# apis_v1/documentation_source/representatives_query.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+
+
+def representatives_query_doc_template_values(url_root):
+    """
+    Show documentation about representativesQuery
+    """
+    required_query_parameter_list = [
+        {
+            'name':         'year',
+            'value':        'string',  # boolean, integer, long, string
+            'description':  'Year in this format: YYYY',
+        },
+    ]
+    optional_query_parameter_list = [
+        {
+            'name': 'race_office_level',
+            'value': 'list of strings',  # boolean, integer, long, string
+            'description': 'Limit the representatives returned to: Federal, State, Local',
+        },
+        {
+            'name': 'search_text',
+            'value': 'string',  # boolean, integer, long, string
+            'description': 'The word or words we want to search for in all representatives.',
+        },
+        {
+            'name': 'state',
+            'value': 'string',  # boolean, integer, long, string
+            'description': 'Limit the representatives returned to this state.',
+        },
+    ]
+
+    potential_status_codes_list = [
+        {
+            'code':         'CANDIDATES_RETRIEVED',
+            'description':  'Candidates were returned.',
+        },
+        {
+            'code':         'NO_CANDIDATES_RETRIEVED',
+            'description':  'There are no representatives stored for this Office.',
+        },
+    ]
+
+    try_now_link_variables_dict = {
+        'year': '2023',
+    }
+
+    api_response = '{\n' \
+                   '  "status": string,\n' \
+                   '  "success": boolean,\n' \
+                   '  "index_start": integer,\n' \
+                   '  "returned_count": integer,\n' \
+                   '  "total_count": integer,\n' \
+                   '  "kind": string,\n' \
+                   '  "state": string,\n' \
+                   '  "office_held_list": {\n' \
+                   '     "id": integer,\n' \
+                   '     "name": string,\n' \
+                   '     "we_vote_id": string,\n' \
+                   '   },\n' \
+                   '  "representatives": list\n' \
+                   '   [\n' \
+                   '     "id": integer,\n' \
+                   '     "status": string,\n' \
+                   '     "success": boolean,\n' \
+                   '     "ballot_item_display_name": string,\n' \
+                   '     "kind_of_ballot_item": string,\n' \
+                   '     "last_updated": string (time in this format %Y-%m-%d %H:%M:%S),\n' \
+                   '     "office_held_we_vote_id": string,\n' \
+                   '     "party": string,\n' \
+                   '     "politician_we_vote_id": string,\n' \
+                   '     "representative_photo_url_large": string,\n' \
+                   '     "representative_photo_url_medium": string,\n'\
+                   '     "representative_photo_url_tiny": string,\n' \
+                   '     "we_vote_id": string,\n' \
+                   '   ],\n' \
+                   '}'
+
+    template_values = {
+        'api_name': 'representativesQuery',
+        'api_slug': 'representativesQuery',
+        'api_introduction':
+            "Retrieve all the representatives in a particular election or state.",
+        'try_now_link': 'apis_v1:representativesQueryView',
+        'try_now_link_variables_dict': try_now_link_variables_dict,
+        'url_root': url_root,
+        'get_or_post': 'GET',
+        'required_query_parameter_list': required_query_parameter_list,
+        'optional_query_parameter_list': optional_query_parameter_list,
+        'api_response': api_response,
+        'api_response_notes':
+            "",
+        'potential_status_codes_list': potential_status_codes_list,
+    }
+    return template_values

--- a/apis_v1/urls.py
+++ b/apis_v1/urls.py
@@ -14,7 +14,7 @@ from apis_v1.views import views_activity, views_apple, views_docs, views_analyti
     views_campaign, views_candidate, views_donation, \
     views_election, views_extension, views_facebook, views_friend, \
     views_issues, views_measure, views_misc, views_organization, \
-    views_pledge_to_vote, views_position, views_reaction, views_retrieve_tables, \
+    views_pledge_to_vote, views_position, views_reaction, views_representative, views_retrieve_tables, \
     views_task, views_share, views_twitter, views_voter, views_voter_guide
 from analytics.views_admin import analytics_action_sync_out_view, organization_daily_metrics_sync_out_view, \
     organization_election_metrics_sync_out_view, sitewide_daily_metrics_sync_out_view, \
@@ -247,8 +247,9 @@ urlpatterns = [
               views_position.position_support_count_for_ballot_item_view,
               name='positionSupportCountForBallotItemView'),
       re_path(r'^quickInfoRetrieve/', views_misc.quick_info_retrieve_view, name='quickInfoRetrieveView'),
-      re_path(r'^reactionLikeCount/', views_reaction.reaction_like_count_view,
-              name='reactionLikeCountView'),
+      re_path(r'^reactionLikeCount/', views_reaction.reaction_like_count_view, name='reactionLikeCountView'),
+      re_path(r'^representativesQuery/', views_representative.representatives_query_view,
+              name='representativesQueryView'),
       re_path(r'^retrieveIssuesToFollow/', retrieve_issues_to_follow_view,
               name='retrieveIssuesToFollowView'),
       re_path(r'^saveAnalyticsAction/', views_analytics.save_analytics_action_view,
@@ -627,6 +628,8 @@ urlpatterns = [
               name='quickInfoRetrieveDocs'),
       re_path(r'^docs/reactionLikeCount/$', views_docs.reaction_like_count_doc_view,
               name='reactionLikeCountDocs'),
+      re_path(r'^docs/representativesQuery/$', views_docs.representatives_query_doc_view,
+              name='representativesQueryDocs'),
       re_path(r'^docs/retrieveIssuesToFollow/', views_docs.retrieve_issues_to_follow_doc_view,
               name='retrieveIssuesToFollowDocs'),
       re_path(r'^docs/saveAnalyticsAction/$',

--- a/apis_v1/views/views_apple.py
+++ b/apis_v1/views/views_apple.py
@@ -407,6 +407,8 @@ def sign_in_with_apple_oauth_redirect_view(request):  # appleSignInOauthRedirect
     if DEBUG_LOGGING:
         logger.error('awsApple ' + status)
 
+    # TODO: We need to add a URL variable here that asks WebApp to fire off a VoterRetrieve
+    #  with the merge_from... and merge_to... variables
     return HttpResponseRedirect(return_url)
 
 

--- a/apis_v1/views/views_docs.py
+++ b/apis_v1/views/views_docs.py
@@ -41,7 +41,7 @@ from apis_v1.documentation_source import \
     position_public_oppose_count_for_ballot_item_doc, position_retrieve_doc, position_save_doc, \
     positions_sync_out_doc, \
     position_public_support_count_for_ballot_item_doc, position_support_count_for_ballot_item_doc, \
-    quick_info_retrieve_doc, retrieve_issues_to_follow_doc, \
+    quick_info_retrieve_doc, representatives_query_doc, retrieve_issues_to_follow_doc, \
     save_analytics_action_doc, search_all_doc, shared_item_list_save_doc, shared_item_retrieve_doc, \
     shared_item_save_doc, super_share_item_save_doc, site_configuration_retrieve_doc, \
     sitewide_daily_metrics_sync_out_doc, sitewide_election_metrics_sync_out_doc, sitewide_voter_metrics_sync_out_doc, \
@@ -1025,6 +1025,15 @@ def quick_info_retrieve_doc_view(request):
     url_root = WE_VOTE_SERVER_ROOT_URL
     template_values = quick_info_retrieve_doc.\
         quick_info_retrieve_doc_template_values(url_root)
+    return render(request, 'apis_v1/api_doc_page.html', template_values)
+
+
+def representatives_query_doc_view(request):
+    """
+    Show documentation about representativesQuery
+    """
+    url_root = WE_VOTE_SERVER_ROOT_URL
+    template_values = representatives_query_doc.representatives_query_doc_template_values(url_root)
     return render(request, 'apis_v1/api_doc_page.html', template_values)
 
 

--- a/apis_v1/views/views_representative.py
+++ b/apis_v1/views/views_representative.py
@@ -1,0 +1,25 @@
+# apis_v1/views/views_representative.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+from representative.controllers import representatives_query_for_api
+from config.base import get_environment_variable
+import wevote_functions.admin
+from wevote_functions.functions import positive_value_exists
+
+logger = wevote_functions.admin.get_logger(__name__)
+
+WE_VOTE_SERVER_ROOT_URL = get_environment_variable("WE_VOTE_SERVER_ROOT_URL")
+
+
+def representatives_query_view(request):  # representativesQuery
+    index_start = request.GET.get('index_start', 0)
+    limit_to_this_state_code = request.GET.get('state', '')
+    race_office_level_list = request.GET.getlist('race_office_level[]', False)
+    search_text = request.GET.get('search_text', '')
+    year = request.GET.get('year', '')
+    return representatives_query_for_api(
+        index_start=index_start,
+        limit_to_this_state_code=limit_to_this_state_code,
+        race_office_level_list=race_office_level_list,
+        search_text=search_text,
+        year=year)

--- a/candidate/controllers.py
+++ b/candidate/controllers.py
@@ -1957,6 +1957,14 @@ def candidate_politician_match(candidate):
             candidate.politician_id = politician.id
             candidate.save()
 
+            if positive_value_exists(candidate.we_vote_id):
+                from politician.controllers import update_parallel_fields_with_years_in_related_objects
+                results = update_parallel_fields_with_years_in_related_objects(
+                    field_key_root='is_battleground_race_',
+                    master_we_vote_id_updated=candidate.we_vote_id,
+                )
+                status += results['status']
+
             results = {
                 'success':                  results['success'],
                 'status':                   status,
@@ -2031,6 +2039,14 @@ def candidate_politician_match(candidate):
         candidate.politician_id = politician.id
         candidate.save()
 
+        if positive_value_exists(candidate.we_vote_id):
+            from politician.controllers import update_parallel_fields_with_years_in_related_objects
+            results = update_parallel_fields_with_years_in_related_objects(
+                field_key_root='is_battleground_race_',
+                master_we_vote_id_updated=candidate.we_vote_id,
+            )
+            status += results['status']
+
         results = {
             'success':                  True,
             'status':                   status,
@@ -2051,6 +2067,14 @@ def candidate_politician_match(candidate):
             candidate.politician_we_vote_id = politician.we_vote_id
             candidate.politician_id = politician.id
             candidate.save()
+
+            if positive_value_exists(candidate.we_vote_id):
+                from politician.controllers import update_parallel_fields_with_years_in_related_objects
+                results = update_parallel_fields_with_years_in_related_objects(
+                    field_key_root='is_battleground_race_',
+                    master_we_vote_id_updated=candidate.we_vote_id,
+                )
+                status += results['status']
 
         results = {
             'success':                      create_results['success'],

--- a/candidate/models.py
+++ b/candidate/models.py
@@ -252,6 +252,7 @@ class CandidateListManager(models.Manager):
             candidate_vote_smart_id_list=None,
             candidate_ctcl_uuid_list=None,
             ballotpedia_candidate_id_list=None,
+            politician_we_vote_id_list=None,
             read_only=False):
         status = ""
         success = True
@@ -316,6 +317,16 @@ class CandidateListManager(models.Manager):
                 candidate_list = list(candidate_query)
                 candidate_list_found = True
                 status += "RETRIEVE_CANDIDATE_LIST_FOUND_BY_BALLOTPEDIA_CANDIDATE_ID_LIST "
+            elif positive_value_exists(politician_we_vote_id_list):
+                if positive_value_exists(read_only):
+                    candidate_query = CandidateCampaign.objects.using('readonly').filter(
+                        politician_we_vote_id__in=politician_we_vote_id_list)
+                else:
+                    candidate_query = CandidateCampaign.objects.filter(
+                        politician_we_vote_id__in=politician_we_vote_id_list)
+                candidate_list = list(candidate_query)
+                candidate_list_found = True
+                status += "RETRIEVE_CANDIDATE_LIST_FOUND_BY_WE_VOTE_ID_LIST "
             else:
                 candidate_list_found = False
                 status += "RETRIEVE_CANDIDATE_SEARCH_LIST_MISSING "
@@ -456,6 +467,7 @@ class CandidateListManager(models.Manager):
             candidates_limit=300,
             is_missing_politician_we_vote_id=False,
             limit_to_this_state_code='',
+            politician_we_vote_id_list=[],
             return_list_of_objects=False,
             read_only=False,
             search_string=False,
@@ -467,6 +479,7 @@ class CandidateListManager(models.Manager):
         :param candidates_limit:
         :param is_missing_politician_we_vote_id:
         :param limit_to_this_state_code:
+        :param politician_we_vote_id_list:
         :param search_string:
         :param return_list_of_objects:
         :param read_only:
@@ -526,6 +539,8 @@ class CandidateListManager(models.Manager):
                     Q(politician_we_vote_id__isnull=True) |
                     Q(politician_we_vote_id='')
                 )
+            if politician_we_vote_id_list and len(politician_we_vote_id_list) > 0:
+                candidate_query = candidate_query.filter(politician_we_vote_id__in=politician_we_vote_id_list)
             if positive_value_exists(limit_to_this_state_code):
                 candidate_query = candidate_query.filter(state_code__iexact=limit_to_this_state_code)
             if positive_value_exists(search_string):

--- a/office/controllers.py
+++ b/office/controllers.py
@@ -217,11 +217,16 @@ def figure_out_office_conflict_values(contest_office1, contest_office2):
             elif contest_office2_attribute is None or contest_office2_attribute == "":
                 contest_office_merge_conflict_values[attribute] = 'CONTEST_OFFICE1'
             else:
-                if attribute == "office_name" or attribute == "state_code":
-                    if contest_office1_attribute.lower() == contest_office2_attribute.lower():
+                if attribute == "is_battleground_race":
+                    # We always want to default to preserving a true value
+                    if contest_office1_attribute == contest_office2_attribute:
                         contest_office_merge_conflict_values[attribute] = 'MATCHING'
+                    elif positive_value_exists(contest_office1_attribute):
+                        contest_office_merge_conflict_values[attribute] = 'CONTEST_OFFICE1'
+                    elif positive_value_exists(contest_office2_attribute):
+                        contest_office_merge_conflict_values[attribute] = 'CONTEST_OFFICE2'
                     else:
-                        contest_office_merge_conflict_values[attribute] = 'CONFLICT'
+                        contest_office_merge_conflict_values[attribute] = 'CONTEST_OFFICE1'
                 elif attribute == "maplight_id":
                     contest_office1_attribute_empty = False
                     contest_office2_attribute_empty = False
@@ -234,6 +239,11 @@ def figure_out_office_conflict_values(contest_office1, contest_office2):
                     if contest_office1_attribute == contest_office2_attribute:
                         contest_office_merge_conflict_values[attribute] = 'MATCHING'
                     elif contest_office1_attribute_empty and contest_office2_attribute_empty:
+                        contest_office_merge_conflict_values[attribute] = 'MATCHING'
+                    else:
+                        contest_office_merge_conflict_values[attribute] = 'CONFLICT'
+                elif attribute == "office_name" or attribute == "state_code":
+                    if contest_office1_attribute.lower() == contest_office2_attribute.lower():
                         contest_office_merge_conflict_values[attribute] = 'MATCHING'
                     else:
                         contest_office_merge_conflict_values[attribute] = 'CONFLICT'

--- a/office/models.py
+++ b/office/models.py
@@ -167,7 +167,7 @@ class ContestOffice(models.Model):
     ballotpedia_election_id = models.PositiveIntegerField(verbose_name="ballotpedia election id", null=True, blank=True)
     ballotpedia_is_marquee = models.BooleanField(default=None, null=True)
     is_battleground_race = models.BooleanField(default=None, null=True)
-    is_battleground_race_cached_in_candidates = models.BooleanField(default=None, null=True)
+    # is_battleground_race_spread_to_all_objects = models.BooleanField(default=None, null=True)
 
     # Which kind of ballotpedia election "state" is this office in. Ex/ You can have an office in a primary be labeled
     #  general election if it is to decide on the final outcome, like for a mayor

--- a/office_held/views_admin.py
+++ b/office_held/views_admin.py
@@ -16,10 +16,12 @@ from election.models import Election, ElectionManager
 import exception.models
 import json
 from office_held.models import OfficeHeld, OfficeHeldManager
+from politician.controllers import update_parallel_fields_with_years_in_related_objects
 from representative.models import Representative, RepresentativeManager
 from voter.models import voter_has_authority
 import wevote_functions.admin
 from wevote_functions.functions import convert_to_int, positive_value_exists, STATE_CODE_MAP
+from wevote_settings.constants import IS_BATTLEGROUND_YEARS_AVAILABLE
 
 OFFICES_SYNC_URL = get_environment_variable("OFFICES_SYNC_URL")  # officesSyncOut
 WE_VOTE_SERVER_ROOT_URL = get_environment_variable("WE_VOTE_SERVER_ROOT_URL")
@@ -38,6 +40,7 @@ def office_held_list_view(request):
     google_civic_election_id = convert_to_int(request.GET.get('google_civic_election_id', 0))
     state_code = request.GET.get('state_code', '')
     show_all = request.GET.get('show_all', False)
+    show_battleground = positive_value_exists(request.GET.get('show_battleground', False))
     show_all_elections = positive_value_exists(request.GET.get('show_all_elections', False))
     office_held_search = request.GET.get('office_held_search', '')
 
@@ -52,6 +55,20 @@ def office_held_list_view(request):
         else:
             # TODO Limit this search to upcoming_elections only
             pass
+        if positive_value_exists(show_battleground):
+            year_filters = []
+            for year_integer in IS_BATTLEGROUND_YEARS_AVAILABLE:
+                if positive_value_exists(year_integer):
+                    is_battleground_race_key = 'is_battleground_race_' + str(year_integer)
+                    one_year_filter = Q(**{is_battleground_race_key: True})
+                    year_filters.append(one_year_filter)
+            if len(year_filters) > 0:
+                # Add the first query
+                final_filters = year_filters.pop()
+                # ...and "OR" the remaining items in the list
+                for item in year_filters:
+                    final_filters |= item
+                office_held_queryset = office_held_queryset.filter(final_filters)
         if positive_value_exists(state_code):
             office_held_queryset = office_held_queryset.filter(state_code__iexact=state_code)
         office_held_queryset = office_held_queryset.order_by("office_held_name")
@@ -143,15 +160,16 @@ def office_held_list_view(request):
 
     template_values = {
         'messages_on_stage':        messages_on_stage,
-        'office_held_list':      updated_office_held_list,
-        'office_held_search':    office_held_search,
+        'office_held_list':         updated_office_held_list,
+        'office_held_search':       office_held_search,
         'election_list':            election_list,
         'state_code':               state_code,
         'show_all_elections':       show_all_elections,
+        'show_battleground':        show_battleground,
         'state_list':               sorted_state_list,
         'google_civic_election_id': google_civic_election_id,
         'status':                   status,
-        success:                    success
+        'success':                  success
     }
     return render(request, 'office_held/office_held_list.html', template_values)
 
@@ -193,34 +211,35 @@ def office_held_edit_view(request, office_held_id=0, office_held_we_vote_id=""):
 
     messages_on_stage = get_messages(request)
     office_held_id = convert_to_int(office_held_id)
-    google_civic_election_id = request.GET.get('google_civic_election_id', 0)
+    state_code = request.GET.get('state_code', 0)
+    twitter_handle = request.GET.get('twitter_handle', '')
 
-    office_held_on_stage = OfficeHeld()
-    office_held_on_stage_found = False
+    office_held = None
+    office_held_found = False
     try:
         if positive_value_exists(office_held_id):
-            office_held_on_stage = OfficeHeld.objects.get(id=office_held_id)
+            office_held = OfficeHeld.objects.get(id=office_held_id)
         else:
-            office_held_on_stage = OfficeHeld.objects.get(we_vote_id=office_held_we_vote_id)
-        office_held_on_stage_found = True
+            office_held = OfficeHeld.objects.get(we_vote_id=office_held_we_vote_id)
+        office_held_found = True
     except OfficeHeld.MultipleObjectsReturned as e:
         exception.models.handle_record_found_more_than_one_exception(e, logger=logger)
     except OfficeHeld.DoesNotExist:
         # This is fine, create new
         pass
 
-    if office_held_on_stage_found:
-        # Was a office_held_merge_possibility_found?
-        office_held_on_stage.contest_office_merge_possibility_found = True  # TODO DALE Make dynamic
+    if office_held_found:
+        # Was office_held_merge_possibility_found?
+        office_held.contest_office_merge_possibility_found = True  # TODO DALE Make dynamic
         template_values = {
-            'messages_on_stage':        messages_on_stage,
-            'office_held':           office_held_on_stage,
-            'google_civic_election_id': google_civic_election_id,
+            'messages_on_stage':    messages_on_stage,
+            'office_held':          office_held,
         }
     else:
         template_values = {
-            'messages_on_stage':        messages_on_stage,
-            'google_civic_election_id': google_civic_election_id,
+            'messages_on_stage':    messages_on_stage,
+            'state_code':           state_code,
+            'twitter_handle':       twitter_handle,
         }
     return render(request, 'office_held/office_held_edit.html', template_values)
 
@@ -233,13 +252,11 @@ def office_held_summary_view(request, office_held_we_vote_id):
         return redirect_to_sign_in_page(request, authority_required)
 
     messages_on_stage = get_messages(request)
-    office_held_on_stage = None
-    office_held_on_stage_found = False
+    office_held = None
     representative_list = []
     state_code = request.GET.get('state_code', "")
     try:
-        office_held_on_stage = OfficeHeld.objects.get(we_vote_id=office_held_we_vote_id)
-        office_held_on_stage_found = True
+        office_held = OfficeHeld.objects.get(we_vote_id=office_held_we_vote_id)
     except OfficeHeld.MultipleObjectsReturned as e:
         exception.models.handle_record_found_more_than_one_exception(e, logger=logger)
     except OfficeHeld.DoesNotExist:
@@ -251,16 +268,13 @@ def office_held_summary_view(request, office_held_we_vote_id):
         query = query.order_by('id')
         representative_list = list(query)
     except Exception as e:
-        pass
-
-    candidate_list_modified = []
-    # position_list_manager = PositionListManager()
+        messages.add_message(request, messages.ERROR, 'Could not retrieve representatives:' + str(e))
 
     election_list = Election.objects.order_by('-election_day_text')
 
     template_values = {
         'messages_on_stage':        messages_on_stage,
-        'office_held':              office_held_on_stage,
+        'office_held':              office_held,
         'representative_list':      representative_list,
         'state_code':               state_code,
         'election_list':            election_list,
@@ -283,92 +297,102 @@ def office_held_edit_process_view(request):
     office_held_id = convert_to_int(request.POST.get('office_held_id', 0))
     office_held_name = request.POST.get('office_held_name', False)
     google_civic_office_held_name = request.POST.get('google_civic_office_held_name', False)
+    google_civic_office_held_name2 = request.POST.get('google_civic_office_held_name2', False)
+    google_civic_office_held_name3 = request.POST.get('google_civic_office_held_name3', False)
     google_civic_election_id = request.POST.get('google_civic_election_id', 0)
     ocd_division_id = request.POST.get('ocd_division_id', False)
     primary_party = request.POST.get('primary_party', False)
-    state_code = request.POST.get('state_code', False)
-    # ballotpedia_office_id = request.POST.get('ballotpedia_office_id', False)
-    # ballotpedia_office_name = request.POST.get('ballotpedia_office_name', False)
     remove_duplicate_process = request.POST.get('remove_duplicate_process', False)
     redirect_to_office_held_list = convert_to_int(request.POST['redirect_to_office_held_list'])
+    state_code = request.POST.get('state_code', False)
+    office_held_twitter_handle = request.POST.get('office_held_twitter_handle', False)
+    # is_battleground_race_ values taken in below
 
-    election_state = ''
-    if state_code is not False:
-        election_state = state_code
-    elif google_civic_election_id:
-        election_manager = ElectionManager()
-        results = election_manager.retrieve_election(google_civic_election_id)
-        if results['election_found']:
-            election = results['election']
-            election_state = election.get_election_state()
+    office_held_found = False
+    office_held = None
+    office_held_we_vote_id = ''
+    success = True
+    years_false_list = []
+    years_true_list = []
 
     # Check to see if this office is already in the database
-    office_held_on_stage_found = False
-    office_held_on_stage = None
-    office_held_we_vote_id = ''
     try:
         office_held_query = OfficeHeld.objects.filter(id=office_held_id)
         if len(office_held_query):
-            office_held_on_stage = office_held_query[0]
-            office_held_we_vote_id = office_held_on_stage.we_vote_id
-            office_held_on_stage_found = True
+            office_held = office_held_query[0]
+            office_held_we_vote_id = office_held.we_vote_id
+            office_held_found = True
     except Exception as e:
         exception.models.handle_record_not_found_exception(e, logger=logger)
+        success = False
 
-    try:
-        if office_held_on_stage_found:
+    if success:
+        try:
+            if office_held_found:
+                office_held_id = office_held.id
+            else:
+                # Create new
+                office_held = OfficeHeld(
+                    office_held_name=office_held_name,
+                    state_code=state_code,
+                )
+                office_held_id = office_held.id
+                office_held_we_vote_id = office_held.we_vote_id
             # Update
-            # Removed for now: convert_to_int(office_on_stage.google_civic_election_id) >= 1000000 and
             if office_held_name is not False:
-                office_held_on_stage.office_held_name = office_held_name
+                office_held.office_held_name = office_held_name
             if google_civic_office_held_name is not False:
-                office_held_on_stage.google_civic_office_held_name = google_civic_office_held_name
+                office_held.google_civic_office_held_name = google_civic_office_held_name
+            if google_civic_office_held_name2 is not False:
+                office_held.google_civic_office_held_name2 = google_civic_office_held_name2
+            if google_civic_office_held_name is not False:
+                office_held.google_civic_office_held_name3 = google_civic_office_held_name3
             if ocd_division_id is not False:
-                office_held_on_stage.ocd_division_id = ocd_division_id
+                office_held.ocd_division_id = ocd_division_id
             if primary_party is not False:
-                office_held_on_stage.primary_party = primary_party
-            if election_state is not False:
-                office_held_on_stage.state_code = election_state
-            # if ballotpedia_office_id is not False:
-            #     office_on_stage.ballotpedia_office_id = ballotpedia_office_id
-            # if ballotpedia_office_name is not False:
-            #     office_on_stage.ballotpedia_office_name = ballotpedia_office_name
-            office_held_on_stage.save()
-            office_held_on_stage_id = office_held_on_stage.id
+                office_held.primary_party = primary_party
+            if state_code is not False:
+                office_held.state_code = state_code
+            if office_held_twitter_handle is not False:
+                office_held.office_held_twitter_handle = office_held_twitter_handle
+            is_battleground_years_list = IS_BATTLEGROUND_YEARS_AVAILABLE
+            for year in is_battleground_years_list:
+                is_battleground_race_key = 'is_battleground_race_' + str(year)
+                incoming_is_battleground_race = positive_value_exists(request.POST.get(is_battleground_race_key, False))
+                if hasattr(office_held, is_battleground_race_key):
+                    if incoming_is_battleground_race:
+                        years_true_list.append(year)
+                    else:
+                        years_false_list.append(year)
+                    setattr(office_held, is_battleground_race_key, incoming_is_battleground_race)
+            office_held.save()
+        except Exception as e:
+            exception.models.handle_record_not_saved_exception(e, logger=logger)
+            messages.add_message(request, messages.ERROR, 'Could not save office held:' + str(e))
+            success = False
+
+    if success and positive_value_exists(office_held_we_vote_id):
+        update_parallel_fields_with_years_in_related_objects(
+            field_key_root='is_battleground_race_',
+            master_we_vote_id_updated=office_held_we_vote_id,
+            years_false_list=years_false_list,
+            years_true_list=years_true_list,
+        )
+
+    if success:
+        if office_held_found:
             messages.add_message(request, messages.INFO, 'Office updated.')
-            google_civic_election_id = office_held_on_stage.google_civic_election_id
 
             return HttpResponseRedirect(reverse('office_held:office_held_summary', args=(office_held_we_vote_id,)) +
                                         "?google_civic_election_id=" + str(google_civic_election_id) +
                                         "&state_code=" + str(state_code))
         else:
-            # Create new
-            office_held_on_stage = OfficeHeld(
-                office_held_name=office_held_name,
-                google_civic_election_id=google_civic_election_id,
-                state_code=election_state,
-            )
-            # Removing this limitation: convert_to_int(office_on_stage.google_civic_election_id) >= 1000000 and
-            if google_civic_office_held_name is not False:
-                office_held_on_stage.google_civic_office_name = google_civic_office_held_name
-            if ocd_division_id is not False:
-                office_held_on_stage.ocd_division_id = ocd_division_id
-            if primary_party is not False:
-                office_held_on_stage.primary_party = primary_party
-            # if ballotpedia_office_id is not False:
-            #     office_on_stage.ballotpedia_office_id = ballotpedia_office_id
-            # if ballotpedia_office_name is not False:
-            #     office_on_stage.ballotpedia_office_name = ballotpedia_office_name
-            office_held_on_stage.save()
             messages.add_message(request, messages.INFO, 'New office held saved.')
 
             # Come back to the "Create New Office" page
             return HttpResponseRedirect(reverse('office_held:office_held_new', args=()) +
                                         "?google_civic_election_id=" + str(google_civic_election_id) +
                                         "&state_code=" + str(state_code))
-    except Exception as e:
-        exception.models.handle_record_not_saved_exception(e, logger=logger)
-        messages.add_message(request, messages.ERROR, 'Could not save office held:' + str(e))
 
     if redirect_to_office_held_list:
         return HttpResponseRedirect(reverse('office_held:office_held_list', args=()) +
@@ -393,14 +417,14 @@ def office_held_delete_process_view(request):
     office_held_id = convert_to_int(request.GET.get('office_held_id', 0))
     google_civic_election_id = convert_to_int(request.GET.get('google_civic_election_id', 0))
 
-    # office_held_on_stage_found = False
-    office_held_on_stage = OfficeHeld()
+    # office_held_found = False
+    office_held = OfficeHeld()
     office_held_we_vote_id = ''
     try:
-        office_held_on_stage = OfficeHeld.objects.get(id=office_held_id)
-        office_held_we_vote_id = office_held_on_stage.we_vote_id
-        # office_held_on_stage_found = True
-        google_civic_election_id = office_held_on_stage.google_civic_election_id
+        office_held = OfficeHeld.objects.get(id=office_held_id)
+        office_held_we_vote_id = office_held.we_vote_id
+        # office_held_found = True
+        google_civic_election_id = office_held.google_civic_election_id
     except OfficeHeld.MultipleObjectsReturned:
         pass
     except OfficeHeld.DoesNotExist:
@@ -408,7 +432,7 @@ def office_held_delete_process_view(request):
 
     # TODO fetch representatives instead candidate
     candidates_found_for_this_office = False
-    # if office_held_on_stage_found:
+    # if office_held_found:
     #     try:
     #         candidate_list = CandidateCampaign.objects.filter(contest_office_id=office_held_id)
     #         # if positive_value_exists(google_civic_election_id):
@@ -422,7 +446,7 @@ def office_held_delete_process_view(request):
     try:
         if not candidates_found_for_this_office:
             # Delete the office
-            office_held_on_stage.delete()
+            office_held.delete()
             messages.add_message(request, messages.INFO, 'Office Held deleted.')
         else:
             messages.add_message(request, messages.ERROR, 'Could not delete -- '

--- a/organization/models.py
+++ b/organization/models.py
@@ -1268,23 +1268,12 @@ class OrganizationManager(models.Manager):
     # Pass in the value if we want it saved. Pass in "False" if we want to leave it the same.
     def update_or_create_organization(
             self,
-            organization_id, we_vote_id,
-            organization_website_search,
-            organization_twitter_search,
-            organization_name=False,
-            organization_description=False,
-            organization_website=False,
-            organization_twitter_handle=False,
-            organization_email=False,
-            organization_facebook=False,
-            organization_instagram_handle=False,
-            organization_image=False,
-            organization_type=False,
-            refresh_from_twitter=False,
-            facebook_id=False,
-            facebook_email=False,
-            facebook_profile_image_url_https=False,
-            facebook_background_image_url_https=False,
+            # Values for search
+            organization_id=0,
+            we_vote_id='',
+            organization_website_search='',
+            organization_twitter_search='',
+            # Values to save
             chosen_domain_string=False,
             chosen_domain_string2=False,
             chosen_domain_string3=False,
@@ -1297,6 +1286,21 @@ class OrganizationManager(models.Manager):
             chosen_social_share_description=False,
             chosen_subdomain_string=False,
             chosen_subscription_plan=False,
+            facebook_background_image_url_https=False,
+            facebook_email=False,
+            facebook_id=False,
+            facebook_profile_image_url_https=False,
+            organization_description=False,
+            organization_email=False,
+            organization_facebook=False,
+            organization_image=False,
+            organization_instagram_handle=False,
+            organization_name=False,
+            organization_twitter_handle=False,
+            organization_type=False,
+            organization_website=False,
+            profile_image_type_currently_active=False,
+            refresh_from_twitter=False,
     ):
         """
         Either update or create an organization entry.
@@ -1304,20 +1308,6 @@ class OrganizationManager(models.Manager):
         :param we_vote_id:
         :param organization_website_search:
         :param organization_twitter_search:
-        :param organization_name:
-        :param organization_description:
-        :param organization_website:
-        :param organization_twitter_handle:
-        :param organization_email:
-        :param organization_facebook:
-        :param organization_instagram_handle:
-        :param organization_image:
-        :param organization_type:
-        :param refresh_from_twitter:
-        :param facebook_id:
-        :param facebook_email:
-        :param facebook_profile_image_url_https:
-        :param facebook_background_image_url_https:
         :param chosen_domain_string:
         :param chosen_domain_string2:
         :param chosen_domain_string3:
@@ -1330,6 +1320,21 @@ class OrganizationManager(models.Manager):
         :param chosen_social_share_description:
         :param chosen_subdomain_string:
         :param chosen_subscription_plan:
+        :param facebook_background_image_url_https:
+        :param facebook_email:
+        :param facebook_id:
+        :param facebook_profile_image_url_https:
+        :param organization_description:
+        :param organization_email:
+        :param organization_facebook:
+        :param organization_image:
+        :param organization_instagram_handle:
+        :param organization_name:
+        :param organization_twitter_handle:
+        :param organization_type:
+        :param organization_website:
+        :param profile_image_type_currently_active:
+        :param refresh_from_twitter:
         :return:
         """
         exception_does_not_exist = False
@@ -1434,34 +1439,6 @@ class OrganizationManager(models.Manager):
                         twitter_location = twitter_json['location']
 
                 value_changed = False
-                if organization_name is not False:
-                    organization_on_stage.organization_name = organization_name
-                    organization_on_stage.most_recent_name_update_from_voter_first_and_last = False
-                    value_changed = True
-                if organization_description is not False:
-                    organization_on_stage.organization_description = organization_description
-                    value_changed = True
-                if organization_website is not False:
-                    organization_on_stage.organization_website = organization_website
-                    value_changed = True
-                if organization_twitter_handle is not False:
-                    organization_on_stage.organization_twitter_handle = organization_twitter_handle
-                    value_changed = True
-                if organization_email is not False:
-                    organization_on_stage.organization_email = organization_email
-                    value_changed = True
-                if organization_facebook is not False:
-                    organization_on_stage.organization_facebook = organization_facebook
-                    value_changed = True
-                if organization_image is not False:
-                    organization_on_stage.organization_image = organization_image
-                    value_changed = True
-                if organization_instagram_handle is not False:
-                    value_changed = True
-                    organization_on_stage.organization_instagram_handle = organization_instagram_handle
-                if organization_type is not False:
-                    value_changed = True
-                    organization_on_stage.organization_type = organization_type
                 if chosen_domain_string is not False:
                     value_changed = True
                     organization_on_stage.chosen_domain_string = chosen_domain_string
@@ -1500,6 +1477,37 @@ class OrganizationManager(models.Manager):
                 if chosen_subscription_plan is not False:
                     value_changed = True
                     organization_on_stage.chosen_subscription_plan = chosen_subscription_plan
+                if organization_name is not False:
+                    organization_on_stage.organization_name = organization_name
+                    organization_on_stage.most_recent_name_update_from_voter_first_and_last = False
+                    value_changed = True
+                if organization_description is not False:
+                    organization_on_stage.organization_description = organization_description
+                    value_changed = True
+                if organization_website is not False:
+                    organization_on_stage.organization_website = organization_website
+                    value_changed = True
+                if organization_twitter_handle is not False:
+                    organization_on_stage.organization_twitter_handle = organization_twitter_handle
+                    value_changed = True
+                if organization_email is not False:
+                    organization_on_stage.organization_email = organization_email
+                    value_changed = True
+                if organization_facebook is not False:
+                    organization_on_stage.organization_facebook = organization_facebook
+                    value_changed = True
+                if organization_image is not False:
+                    organization_on_stage.organization_image = organization_image
+                    value_changed = True
+                if organization_instagram_handle is not False:
+                    value_changed = True
+                    organization_on_stage.organization_instagram_handle = organization_instagram_handle
+                if organization_type is not False:
+                    value_changed = True
+                    organization_on_stage.organization_type = organization_type
+                if profile_image_type_currently_active is not False:
+                    value_changed = True
+                    organization_on_stage.profile_image_type_currently_active = profile_image_type_currently_active
 
                 if twitter_user_id or twitter_name or twitter_followers_count or twitter_profile_image_url_https \
                         or twitter_profile_banner_url_https or twitter_profile_background_image_url_https \
@@ -1664,34 +1672,6 @@ class OrganizationManager(models.Manager):
                             twitter_location = twitter_json['location']
 
                     value_changed = False
-                    if organization_name is not False:
-                        organization_on_stage.organization_name = organization_name
-                        organization_on_stage.most_recent_name_update_from_voter_first_and_last = False
-                        value_changed = True
-                    if organization_description is not False:
-                        organization_on_stage.organization_description = organization_description
-                        value_changed = True
-                    if organization_website is not False:
-                        organization_on_stage.organization_website = organization_website
-                        value_changed = True
-                    if organization_twitter_handle is not False:
-                        organization_on_stage.organization_twitter_handle = organization_twitter_handle
-                        value_changed = True
-                    if organization_email is not False:
-                        organization_on_stage.organization_email = organization_email
-                        value_changed = True
-                    if organization_facebook is not False:
-                        organization_on_stage.organization_facebook = organization_facebook
-                        value_changed = True
-                    if organization_image is not False:
-                        organization_on_stage.organization_image = organization_image
-                        value_changed = True
-                    if organization_instagram_handle is not False:
-                        value_changed = True
-                        organization_on_stage.organization_instagram_handle = organization_instagram_handle
-                    if organization_type is not False:
-                        value_changed = True
-                        organization_on_stage.organization_type = organization_type
                     if chosen_domain_string is not False:
                         value_changed = True
                         organization_on_stage.chosen_domain_string = chosen_domain_string
@@ -1730,6 +1710,37 @@ class OrganizationManager(models.Manager):
                     if chosen_subscription_plan is not False:
                         value_changed = True
                         organization_on_stage.chosen_subscription_plan = chosen_subscription_plan
+                    if organization_name is not False:
+                        organization_on_stage.organization_name = organization_name
+                        organization_on_stage.most_recent_name_update_from_voter_first_and_last = False
+                        value_changed = True
+                    if organization_description is not False:
+                        organization_on_stage.organization_description = organization_description
+                        value_changed = True
+                    if organization_website is not False:
+                        organization_on_stage.organization_website = organization_website
+                        value_changed = True
+                    if organization_twitter_handle is not False:
+                        organization_on_stage.organization_twitter_handle = organization_twitter_handle
+                        value_changed = True
+                    if organization_email is not False:
+                        organization_on_stage.organization_email = organization_email
+                        value_changed = True
+                    if organization_facebook is not False:
+                        organization_on_stage.organization_facebook = organization_facebook
+                        value_changed = True
+                    if organization_image is not False:
+                        organization_on_stage.organization_image = organization_image
+                        value_changed = True
+                    if organization_instagram_handle is not False:
+                        value_changed = True
+                        organization_on_stage.organization_instagram_handle = organization_instagram_handle
+                    if organization_type is not False:
+                        value_changed = True
+                        organization_on_stage.organization_type = organization_type
+                    if profile_image_type_currently_active is not False:
+                        value_changed = True
+                        organization_on_stage.profile_image_type_currently_active = profile_image_type_currently_active
 
                     if positive_value_exists(twitter_user_id) or positive_value_exists(twitter_name) \
                             or positive_value_exists(twitter_followers_count) \
@@ -1900,13 +1911,17 @@ class OrganizationManager(models.Manager):
                     if chosen_subscription_plan is not False:
                         value_changed = True
                         organization_on_stage.chosen_subscription_plan = chosen_subscription_plan
+                    if profile_image_type_currently_active is not False:
+                        value_changed = True
+                        organization_on_stage.profile_image_type_currently_active = profile_image_type_currently_active
 
                     if value_changed:
                         try:
                             organization_on_stage.save()
                             status += " EXTRA_VALUES_SAVED "
                         except Exception as e:
-                            logger.error("organization_on_stage.save() failed to save #3")
+                            logger.error("organization_on_stage.save() failed to save #3:" + str(e))
+                            status += "organization_on_stage.save() failed to save #3:" + str(e) + " "
                     else:
                         status += " EXTRA_VALUES_NOT_SAVED "
 

--- a/politician/models.py
+++ b/politician/models.py
@@ -49,6 +49,14 @@ POLITICIAN_UNIQUE_IDENTIFIERS = [
     'icpsr_id',
     'instagram_followers_count',
     'instagram_handle',
+    'is_battleground_race_2019',
+    'is_battleground_race_2020',
+    'is_battleground_race_2021',
+    'is_battleground_race_2022',
+    'is_battleground_race_2023',
+    'is_battleground_race_2024',
+    'is_battleground_race_2025',
+    'is_battleground_race_2026',
     'last_name',
     'lis_id',
     'maplight_id',
@@ -212,6 +220,15 @@ class Politician(models.Model):
     instagram_handle = models.TextField(verbose_name="politician's instagram handle", blank=True, null=True)
     instagram_followers_count = models.IntegerField(
         verbose_name="count of candidate's instagram followers", null=True, blank=True)
+    # As we add more years here, update /wevote_settings/constants.py IS_BATTLEGROUND_YEARS_AVAILABLE
+    is_battleground_race_2019 = models.BooleanField(default=False, null=False)
+    is_battleground_race_2020 = models.BooleanField(default=False, null=False)
+    is_battleground_race_2021 = models.BooleanField(default=False, null=False)
+    is_battleground_race_2022 = models.BooleanField(default=False, null=False)
+    is_battleground_race_2023 = models.BooleanField(default=False, null=False)
+    is_battleground_race_2024 = models.BooleanField(default=False, null=False)
+    is_battleground_race_2025 = models.BooleanField(default=False, null=False)
+    is_battleground_race_2026 = models.BooleanField(default=False, null=False)
     linkedin_url = models.TextField(null=True, blank=True)
     politician_facebook_id = models.CharField(
         verbose_name='politician facebook user name', max_length=255, null=True, unique=False)
@@ -1406,14 +1423,16 @@ class PoliticianManager(models.Manager):
 #             politician_entry = Politician.objects.order_by('last_name')[0]
 #             politician_entry.delete()
 
-    def retrieve_politicians(
+    def retrieve_politician_list(
             self,
             limit_to_this_state_code="",
+            politician_we_vote_id_list=[],
             read_only=False,
     ):
         """
 
         :param limit_to_this_state_code:
+        :param politician_we_vote_id_list:
         :param read_only:
         :return:
         """
@@ -1426,6 +1445,8 @@ class PoliticianManager(models.Manager):
                 politician_query = Politician.objects.using('readonly').all()
             else:
                 politician_query = Politician.objects.all()
+            if len(politician_we_vote_id_list):
+                politician_query = politician_query.filter(we_vote_id__in=politician_we_vote_id_list)
             if positive_value_exists(limit_to_this_state_code):
                 politician_query = politician_query.filter(state_code__iexact=limit_to_this_state_code)
             politician_list = list(politician_query)

--- a/templates/apis_v1/apis_index.html
+++ b/templates/apis_v1/apis_index.html
@@ -117,12 +117,12 @@
         <tr>
           <td><a href="{% url 'apis_v1:voterEmailAddressSignInDocs' %}">voterEmailAddressSignIn</a></td>
           <td></td>
-          <td>Sign in based on an email_secret_key that get's emailed to voter.</td>
+          <td>Sign in based on an email_secret_key that gets emailed to voter.</td>
         </tr>
         <tr>
           <td><a href="{% url 'apis_v1:voterEmailAddressVerifyDocs' %}">voterEmailAddressVerify</a></td>
           <td></td>
-          <td>Verify an email address using an email_secret_key that get's emailed to voter.</td>
+          <td>Verify an email address using an email_secret_key that gets emailed to voter.</td>
         </tr>
         <tr>
           <td><a href="{% url 'apis_v1:voterPhotoSaveDocs' %}">voterPhotoSave - DEPRECATED, PLEASE USE voterUpdate</a>
@@ -133,7 +133,7 @@
         <tr>
           <td><a href="{% url 'apis_v1:voterPlanListRetrieveDocs' %}">voterPlanListRetrieve</a></td>
           <td></td>
-          <td>Retrieve public voter plans so we can show off examples from other voters.</td>
+          <td>Retrieve public voter plans, so we can show off examples from other voters.</td>
         </tr>
         <tr>
           <td><a href="{% url 'apis_v1:voterPlanSaveDocs' %}">voterPlanSave</a></td>
@@ -168,7 +168,7 @@
         <tr>
           <td><a href="{% url 'apis_v1:voterVerifySecretCodeDocs' %}">voterVerifySecretCode</a></td>
           <td></td>
-          <td>Voter submits this six digit code to verify that they received an SMS message or email.</td>
+          <td>Voter submits this six-digit code to verify that they received an SMS message or email.</td>
         </tr>
 
         {###  ###}
@@ -252,7 +252,7 @@
         <tr>
           <td><a href="{% url 'apis_v1:twitterRetrieveIdsIFollowDocs' %}">twitterRetrieveIdsIFollow</a></td>
           <td></td>
-          <td>Retrieve the Twitter ids i follow.
+          <td>Retrieve the Twitter ids I follow.
           </td>
         </tr>
         <tr>
@@ -284,7 +284,7 @@
         <tr>
           <td><a href="{% url 'apis_v1:voterContactListRetrieveDocs' %}">voterContactListRetrieve</a></td>
           <td></td>
-          <td>Retrieve from the We Vote database all contacts previously uploaded
+          <td>Retrieve from We Vote database all contacts previously uploaded
           </td>
         </tr>
         <tr>
@@ -352,7 +352,7 @@
         <tr>
           <td><a href="{% url 'apis_v1:voterBallotItemsRetrieveDocs' %}">voterBallotItemsRetrieve</a></td>
           <td>c3</td>
-          <td>Retrieve a list of ballot items to display for the current voter from the We Vote database. These entries
+          <td>Retrieve a list of ballot items to display for the current voter from We Vote database. These entries
             would have been previously retrieved from Google Civic with voterBallotItemsRetrieveFromGoogleCivic.
           </td>
         </tr>
@@ -360,16 +360,16 @@
           <td><a href="{% url 'apis_v1:voterBallotItemsRetrieveFromGoogleCivicDocs' %}">
             voterBallotItemsRetrieveFromGoogleCivic</a></td>
           <td>c3</td>
-          <td>Tell the We Vote server to reach out to the Google Civic API and retrieve a list of ballot items
+          <td>Tell We Vote server to reach out to the Google Civic API and retrieve a list of ballot items
             for the current voter (based on the address saved with voterAddressSave), and store them in
-            the We Vote database so we can display them
+            We Vote database, so we can display them
             with voterBallotItemsRetrieve, and other API calls.
           </td>
         </tr>
         <tr>
           <td><a href="{% url 'apis_v1:voterBallotListRetrieveDocs' %}">voterBallotListRetrieve</a></td>
           <td>c3</td>
-          <td>Retrieve a list of users ballots from different elections from the We Vote database.</td>
+          <td>Retrieve a list of users ballots from different elections from We Vote database.</td>
         </tr>
         <tr>
           <td><a href="{% url 'apis_v1:electionsRetrieveDocs' %}">electionsRetrieve</a></td>
@@ -445,7 +445,17 @@
 
         {###  ###}
         <tr>
-          <td colspan="3"><strong>Offices, Candidates &amp; Measures</strong></td>
+          <td colspan="3"><strong>Elected Officials, Offices Held by a Politician &amp; Politicians</strong></td>
+        </tr>
+        <tr>
+          <td><a href="{% url 'apis_v1:representativesQueryDocs' %}">representativesQuery</a></td>
+          <td>static c3</td>
+          <td>Retrieve a list of representatives currently in office, for an entire year.</td>
+        </tr>
+
+        {###  ###}
+        <tr>
+          <td colspan="3"><strong>Offices (i.e. races), Candidates running &amp; Measures</strong></td>
         </tr>
         <tr>
           <td><a href="{% url 'apis_v1:ballotItemRetrieveDocs' %}">ballotItemRetrieve</a></td>
@@ -1071,7 +1081,7 @@
         <tr>
           <td><a href="{% url 'apis_v1:saveAnalyticsActionDocs' %}">saveAnalyticsAction</a></td>
           <td></td>
-          <td>Save an entry in the We Vote Analytics system so we can publish daily, monthly, election and sitewide
+          <td>Save an entry in We Vote Analytics system, so we can publish daily, monthly, election and sitewide
             reports.
           </td>
         </tr>

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -60,7 +60,7 @@ th, td {
     <div class="col-sm-8">
         <input type="text" name="candidate_name" id="candidate_name_id" class="form-control"
                value="{% if candidate %}{{ candidate.candidate_name|default_if_none:"" }}{% else %}{{ candidate_name|default_if_none:"" }}{% endif %}" />
-        <div style='position:absolute; width: 100%; height: 30px; margin: 4px 0 0 12px;'>
+        <div>
             {% if candidate %}
                {% if candidate.candidate_name_normalized|length|get_digit:"-1" > 0 %}
                     <span style='display: inline-block; width: 42%; text-align: left; padding-left: 6px'>
@@ -70,7 +70,7 @@ th, td {
                         </button>
                     </span>
                {% endif %}
-               <span style='display: inline-block;text-align: right;'>
+               <div>
                     {{ candidate.we_vote_id }}
                     (<a href="{% url 'candidate:candidate_delete_process' %}?candidate_id={{ candidate.id }}&google_civic_election_id={{ google_civic_election_id }}">delete candidate</a>)
 
@@ -86,7 +86,7 @@ th, td {
                         &nbsp;&nbsp;&nbsp;&nbsp;(<a href="{% url 'candidate:find_duplicate_candidate' candidate.id %}?google_civic_election_id={{ google_civic_election_id }}"
                             target="_blank">check for duplicate candidates <span class="glyphicon glyphicon-new-window"></span></a>)
                     {% endif %}
-                </span>
+                </div>
             {% else %}
                 {{ we_vote_id }}
                 {% if politician_we_vote_id and politician_we_vote_id != "False" and politician_we_vote_id != False %}

--- a/templates/office_held/is_battleground_race_year_checkboxes.html
+++ b/templates/office_held/is_battleground_race_year_checkboxes.html
@@ -1,0 +1,36 @@
+{# templates/office_held/is_battleground_race_year_checkboxes.html #}
+
+<span class="u-no-break">Is battleground:&nbsp;
+    <label for="is_battleground_race_2019_id">
+      <input type="checkbox" name="is_battleground_race_2019" id="is_battleground_race_2019_id" value="1"
+             {% if office_held.is_battleground_race_2019 %}checked{% endif %} /> 2019&nbsp;&nbsp;&nbsp;
+    </label>
+    <label for="is_battleground_race_2020_id">
+      <input type="checkbox" name="is_battleground_race_2020" id="is_battleground_race_2020_id" value="1"
+             {% if office_held.is_battleground_race_2020 %}checked{% endif %} /> 2020&nbsp;&nbsp;&nbsp;
+    </label>
+    <label for="is_battleground_race_2021_id">
+      <input type="checkbox" name="is_battleground_race_2021" id="is_battleground_race_2021_id" value="1"
+             {% if office_held.is_battleground_race_2021 %}checked{% endif %} /> 2021&nbsp;&nbsp;&nbsp;
+    </label>
+    <label for="is_battleground_race_2022_id">
+      <input type="checkbox" name="is_battleground_race_2022" id="is_battleground_race_2022_id" value="1"
+             {% if office_held.is_battleground_race_2022 %}checked{% endif %} /> 2022&nbsp;&nbsp;&nbsp;
+    </label>
+    <label for="is_battleground_race_2023_id">
+      <input type="checkbox" name="is_battleground_race_2023" id="is_battleground_race_2023_id" value="1"
+             {% if office_held.is_battleground_race_2023 %}checked{% endif %} /> 2023&nbsp;&nbsp;&nbsp;
+    </label>
+    <label for="is_battleground_race_2024_id">
+      <input type="checkbox" name="is_battleground_race_2024" id="is_battleground_race_2024_id" value="1"
+             {% if office_held.is_battleground_race_2024 %}checked{% endif %} /> 2024&nbsp;&nbsp;&nbsp;
+    </label>
+    <label for="is_battleground_race_2025_id">
+      <input type="checkbox" name="is_battleground_race_2025" id="is_battleground_race_2025_id" value="1"
+             {% if office_held.is_battleground_race_2025 %}checked{% endif %} /> 2025&nbsp;&nbsp;&nbsp;
+    </label>
+    <label for="is_battleground_race_2026_id">
+      <input type="checkbox" name="is_battleground_race_2026" id="is_battleground_race_2026_id" value="1"
+             {% if office_held.is_battleground_race_2026 %}checked{% endif %} /> 2026&nbsp;&nbsp;&nbsp;
+    </label>
+</span>

--- a/templates/office_held/office_held_edit.html
+++ b/templates/office_held/office_held_edit.html
@@ -40,14 +40,40 @@
             <!--(<a href="{% url 'office:find_duplicate_office' office_held.id %}?google_civic_election_id={{ office_held.google_civic_election_id }}"-->
                 <!--target="_blank">check for duplicate office helds</a> - in new window)-->
         <!--{% endif %}-->
+        <br />
+        Years with data:
+          <strong>
+        {% if office_held.year_with_data_2023 %}2023 {% endif %}
+        {% if office_held.year_with_data_2024 %}2024 {% endif %}
+        {% if office_held.year_with_data_2025 %}2025 {% endif %}
+        {% if office_held.year_with_data_2026 %}2026 {% endif %}
+          </strong>
+        <br />
+{% include "office_held/is_battleground_race_year_checkboxes.html" with office_held=office_held %}
     </div>
 </div>
 
 <div class="form-group">
-    <label for="google_civic_office_held_name_id" class="col-sm-3 control-label">Office Held Name (for Google Civic matching)</label>
+    <label for="google_civic_office_held_name_id" class="col-sm-3 control-label">Alternate Name (for Google Civic matching)</label>
     <div class="col-sm-8">
         <input type="text" name="google_civic_office_held_name" id="google_civic_office_held_name_id" class="form-control"
                value="{% if office_held %}{{ office_held.google_civic_office_held_name|default_if_none:"" }}{% else %}{{ google_civic_office_held_name|default_if_none:"" }}{% endif %}" />
+    </div>
+</div>
+
+<div class="form-group">
+    <label for="google_civic_office_held_name2_id" class="col-sm-3 control-label">Alternate Name 2</label>
+    <div class="col-sm-8">
+        <input type="text" name="google_civic_office_held_name2" id="google_civic_office_held_name2_id" class="form-control"
+               value="{% if office_held %}{{ office_held.google_civic_office_held_name2|default_if_none:"" }}{% else %}{{ google_civic_office_held_name2|default_if_none:"" }}{% endif %}" />
+    </div>
+</div>
+
+<div class="form-group">
+    <label for="google_civic_office_held_name3_id" class="col-sm-3 control-label">Alternate Name 3</label>
+    <div class="col-sm-8">
+        <input type="text" name="google_civic_office_held_name3" id="google_civic_office_held_name3_id" class="form-control"
+               value="{% if office_held %}{{ office_held.google_civic_office_held_name3|default_if_none:"" }}{% else %}{{ google_civic_office_held_name3|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
 
@@ -59,18 +85,28 @@
     </div>
 </div>
 
+{% if office_held.primary_party %}
 <div class="form-group">
     <label for="primary_party_id" class="col-sm-3 control-label">Primary Party</label>
     <div class="col-sm-8">
         {% if office_held %}{{ office_held.primary_party|default_if_none:"" }}{% else %}{{ primary_party|default_if_none:"" }}{% endif %}
     </div>
 </div>
+{% endif %}
 
 <div class="form-group">
     <label for="state_code_id" class="col-sm-3 control-label">State Code</label>
     <div class="col-sm-8">
         <input type="text" name="state_code" id="state_code_id" class="form-control"
-               value="{% if office_held %}{{ office_held.get_office_state|default_if_none:"" }}{% else %}{{ state_code|default_if_none:"" }}{% endif %}" />
+               value="{% if office_held %}{{ office_held.state_code|default_if_none:"" }}{% else %}{{ state_code|default_if_none:"" }}{% endif %}" />
+    </div>
+</div>
+
+<div class="form-group">
+    <label for="office_held_twitter_handle_id" class="col-sm-3 control-label">Office Held Twitter Handle</label>
+    <div class="col-sm-8">
+        <input type="text" name="office_held_twitter_handle" id="office_held_twitter_handle_id" class="form-control"
+               value="{% if office_held %}{{ office_held.office_held_twitter_handle|default_if_none:"" }}{% else %}{{ office_held_twitter_handle|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
 

--- a/templates/office_held/office_held_list.html
+++ b/templates/office_held/office_held_list.html
@@ -29,6 +29,11 @@
     Show all Offices Held in this state</a>
 {% endif %}
 {% endif %}
+    &nbsp;&nbsp;
+    <label for="show_battleground_id">
+      <input type="checkbox" name="show_battleground" id="show_battleground_id" value="1"
+             {% if show_battleground %}checked{% endif %} /> Show battleground races
+    </label>
 <br/><br/>
 {% if office_held_search %}
     <a href="{% url 'office_held:office_held_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
@@ -66,6 +71,7 @@
             <td>{{ forloop.counter }}</td>
             <td>
                 <a href="{% url 'office_held:office_held_summary' office_held.we_vote_id %}">{{ office_held.office_held_name }}</a>
+                {% include "politician/is_battleground_race_year_display.html" with linebreak_at_start=True politician=office_held %}
             </td>
             <td>{{ office_held.district_name|default_if_none:"" }}</td>
             <td>{{ office_held.state_code|default_if_none:"" }}</td>
@@ -86,12 +92,17 @@
 
 <script>
     $(function() {
-        $('#google_civic_election_id').change(function() {
+        $('#show_all_elections_id').change(function() {
             this.form.submit();
         });
     });
     $(function() {
-        $('#show_all_elections_id').change(function() {
+        $('#show_battleground_id').change(function() {
+            this.form.submit();
+        });
+    });
+    $(function() {
+        $('#google_civic_election_id').change(function() {
             this.form.submit();
         });
     });

--- a/templates/office_held/office_held_summary.html
+++ b/templates/office_held/office_held_summary.html
@@ -43,6 +43,21 @@
           </strong>
       </td>
     </tr>
+    <tr>
+      <td>Is Battleground Race:</td>
+      <td>
+          <strong>
+        {% if office_held.is_battleground_race_2019 %}2019 {% endif %}
+        {% if office_held.is_battleground_race_2020 %}2020 {% endif %}
+        {% if office_held.is_battleground_race_2021 %}2021 {% endif %}
+        {% if office_held.is_battleground_race_2022 %}2022 {% endif %}
+        {% if office_held.is_battleground_race_2023 %}2023 {% endif %}
+        {% if office_held.is_battleground_race_2024 %}2024 {% endif %}
+        {% if office_held.is_battleground_race_2025 %}2025 {% endif %}
+        {% if office_held.is_battleground_race_2026 %}2026 {% endif %}
+          </strong>
+      </td>
+    </tr>
     {% if office_held.office_url %}
     <tr>
       <td>Office Held Website:</td>

--- a/templates/politician/is_battleground_race_year_display.html
+++ b/templates/politician/is_battleground_race_year_display.html
@@ -1,0 +1,17 @@
+{# templates/politician/is_battleground_race_year_display.html #}
+{% if politician.is_battleground_race_2019 or politician.is_battleground_race_2020 or politician.is_battleground_race_2021 or politician.is_battleground_race_2022 or politician.is_battleground_race_2023 or politician.is_battleground_race_2024 or politician.is_battleground_race_2025 or politician.is_battleground_race_2026 %}
+    {% if linebreak_at_start %}
+    <br />
+    {% endif %}
+    Is in battleground race:
+    <strong>
+    {% if politician.is_battleground_race_2019 %}2019 {% endif %}
+    {% if politician.is_battleground_race_2020 %}2020 {% endif %}
+    {% if politician.is_battleground_race_2021 %}2021 {% endif %}
+    {% if politician.is_battleground_race_2022 %}2022 {% endif %}
+    {% if politician.is_battleground_race_2023 %}2023 {% endif %}
+    {% if politician.is_battleground_race_2024 %}2024 {% endif %}
+    {% if politician.is_battleground_race_2025 %}2025 {% endif %}
+    {% if politician.is_battleground_race_2026 %}2026 {% endif %}
+    </strong>
+{% endif %}

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -86,23 +86,22 @@
     <div class="col-sm-8">
         <input type="text" name="politician_name" id="politician_name_id" class="form-control pol_name_text"
                value="{% if politician %}{{ politician.politician_name|default_if_none:"" }}{% else %}{{ politician_name|default_if_none:"" }}{% endif %}" />
-        <div style='position:absolute; width: 100%; height: 30px; margin: 4px 0 0 12px;'>
-            {% if politician %}
-                {% if politician.politician_name_normalized|length|get_digit:"-1" > 0 %}
-                    <span style='display: inline-block; width: 50%; text-align: left; padding-left: 6px'>
-                        <span id='hidden_name' style="display:none;">{{ politician.politician_name_normalized }}</span>
-                        <button type="button" id="update_name_id" name="update_name" style="border-width: 1px">
-                            Change name to <span style='font-weight: 900; margin-left: 1px'>{{ politician.politician_name_normalized }}</span>
-                        </button>
-                    </span>
-                {% endif %}
-                <span style='display: inline-block; width: 44%; text-align: right;'>
-                    {{ politician.we_vote_id }} (politician id: {{ politician.id }})
-                    (<a href="{% url 'politician:politician_delete_process' %}?politician_id={{ politician.id }}">delete politician</a>)
-                    {{ we_vote_id }}
+        {% if politician %}
+            {% if politician.politician_name_normalized|length|get_digit:"-1" > 0 %}
+                <span style='display: inline-block; width: 50%; text-align: left; padding-left: 6px'>
+                    <span id='hidden_name' style="display:none;">{{ politician.politician_name_normalized }}</span>
+                    <button type="button" id="update_name_id" name="update_name" style="border-width: 1px">
+                        Change name to <span style='font-weight: 900; margin-left: 1px'>{{ politician.politician_name_normalized }}</span>
+                    </button>
                 </span>
             {% endif %}
-        </div>
+            <div>
+                {{ politician.we_vote_id }} (politician id: {{ politician.id }})
+                (<a href="{% url 'politician:politician_delete_process' %}?politician_id={{ politician.id }}">delete politician</a>)
+                {{ we_vote_id }}
+            </div>
+            {% include "office_held/is_battleground_race_year_checkboxes.html" with office_held=politician %}
+        {% endif %}
     </div>
 </div>
 

--- a/templates/politician/politician_list.html
+++ b/templates/politician/politician_list.html
@@ -62,6 +62,11 @@
              {% if show_all %}checked{% endif %} /> Show up to 200 politicians
     </label>
     &nbsp;&nbsp;
+    <label for="show_battleground_id">
+      <input type="checkbox" name="show_battleground" id="show_battleground_id" value="1"
+             {% if show_battleground %}checked{% endif %} /> Battleground races
+    </label>
+    &nbsp;&nbsp;&nbsp;&nbsp;
     <label for="show_related_candidates_id">
       <input type="checkbox" name="show_related_candidates" id="show_related_candidates_id" value="1"
              {% if show_related_candidates %}checked{% endif %} /> Show related candidates count
@@ -145,6 +150,7 @@
                 {% if politician.facebook_url %}<a href="{{ politician.facebook_url }}" target="_blank">{{ politician.facebook_url }}</a>{% endif %}
                 {% if politician.facebook_url2 %}<br /><a href="{{ politician.facebook_url2 }}" target="_blank">{{ politician.facebook_url2 }}</a>{% endif %}
                 {% if politician.facebook_url3 %}<br /><a href="{{ politician.facebook_url3 }}" target="_blank">{{ politician.facebook_url3 }}</a>{% endif %}
+            {% include "politician/is_battleground_race_year_display.html" with linebreak_at_start=True politician=politician %}
             </td>
             <td>{% if politician.linked_candidate_list_count > 0 %}{{ politician.linked_candidate_list_count }}{% endif %}</td>
         {% if show_related_candidates %}
@@ -165,6 +171,11 @@
     <script>
         $(function() {
             $('#show_all_id').change(function() {
+                this.form.submit();
+            });
+        });
+        $(function() {
+            $('#show_battleground_id').change(function() {
                 this.form.submit();
             });
         });

--- a/templates/representative/representative_edit.html
+++ b/templates/representative/representative_edit.html
@@ -78,6 +78,25 @@
         {% else %}
             {{ we_vote_id }}
         {% endif %}
+        <br />
+        <span class="u-no-break">In office:&nbsp;
+            <label for="year_in_office_2023_id">
+              <input type="checkbox" name="year_in_office_2023" id="year_in_office_2023_id" value="1"
+                     {% if representative.year_in_office_2023 %}checked{% endif %} /> 2023&nbsp;&nbsp;&nbsp;
+            </label>
+            <label for="year_in_office_2024_id">
+              <input type="checkbox" name="year_in_office_2024" id="year_in_office_2024_id" value="1"
+                     {% if representative.year_in_office_2024 %}checked{% endif %} /> 2024&nbsp;&nbsp;&nbsp;
+            </label>
+            <label for="year_in_office_2025_id">
+              <input type="checkbox" name="year_in_office_2025" id="year_in_office_2025_id" value="1"
+                     {% if representative.year_in_office_2025 %}checked{% endif %} /> 2025&nbsp;&nbsp;&nbsp;
+            </label>
+            <label for="year_in_office_2026_id">
+              <input type="checkbox" name="year_in_office_2026" id="year_in_office_2026_id" value="1"
+                     {% if representative.year_in_office_2026 %}checked{% endif %} /> 2026&nbsp;&nbsp;&nbsp;
+            </label>
+        </span>
     </div>
 </div>
 
@@ -113,24 +132,7 @@
                value="{% if representative %}{{ representative.office_held_name|default_if_none:"" }}{% else %}{{ office_held_name|default_if_none:"" }}{% endif %}" />
         <input type="text" name="office_held_we_vote_id" id="office_held_we_vote_id_id" class="form-control"
                value="{% if representative %}{{ representative.office_held_we_vote_id|default_if_none:"" }}{% else %}{{ office_held_we_vote_id|default_if_none:"" }}{% endif %}" />
-        <span class="u-no-break">In office:
-    <label for="year_in_office_2023_id">
-      <input type="checkbox" name="year_in_office_2023" id="year_in_office_2023_id" value="1"
-             {% if representative.year_in_office_2023 %}checked{% endif %} /> 2023&nbsp;&nbsp;&nbsp;
-    </label>
-    <label for="year_in_office_2024_id">
-      <input type="checkbox" name="year_in_office_2024" id="year_in_office_2024_id" value="1"
-             {% if representative.year_in_office_2024 %}checked{% endif %} /> 2024&nbsp;&nbsp;&nbsp;
-    </label>
-    <label for="year_in_office_2025_id">
-      <input type="checkbox" name="year_in_office_2025" id="year_in_office_2025_id" value="1"
-             {% if representative.year_in_office_2025 %}checked{% endif %} /> 2025&nbsp;&nbsp;&nbsp;
-    </label>
-    <label for="year_in_office_2026_id">
-      <input type="checkbox" name="year_in_office_2026" id="year_in_office_2026_id" value="1"
-             {% if representative.year_in_office_2026 %}checked{% endif %} /> 2026&nbsp;&nbsp;&nbsp;
-    </label>
-        </span>
+    {% include "office_held/is_battleground_race_year_checkboxes.html" with office_held=representative %}
     </div>
 </div>
 

--- a/templates/representative/representative_list.html
+++ b/templates/representative/representative_list.html
@@ -68,12 +68,17 @@
     &nbsp;&nbsp;
     <label for="show_representatives_with_email_id">
       <input type="checkbox" name="show_representatives_with_email" id="show_representatives_with_email_id" value="1"
-             {% if show_representatives_with_email %}checked{% endif %} /> Has Email
+             {% if show_representatives_with_email %}checked{% endif %} /> Has email
     </label>
     &nbsp;&nbsp;
     <label for="missing_politician_id">
       <input type="checkbox" name="missing_politician" id="missing_politician_id" value="1"
-             {% if missing_politician %}checked{% endif %} /> Missing Politician
+             {% if missing_politician %}checked{% endif %} /> Missing politician
+    </label>
+    &nbsp;&nbsp;
+    <label for="show_battleground_id">
+      <input type="checkbox" name="show_battleground" id="show_battleground_id" value="1"
+             {% if show_battleground %}checked{% endif %} /> Show battleground races
     </label>
     &nbsp;&nbsp;
     <label for="show_all_id">
@@ -165,6 +170,11 @@
         });
         $(function() {
             $('#show_all_id').change(function() {
+                this.form.submit();
+            });
+        });
+        $(function() {
+            $('#show_battleground_id').change(function() {
                 this.form.submit();
             });
         });

--- a/templates/voter/voter_list.html
+++ b/templates/voter/voter_list.html
@@ -323,11 +323,17 @@
     });
     $(function() {
         $('#has_voter_merge_problem_id').change(function() {
+            if(this.form.has_voter_merge_problem_id.checked) {
+                this.form.show_voter_merge_data_id.checked = false;
+            }
             this.form.submit();
         });
     });
     $(function() {
         $('#show_voter_merge_data_id').change(function() {
+            if(this.form.show_voter_merge_data_id.checked) {
+                this.form.has_voter_merge_problem_id.checked = false;
+            }
             this.form.submit();
         });
     });

--- a/twitter/functions.py
+++ b/twitter/functions.py
@@ -104,9 +104,13 @@ def retrieve_twitter_user_info(twitter_user_id=0, twitter_handle=''):
         status += 'TWITTER_RATE_LIMIT_ERROR: ' + str(rate_limit_error) + " "
         handle_exception(rate_limit_error, logger=logger, exception_message=status)
     except tweepy.errors.HTTPException as error_instance:
-        success = False
-        status += 'TWITTER_HTTP_EXCEPTION '
-        handle_exception(error_instance, logger=logger, exception_message=status)
+        if 'User not found.' in error_instance.api_messages:
+            status += 'TWITTER_USER_NOT_FOUND_ON_TWITTER: ' + str(error_instance) + ' '
+            twitter_user_not_found_in_twitter = True
+        else:
+            success = False
+            status += 'TWITTER_HTTP_EXCEPTION ' + str(error_instance) + ' '
+            handle_exception(error_instance, logger=logger, exception_message=status)
     except tweepy.errors.TweepyException as error_instance:
         success = False
         status += "[TWEEPY_EXCEPTION_ERROR: "

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -431,15 +431,25 @@ class TwitterUserManager(models.Manager):
 
     def retrieve_twitter_link_to_organization_from_twitter_handle(self, twitter_handle, read_only=False):
         status = ""
+        success = True
         twitter_user_id = 0
         results = self.retrieve_twitter_user_locally_or_remotely(twitter_user_id, twitter_handle, read_only=read_only)
-        if results['twitter_user_found']:
+        if not results['success']:
+            status += "SUCCESS_FALSE_RETRIEVING_TWITTER_USER: " + results['status'] + " "
+            success = False
+            results = {
+                'success': success,
+                'status': status,
+                'twitter_link_to_organization_found': False,
+            }
+            return results
+        elif results['twitter_user_found']:
             twitter_user = results['twitter_user']
             twitter_user_id = twitter_user.twitter_id
         else:
-            status += "RETRIEVE_TWITTER_ERROR: " + results['status'] + " "
+            status += "TWITTER_USER_NOT_FOUND: " + results['status'] + " "
             results = {
-                'success':  False,
+                'success':  success,
                 'status':   status,
                 'twitter_link_to_organization_found': False,
             }
@@ -706,7 +716,7 @@ class TwitterUserManager(models.Manager):
         """
         twitter_user_found = False
         twitter_user = None
-        success = False
+        success = True
         status = ""
 
         # Strip out the twitter handles "False" or "None"
@@ -731,6 +741,7 @@ class TwitterUserManager(models.Manager):
         twitter_results = retrieve_twitter_user_info(twitter_user_id, twitter_handle)
         if twitter_results['success'] is False:
             status += twitter_results['status']
+            success = False
         if twitter_results['twitter_handle_found']:
             twitter_save_results = self.update_or_create_twitter_user(
                 twitter_json=twitter_results['twitter_json'], twitter_id=twitter_user_id)

--- a/voter/views_admin.py
+++ b/voter/views_admin.py
@@ -1264,17 +1264,17 @@ def voter_list_view(request):
         voter_query = voter_query.order_by('-friend_count')
     from_merge_status_dict = {}
     to_merge_status_dict = {}
-    voter_merge_status_list = []
     if positive_value_exists(has_voter_merge_problem) or positive_value_exists(show_voter_merge_data):
-        if positive_value_exists(show_voter_merge_data):
-            queryset = VoterMergeStatus.objects.all().order_by('-id')
-            voter_merge_status_list = list(queryset[:500])
-            queryset_from_ids = queryset.values_list('from_voter_we_vote_id', flat=True).distinct()
-            from_list = list(queryset_from_ids[:500])
-            queryset_to_ids = queryset.values_list('to_voter_we_vote_id', flat=True).distinct()
-            to_list = list(queryset_to_ids[:500])
-            merge_data_we_vote_id_list = list(set(from_list + to_list))
-            voter_query = voter_query.filter(we_vote_id__in=merge_data_we_vote_id_list)
+        queryset = VoterMergeStatus.objects.all().order_by('-id')
+        if positive_value_exists(has_voter_merge_problem):
+            queryset = queryset.filter(total_merge_complete=False)
+        voter_merge_status_list = list(queryset[:500])
+        queryset_from_ids = queryset.values_list('from_voter_we_vote_id', flat=True).distinct()
+        from_list = list(queryset_from_ids[:500])
+        queryset_to_ids = queryset.values_list('to_voter_we_vote_id', flat=True).distinct()
+        to_list = list(queryset_to_ids[:500])
+        merge_data_we_vote_id_list = list(set(from_list + to_list))
+        voter_query = voter_query.filter(we_vote_id__in=merge_data_we_vote_id_list)
         for voter_merge_status in voter_merge_status_list:
             log_queryset = VoterMergeLog.objects.filter(
                 from_voter_we_vote_id__iexact=voter_merge_status.from_voter_we_vote_id,

--- a/wevote_settings/constants.py
+++ b/wevote_settings/constants.py
@@ -1,6 +1,11 @@
 # wevote_settings/constants.py
 
-ELECTION_YEARS_AVAILABLE = [2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016]
-# When we update this list, at least two db tables need to update at the same time:
+ELECTION_YEARS_AVAILABLE = [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
+
+# When we update IS_BATTLEGROUND_YEARS_AVAILABLE, update at the same time:
+#  OfficeHeld.is_battleground_race_2019 (etc.), Politician, and Representative
+IS_BATTLEGROUND_YEARS_AVAILABLE = [2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026]
+
+# When we update OFFICE_HELD_YEARS_AVAILABLE, update at the same time:
 #  OfficeHeld.year_with_data_2023 (etc.) and Representative.year_in_office_2023 (etc.)
 OFFICE_HELD_YEARS_AVAILABLE = [2023, 2024, 2025, 2026]


### PR DESCRIPTION
Added representativesQuery, so we can see all the cool data we've added. Created 'update_parallel_fields_with_years_in_related_objects' function to update all related fields when ContestOffice, OfficeHeld, Representative, Candidate or Politician are updated. Added filter checkbox on Politician, Representative and OfficeHeld pages to show Battleground races. Added OfficeHeld field for Twitter accounts for offices (as opposed to individual representatives.) Assorted refactoring during bug fixes. Fixed retrieve_twitter_user_info to return 'success' (and another 'not found' variable) when handle doesn't exist on Twitter.