### PR TITLE
Eighth pass at instr. for voterGuidePossibilityHighlightsRetrieve

### DIFF
--- a/voter_guide/controllers.py
+++ b/voter_guide/controllers.py
@@ -635,7 +635,7 @@ def augment_candidate_possible_position_data(
         possible_endorsement_count += 1
         possible_endorsement_return_list.append(possible_endorsement)
         logger.error(
-            'augment_candidate_possible_position_data  after candidate_we_vote_id in possible_endorsement ' +
+            'augment_candidate_possible_position_data after candidate_we_vote_id in possible_endorsement ' +
             "{:.3f}".format(time.time() - t0) + ' seconds')
     elif 'ballot_item_name' in possible_endorsement and \
             positive_value_exists(possible_endorsement['ballot_item_name']):
@@ -2070,7 +2070,7 @@ def voter_guide_possibility_highlights_retrieve_for_api(  # voterGuidePossibilit
     candidate_manager = CandidateManager()
     t0 = time.time()
 
-    logger.error('voterGuidePossibilityHighlightsRetrieve url:' + url_to_scan)
+    logger.error('voterGuidePossibilityHighlightsRetrieve url: ' + url_to_scan)
     # Once we know we have a voter_device_id to work with, get this working
     voter_guide_possibility_manager = VoterGuidePossibilityManager()
     results = voter_guide_possibility_manager.retrieve_voter_guide_possibility_from_url(
@@ -2080,7 +2080,7 @@ def voter_guide_possibility_highlights_retrieve_for_api(  # voterGuidePossibilit
         # google_civic_election_id=google_civic_election_id
     )
     dt = time.time() - t0
-    logger.error('voterGuidePossibilityHighlightsRetrieve retrieve_voter_guide_possibility_from_url  took ' +
+    logger.error('voterGuidePossibilityHighlightsRetrieve retrieve_voter_guide_possibility_from_url took ' +
                  "{:.3f}".format(dt) + ' seconds')
 
     status += results['status']


### PR DESCRIPTION
I found my problem.  retrieve_candidates_from_non_unique_identifiers takes two seconds to execute, and it gets called 14 times for a page with 14 possible highlights.   The function does un-indexed searches on 12 text fields over 76,000 records.  I could try indexing all of those fields, and see if it improves.  Indexes take some CPU to maintain, but we probably add candidates pretty rarely.  First I am going to run explains and see more detail.