### PR TITLE
Find politicians with representatives with OCD ID/State mismatch.

### DIFF
--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -399,6 +399,7 @@ def politician_list_view(request):
     show_all = positive_value_exists(request.GET.get('show_all', False))
     show_battleground = positive_value_exists(request.GET.get('show_battleground', False))
     show_related_candidates = positive_value_exists(request.GET.get('show_related_candidates', False))
+    show_ocd_id_state_mismatch = positive_value_exists(request.GET.get('show_ocd_id_state_mismatch', False))
     show_politicians_with_email = positive_value_exists(request.GET.get('show_politicians_with_email', False))
 
     state_list = STATE_CODE_MAP
@@ -666,6 +667,8 @@ def politician_list_view(request):
                 Q(politician_email2_length__gt=2) |
                 Q(politician_email3_length__gt=2)
             )
+        if positive_value_exists(show_ocd_id_state_mismatch):
+            politician_query = politician_query.filter(ocd_id_state_mismatch_found=True)
 
         if positive_value_exists(politician_search):
             search_words = politician_search.split()
@@ -867,6 +870,7 @@ def politician_list_view(request):
         'show_battleground':            show_battleground,
         'show_politicians_with_email':  show_politicians_with_email,
         'show_related_candidates':      show_related_candidates,
+        'show_ocd_id_state_mismatch':   show_ocd_id_state_mismatch,
         'state_code':                   state_code,
         'state_list':                   sorted_state_list,
         'web_app_root_url':             web_app_root_url,

--- a/representative/views_admin.py
+++ b/representative/views_admin.py
@@ -1908,7 +1908,7 @@ def update_ocd_id_state_mismatch_view(request):
         bulk_update_list.append(politician)
     Politician.objects.bulk_update(bulk_update_list, ['ocd_id_state_mismatch_found'])
     message = "Politicians updated: {politicians_updated:,}.".format(
-        politicians_updated=len(politician_we_vote_id_with_mismatch_list)
+        politicians_updated=len(politician_list)
     )
     messages.add_message(request, messages.INFO, message)
 

--- a/representative/views_admin.py
+++ b/representative/views_admin.py
@@ -1870,14 +1870,14 @@ def update_ocd_id_state_mismatch_view(request):
         if representative.ocd_id_state_mismatch_found != mismatch_found:
             representative.ocd_id_state_mismatch_found = mismatch_found
             representatives_updated += 1
-            if mismatch_found:
-                # We don't want to unset 'ocd_id_state_mismatch_found' in the Politician table here,
-                #  since there may be repairs we need to complete on the Politician data.
-                if positive_value_exists(representative.politician_we_vote_id):
-                    if representative.politician_we_vote_id not in politician_we_vote_id_with_mismatch_list:
-                        politician_we_vote_id_with_mismatch_list.append(representative.politician_we_vote_id)
         else:
             representatives_without_mismatches += 1
+        if mismatch_found:
+            # We don't want to unset 'ocd_id_state_mismatch_found' in the Politician table here,
+            #  since there may be repairs we need to complete on the Politician data.
+            if positive_value_exists(representative.politician_we_vote_id):
+                if representative.politician_we_vote_id not in politician_we_vote_id_with_mismatch_list:
+                    politician_we_vote_id_with_mismatch_list.append(representative.politician_we_vote_id)
         bulk_update_list.append(representative)
     try:
         Representative.objects.bulk_update(bulk_update_list, [
@@ -1899,6 +1899,17 @@ def update_ocd_id_state_mismatch_view(request):
     # Now transfer ocd_id_state_mismatch_found to all linked Politician records
     #  using politician_we_vote_id_with_mismatch_list. We have to do it here, because the ocd_division_id
     #  data does not exist in the Politician table.
-    # TODO
+    queryset = Politician.objects.all()
+    queryset = queryset.filter(we_vote_id__in=politician_we_vote_id_with_mismatch_list)
+    politician_list = list(queryset)
+    bulk_update_list = []
+    for politician in politician_list:
+        politician.ocd_id_state_mismatch_found = True
+        bulk_update_list.append(politician)
+    Politician.objects.bulk_update(bulk_update_list, ['ocd_id_state_mismatch_found'])
+    message = "Politicians updated: {politicians_updated:,}.".format(
+        politicians_updated=len(politician_we_vote_id_with_mismatch_list)
+    )
+    messages.add_message(request, messages.INFO, message)
 
     return HttpResponseRedirect(reverse('representative:representative_list', args=()))

--- a/templates/politician/politician_list.html
+++ b/templates/politician/politician_list.html
@@ -71,6 +71,11 @@
       <input type="checkbox" name="show_related_candidates" id="show_related_candidates_id" value="1"
              {% if show_related_candidates %}checked{% endif %} /> Show related candidates count
     </label>
+
+   <label for="show_ocd_id_state_mismatch_id">
+      <input type="checkbox" name="show_ocd_id_state_mismatch" id="show_ocd_id_state_mismatch_id" value="1"
+             {% if show_ocd_id_state_mismatch %}checked{% endif %} /> Show OCD ID/State mismatch
+    </label>
 </form>
 
 {% if politician_list %}
@@ -196,6 +201,11 @@
         });
         $(function() {
             $('#show_related_candidates_id').change(function() {
+                this.form.submit();
+            });
+        });
+       $(function() {
+            $('#show_ocd_id_state_mismatch_id').change(function() {
                 this.form.submit();
             });
         });


### PR DESCRIPTION
- Note that we'll need to set `ocd_id_state_mismatch_checked` to False to re-iterate through Representatives and find mismatches and corresponding Politicians.

https://wevoteusa.atlassian.net/browse/WV-92

Tested:
- Running locally and querying all representatives to find mismatches.
- Observing message about politicians found with mismatch.
- Going to Politicians view page and filtering by mismatch.