### PR TITLE
Wrap up for voterUpdateFips project, cleanup and removal of most logging

### DIFF
--- a/apis_v1/views/views_voter.py
+++ b/apis_v1/views/views_voter.py
@@ -3560,7 +3560,7 @@ def voter_contact_save_view(request):  # voterContactSave
 @csrf_exempt
 def voter_update_fips_view(request):  # voterUpdateFips
     limit = request.GET.get('limit', 5000)
-    logger.error('%s', 'KILL9 entry to voter_update_fips_view limit: ' + str(limit))
+    logger.error('%s', 'entry to voter_update_fips_view limit: ' + str(limit))
 
     voteraddress_manager = VoterAddressManager()
     json_data = voteraddress_manager.update_fips_codes_for_all_voteraddresses(limit)


### PR DESCRIPTION
Wrapped the len(addresses_to_fix) in try/except -- hopefully that will protect from the crash, and work when we get Python 11

https://api.wevoteusa.org/apis/v1/voterUpdateFips/?limit=1400   takes 10 minutes (with the logging still in)

Logging should end like this...
[2023-08-01 10:52:59,409] [ERROR] StevesM1Dec2021:voter.models: parse_address: -----Franklin Lakes, NJ 07417, USA===Franklin Lakes====NJ 
[2023-08-01 10:53:00,026] [ERROR] StevesM1Dec2021:voter.models: UPDATE_FIPS_CODES loop cnt: 112, Google lookups: 98, Dupes updated: 14, FCC Success: 98, FCC Fallback: 0 
[2023-08-01 10:53:00,094] [ERROR] StevesM1Dec2021:voter.models: parse_address: -----Sussex, NJ 07461, USA===Sussex====NJ 
[2023-08-01 10:53:00,543] [ERROR] StevesM1Dec2021:voter.models: UPDATE_FIPS_CODES loop cnt: 113, Google lookups: 99, Dupes updated: 14, FCC Success: 99, FCC Fallback: 0 
[2023-08-01 10:53:00,628] [ERROR] StevesM1Dec2021:voter.models: parse_address: -----Hawthorne, NJ 07506, USA===Hawthorne====NJ 
[2023-08-01 10:53:01,214] [ERROR] StevesM1Dec2021:voter.models: update_fips_codes_for_all_voteraddresses statistics: ADDRESESS_TO_PROCESS 662172 GOOGLE_API_ATTEMPTED 100 GOOGLE_API_FAILED 0 SAVED_UNIQUE 100 SAVED_DUPES_UPDATED 14 FCC_API_SUCCESS 100 FIPS_FROM_FALLBACK 0 GARBLED_ADDRESSES 0 ADDRESS_NOT_IN_FIPS__BACKUP 0 
[01/Aug/2023 10:53:01] "GET /apis/v1/voterUpdateFips/?limit=100 HTTP/1.1" 200 9026