### PR TITLE
Update docker-based build environment

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,8 +1,41 @@
-FROM public.ecr.aws/x6s9a3m0/wevote-base:latest
+FROM ubuntu:20.04
 
-COPY requirements.txt .
+ENV DEBIAN_FRONTEND noninteractive
 
-RUN python -m pip install -r requirements.txt --no-cache-dir
+RUN apt update && apt install -y build-essential libpq-dev zlib1g-dev \
+  libffi-dev libjpeg-dev libbz2-dev libssl-dev libgdbm-dev liblzma-dev \
+  libmagic-dev git wget postgresql-client-12
+
+# build and install python
+ENV PYTHON_VERSION 3.9.18
+RUN cd /tmp && wget -q https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz && \
+	tar -xzf Python-$PYTHON_VERSION.tgz && \
+	cd Python-$PYTHON_VERSION && \
+	./configure --prefix=/usr/local && \
+	make -j $(nproc) && \
+	make install && \
+	cd .. && \
+	rm -rf Python-$PYTHON_VERSION* && \
+	ln -s /usr/local/bin/python3 /usr/local/bin/python && \
+	python -m pip install --upgrade pip setuptools wheel
+
+# install pdf2html
+RUN if [ $(uname -m) = "aarch64" ]; then \
+	wget -O /tmp/pdf2html.deb https://wevote-packages.s3.us-west-2.amazonaws.com/pdf2htmlEX-0.18.8.rc2-master-20230113-ubuntu-20.04-aarch64.deb \
+	&& apt install -y /tmp/pdf2html.deb && rm -f /tmp/pdf2html.deb; \
+	fi
+
+RUN if [ $(uname -m) = "x86_64" ]; then \
+	wget -q -O /tmp/pdf2html.deb https://wevote-packages.s3.us-west-2.amazonaws.com/pdf2htmlEX-0.18.8.rc1-master-20200630-Ubuntu-focal-x86_64.deb \
+	&& apt install -y /tmp/pdf2html.deb && rm -f /tmp/pdf2html.deb; \
+	fi
+
+# setup runtime user account
+RUN useradd wevote && mkdir -p /wevote /var/log/wevote && chown wevote.wevote /wevote /var/log/wevote
+
+# install python dependencies
+COPY requirements.txt /tmp/
+RUN python -m pip install -r /tmp/requirements.txt --no-cache-dir
 
 EXPOSE 8000
 WORKDIR /wevote

--- a/docker/dev_environment.sh
+++ b/docker/dev_environment.sh
@@ -77,7 +77,7 @@ start_wevote_localstack() {
 
 start_wevote_db() {
 	if [ -z "$(docker container ls -a | grep $DOCKER_DB_NAME)" ]; then
-		echo "Creating postgres container.."
+		echo "Building postgres container.."
 		# build db docker container
 		docker build -t $DOCKER_DB_TAG \
 			-f $BASEDIR/docker/Dockerfile.db $BASEDIR/docker
@@ -107,6 +107,7 @@ start_wevote_db() {
 
 build_wevote_api() {
 	# build API docker container
+	echo "Building WeVoteServer container.."
 	docker build --pull -t $DOCKER_API_TAG -f docker/Dockerfile.api $BASEDIR
 	if [ ! -e $BASEDIR/config/environment_variables.json ]; then
 		echo "Creating developer configuration file in config/environment_variables.json..."


### PR DESCRIPTION
1. Don't use base image from ECR, instead build it from scratch for transparency. 
2. Upgrade Python to 3.9.18.
3. Minor comment updates to dev env script.