### PR TITLE
Adds fips codes, county, and lat/lng coordinates for every voteraddress (Part 2)

### DIFF
--- a/apis_v1/views/views_voter.py
+++ b/apis_v1/views/views_voter.py
@@ -3559,7 +3559,7 @@ def voter_contact_save_view(request):  # voterContactSave
 
 @csrf_exempt
 def voter_update_fips_view(request):  # voterUpdateFips
-    limit = request.GET.get('limit', 1000)
+    limit = request.GET.get('limit', 5000)
 
     voteraddress_manager = VoterAddressManager()
     json_data = voteraddress_manager.update_fips_codes_for_all_voteraddresses(limit)

--- a/apple/models.py
+++ b/apple/models.py
@@ -18,6 +18,7 @@ class AppleUser(models.Model):
     # objects = None
     # voter_device_id = models.CharField(verbose_name='voter device id',
     #                                    max_length=255, null=False, blank=False, unique=True, default='DELETE_ME')
+    DoesNotExist = None
     objects = None
     voter_we_vote_id = models.CharField(verbose_name="we vote id for the Apple ID owner", max_length=255, unique=True)
     user_code = models.CharField(verbose_name="User's apple id code", max_length=255, null=False, unique=False)

--- a/import_export_open_people/controllers.py
+++ b/import_export_open_people/controllers.py
@@ -2,20 +2,22 @@
 # Brought to you by We Vote. Be good.
 # -*- coding: UTF-8 -*-
 
-from .models import OpenPeopleApiCounterManager
-from config.base import get_environment_variable
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from exception.models import handle_exception
 import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
 import requests
 from requests.structures import CaseInsensitiveDict
+
+import wevote_functions.admin
+from config.base import get_environment_variable
+from exception.models import handle_exception
 from voter.controllers_contacts import assemble_contact_display_name
 from voter.models import VoterContactEmail
-import wevote_functions.admin
 from wevote_functions.functions import convert_state_text_to_state_code, convert_to_int, \
     display_city_with_correct_capitalization, display_full_name_with_correct_capitalization, \
     generate_date_as_integer, positive_value_exists
 from wevote_settings.models import WeVoteSetting, WeVoteSettingsManager
+from .models import OpenPeopleApiCounterManager
 
 logger = wevote_functions.admin.get_logger(__name__)
 


### PR DESCRIPTION
Also adds the same info for newly created voters, and on voter address change
Tested with voteraddresses that I crudely copied from production to my local, so once this is on the production server, I'll test again with a small limit of voters and check with pgadmin and in the logs. 
The voterUpdateFips API (which should only be needed for one pass through all the voteraddresses) logs alot. 
With no initial device id cookie, you get a "Oakland, CA 94611" from the WebApp, which is saved in address and fips lat/lng and county are saved to voter. Then when you sign in with twitter (or equiv.) it references the pre-existing voter -- BUT just until voterUpdateFips is fully run, this voter will not have a parsed voter address voteraddress fips, etc.

https://wevotedeveloper.com:8000/apis/v1/voterUpdateFips/?limit=100