### PR TITLE
Remove linked_politician_we_vote_id when saving a campaign, and the Politician entry doesn't exist. Trap more crashing bugs on campaignx_edit page.

### DIFF
--- a/campaign/views_admin.py
+++ b/campaign/views_admin.py
@@ -517,6 +517,9 @@ def campaign_edit_process_view(request):
                     if results['success']:
                         campaignx = results['campaignx']
                         campaignx.date_last_updated_from_politician = localtime(now()).date()
+                elif politician_results['success']:
+                    # It was a successful query, but politician wasn't found. Remove the linked_politician_we_vote_id
+                    campaignx.linked_politician_we_vote_id = None
             if seo_friendly_path is not None:
                 # If path isn't passed in, create one. If provided, verify it is unique.
                 seo_results = campaignx_manager.generate_seo_friendly_path(

--- a/templates/campaign/campaignx_edit.html
+++ b/templates/campaign/campaignx_edit.html
@@ -31,7 +31,11 @@
 
 <div class="form-group">
     <label class="col-sm-3 control-label">
+    {% if campaignx %}
         <a href="{% url 'campaign:campaignx_summary' campaignx.we_vote_id %}?campaignx_owner_organization_we_vote_id={{ campaignx_owner_organization_we_vote_id }}&campaignx_search={{ campaignx_search }}">cancel</a>
+    {% else %}
+        <a href="{% url 'campaign:campaignx_list' %}?campaignx_search={{ campaignx_search }}">cancel</a>
+    {% endif %}
     </label>
     <div class="col-sm-8">
         <button type="submit" class="btn btn-primary">{% if campaignx %}Update Campaign{% else %}CANNOT SAVE{% endif %}</button>
@@ -187,7 +191,11 @@
 
 <div class="form-group">
     <label class="col-sm-3 control-label">
+    {% if campaignx %}
         <a href="{% url 'campaign:campaignx_summary' campaignx.we_vote_id %}?campaignx_owner_organization_we_vote_id={{ campaignx_owner_organization_we_vote_id }}&campaignx_search={{ campaignx_search }}">cancel</a>
+    {% else %}
+        <a href="{% url 'campaign:campaignx_list' %}?campaignx_search={{ campaignx_search }}">cancel</a>
+    {% endif %}
     </label>
     <div class="col-sm-8">
         <button type="submit" class="btn btn-primary">{% if campaignx %}Update Campaign{% else %}CANNOT SAVE{% endif %}</button>

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -1017,33 +1017,36 @@
             <td>SEO Friendly Path</td>
             <td>Id</td>
         </tr>
-    {% for campaignx in related_campaignx_list %}
+    {% for related_campaignx in related_campaignx_list %}
         <tr>
             <td>{{ forloop.counter }}</td>
             <td>
-                {% if campaignx.we_vote_hosted_campaign_photo_medium_url %}
-                <a href="{% url 'campaign:campaignx_summary' campaignx.we_vote_id %}?google_civic_election_id={{ google_civic_election_id }}" target="_blank">
-                    <img src='{{ campaignx.we_vote_hosted_campaign_photo_medium_url }}' height="48px" />
+                {% if related_campaignx.we_vote_hosted_campaign_photo_medium_url %}
+                <a href="{% url 'campaign:campaignx_summary' related_campaignx.we_vote_id %}?google_civic_election_id={{ google_civic_election_id }}" target="_blank">
+                    <img src='{{ related_campaignx.we_vote_hosted_campaign_photo_medium_url }}' height="48px" />
                 </a>
-                {% elif campaignx.we_vote_hosted_profile_image_url_medium %}
-                <a href="{% url 'campaign:campaignx_summary' campaignx.we_vote_id %}?google_civic_election_id={{ google_civic_election_id }}" target="_blank">
-                    <img src='{{ campaignx.we_vote_hosted_profile_image_url_medium }}' height="48px" />
+                {% elif related_campaignx.we_vote_hosted_profile_image_url_medium %}
+                <a href="{% url 'campaign:campaignx_summary' related_campaignx.we_vote_id %}?google_civic_election_id={{ google_civic_election_id }}" target="_blank">
+                    <img src='{{ related_campaignx.we_vote_hosted_profile_image_url_medium }}' height="48px" />
                 </a>
                 {% endif %}
             </td>
-            <td><a href="{% url 'campaign:campaignx_summary' campaignx.we_vote_id %}?google_civic_election_id={{ google_civic_election_id }}" target="_blank">
-                {{ campaignx.campaign_title }} <span class="glyphicon glyphicon-new-window"></span></a>
+            <td><a href="{% url 'campaign:campaignx_summary' related_campaignx.we_vote_id %}?google_civic_election_id={{ google_civic_election_id }}" target="_blank">
+                {{ related_campaignx.campaign_title }} <span class="glyphicon glyphicon-new-window"></span></a>
             &nbsp;
                 <br />
-                {{ campaignx.supporters_count|intcomma }} supporters
+                {{ related_campaignx.supporters_count|intcomma }} supporters
+                &nbsp;&nbsp;
+                <a href="{% url 'campaign:compare_two_campaigns_for_merge' %}?campaignx1_we_vote_id={{ campaignx.we_vote_id }}&campaignx2_we_vote_id={{ related_campaignx.we_vote_id }}" target="_blank">
+                    compare for merge <span class="glyphicon glyphicon-new-window"></span></a>
             </td>
             <td class="padded">
-                {% if campaignx.seo_friendly_path %}<a href="https://quality.wevote.us/c/{{ campaignx.seo_friendly_path }}" target="_blank" target="_blank">{{ campaignx.seo_friendly_path }} <span class="glyphicon glyphicon-new-window"></span></a>{% endif %}</td>
+                {% if related_campaignx.seo_friendly_path %}<a href="https://quality.wevote.us/c/{{ related_campaignx.seo_friendly_path }}" target="_blank" target="_blank">{{ related_campaignx.seo_friendly_path }} <span class="glyphicon glyphicon-new-window"></span></a>{% endif %}</td>
             </td>
-            <td>{{ campaignx.id }} &nbsp;
-                {{ campaignx.we_vote_id }}
-                {% if campaignx.linked_politician_we_vote_id %}
-                    {{ campaignx.linked_politician_we_vote_id }}
+            <td>{{ related_campaignx.id }} &nbsp;
+                {{ related_campaignx.we_vote_id }}
+                {% if related_campaignx.linked_politician_we_vote_id %}
+                    {{ related_campaignx.linked_politician_we_vote_id }}
                 {% else %}
                     ("pol"&nbsp;missing)
                 {% endif %}


### PR DESCRIPTION
Remove linked_politician_we_vote_id when saving a campaign, and the Politician entry doesn't exist. Trap more crashing bugs on campaignx_edit page.