### PR TITLE
Switched to storing politician profile photo (we_vote_hosted_profile_image_url_large) in separate field from we_vote_hosted_campaign_photo_large_url, so we can deal with the square versus rectangle display problem more elegantly. Also gives us a fallback image if politician adds then deletes campaign photo.

### DIFF
--- a/campaign/controllers.py
+++ b/campaign/controllers.py
@@ -1504,6 +1504,9 @@ def generate_campaignx_dict_from_campaignx_object(
         'we_vote_hosted_campaign_photo_large_url':  campaignx.we_vote_hosted_campaign_photo_large_url,
         'we_vote_hosted_campaign_photo_medium_url': we_vote_hosted_campaign_photo_medium_url,
         'we_vote_hosted_campaign_photo_small_url': we_vote_hosted_campaign_photo_small_url,
+        'we_vote_hosted_profile_image_url_large': campaignx.we_vote_hosted_profile_image_url_large,
+        'we_vote_hosted_profile_image_url_medium': campaignx.we_vote_hosted_profile_image_url_medium,
+        'we_vote_hosted_profile_image_url_tiny': campaignx.we_vote_hosted_profile_image_url_tiny,
     }
 
     results = {
@@ -1896,5 +1899,34 @@ def retrieve_recommended_campaignx_list_for_campaignx_we_vote_id(
         'status': status,
         'campaignx_list_found': campaignx_list_found,
         'campaignx_list': campaignx_list,
+    }
+    return results
+
+
+def update_campaignx_from_politician(campaignx, politician):
+    status = ''
+    success = True
+    save_changes = True
+    # We want to match the campaignx profile images to whatever is in the politician (even None)
+    campaignx.we_vote_hosted_profile_image_url_large = politician.we_vote_hosted_profile_image_url_large
+    campaignx.we_vote_hosted_profile_image_url_medium = politician.we_vote_hosted_profile_image_url_medium
+    campaignx.we_vote_hosted_profile_image_url_tiny = politician.we_vote_hosted_profile_image_url_tiny
+    # TEMPORARY - Clear out we_vote_hosted_campaign_photo_large_url photos for campaigns hard-linked to politicians
+    #  because all of these images were copied from the politician, and we now have a new location for them
+    if positive_value_exists(campaignx.linked_politician_we_vote_id):
+        campaignx.we_vote_hosted_campaign_photo_large_url = None
+        campaignx.we_vote_hosted_campaign_photo_medium_url = None
+        campaignx.we_vote_hosted_campaign_photo_small_url = None
+
+    # if not positive_value_exists(campaignx.wikipedia_url) and \
+    #         positive_value_exists(politician.wikipedia_url):
+    #     campaignx.wikipedia_url = politician.wikipedia_url
+    #     save_changes = True
+
+    results = {
+        'success':      success,
+        'status':       status,
+        'campaignx':    campaignx,
+        'save_changes': save_changes,
     }
     return results

--- a/politician/controllers.py
+++ b/politician/controllers.py
@@ -491,15 +491,14 @@ def generate_campaignx_for_politician(
         update_values['campaign_description_changed'] = True
         update_values['campaign_description_linked_to_twitter'] = True
     if positive_value_exists(politician.we_vote_hosted_profile_image_url_large):
-        update_values['we_vote_hosted_campaign_photo_large_url'] = \
-            politician.we_vote_hosted_profile_image_url_large
-        update_values['campaign_photo_changed'] = True
+        update_values['we_vote_hosted_profile_image_url_large'] = politician.we_vote_hosted_profile_image_url_large
+        update_values['politician_photo_changed'] = True
     if positive_value_exists(politician.we_vote_hosted_profile_image_url_medium):
-        update_values['we_vote_hosted_campaign_photo_medium_url'] = \
-            politician.we_vote_hosted_profile_image_url_medium
-        update_values['we_vote_hosted_campaign_photo_small_url'] = \
-            politician.we_vote_hosted_profile_image_url_medium
-        update_values['campaign_photo_changed'] = True
+        update_values['we_vote_hosted_profile_image_url_medium'] = politician.we_vote_hosted_profile_image_url_medium
+        update_values['politician_photo_changed'] = True
+    if positive_value_exists(politician.we_vote_hosted_profile_image_url_tiny):
+        update_values['we_vote_hosted_profile_image_url_tiny'] = politician.we_vote_hosted_profile_image_url_tiny
+        update_values['politician_photo_changed'] = True
     update_values['in_draft_mode'] = False
     update_values['in_draft_mode_changed'] = True
 

--- a/templates/campaign/campaignx_edit.html
+++ b/templates/campaign/campaignx_edit.html
@@ -197,6 +197,10 @@
         <img src="{{ campaignx.we_vote_hosted_campaign_photo_large_url }}"><br />
         Large<br />
     {% endif %}
+    {% if campaignx.we_vote_hosted_profile_image_url_large %}
+        <img src="{{ campaignx.we_vote_hosted_profile_image_url_large }}"><br />
+        Politician Photo Large<br />
+    {% endif %}
 {% endif %}
 
 

--- a/templates/campaign/campaignx_list.html
+++ b/templates/campaign/campaignx_list.html
@@ -130,9 +130,17 @@
     {% endif %}
         <tr>
             <td>{{ forloop.counter }}</td>
-            <td>{% if campaignx.we_vote_hosted_campaign_photo_large_url %}
+            <td>
+                {% if campaignx.we_vote_hosted_campaign_photo_large_url or campaignx.we_vote_hosted_profile_image_url_large %}
                 <a href="{% url 'campaign:campaignx_summary' campaignx.we_vote_id %}?google_civic_election_id={{ google_civic_election_id }}&campaignx_owner_organization_we_vote_id={{ campaignx_owner_organization_we_vote_id }}&campaignx_search={{ campaignx_search }}">
-                    <img src="{{ campaignx.we_vote_hosted_campaign_photo_large_url }}" width="128px" /></a>{% endif %}</td>
+                {% if campaignx.we_vote_hosted_campaign_photo_large_url %}
+                    <img src="{{ campaignx.we_vote_hosted_campaign_photo_large_url }}" width="128px" />
+                {% elif campaignx.we_vote_hosted_profile_image_url_large %}
+                    <img src="{{ campaignx.we_vote_hosted_profile_image_url_large }}" width="128px" />
+                {% endif %}
+                </a>
+                {% endif %}
+            </td>
             <td>
                 <span class="u-no-break">
                     <a href="{% url 'campaign:campaignx_summary' campaignx.we_vote_id %}?google_civic_election_id={{ google_civic_election_id }}&campaignx_owner_organization_we_vote_id={{ campaignx_owner_organization_we_vote_id }}&campaignx_search={{ campaignx_search }}">

--- a/templates/campaign/campaignx_summary.html
+++ b/templates/campaign/campaignx_summary.html
@@ -15,7 +15,7 @@
 
 <a href="{% url 'campaign:campaignx_list' %}?campaignx_owner_organization_we_vote_id={{ campaignx_owner_organization_we_vote_id }}&campaignx_search={{ campaignx_search }}">< Back to List</a>
 
-<h1>{% if campaignx %}{{ campaignx.campaign_title }}{% else %}New Campaign{% endif %}</h1>
+<h1>{% if campaignx %}Campaign: {{ campaignx.campaign_title }}{% else %}New Campaign{% endif %}</h1>
 {% if error_message %}<p><strong>{{ error_message }}</strong></p>{% endif %}
 
 <table>{# Two column master table #}
@@ -23,6 +23,8 @@
     <td style="vertical-align:top; width: 50%;">
         {% if campaignx.we_vote_hosted_campaign_photo_large_url %}
             <img src="{{ campaignx.we_vote_hosted_campaign_photo_large_url }}" />
+        {% elif campaignx.we_vote_hosted_profile_image_url_large %}
+            <img src="{{ campaignx.we_vote_hosted_profile_image_url_large }}" />
         {% endif %}
         <table>
             <tr>
@@ -31,6 +33,16 @@
                     (<a href="{% url 'campaign:campaignx_edit' campaignx.we_vote_id %}?google_civic_election_id={{ google_civic_election_id }}&campaignx_owner_organization_we_vote_id={{ campaignx_owner_organization_we_vote_id }}&campaignx_search={{ campaignx_search }}">edit</a>)
                 </td>
             </tr>
+        {% if campaignx.linked_politician_we_vote_id %}
+            <tr>
+                <th>Politician We Vote ID:&nbsp;</th>
+                <td> {{ campaignx.linked_politician_we_vote_id }}
+                    <a href="{% url 'politician:politician_we_vote_id_edit' campaignx.linked_politician_we_vote_id %}?google_civic_election_id={{ google_civic_election_id }}"
+                       target="_blank">edit&nbsp;<span class="glyphicon glyphicon-new-window"></span>
+                    </a>
+                </td>
+            </tr>
+        {% endif %}
         {% if campaignx.in_draft_mode %}
             <tr>
                 <th>IN DRAFT MODE</th>


### PR DESCRIPTION
Switched to storing politician profile photo (we_vote_hosted_profile_image_url_large) in separate field from we_vote_hosted_campaign_photo_large_url, so we can deal with the square versus rectangle display problem more elegantly. Also gives us a fallback image if politician adds then deletes campaign photo.