### PR TITLE
Remove linked_politician_we_vote_id when saving a campaign, and the Politician entry doesn't exist. Trap more crashing bugs on campaignx_edit page.

### DIFF
--- a/campaign/controllers.py
+++ b/campaign/controllers.py
@@ -2182,6 +2182,13 @@ def merge_these_two_campaignx_entries(
         .update(campaignx_we_vote_id=campaignx1_we_vote_id)
 
     # ##################################
+    # Update the linked_campaignx_we_vote_id in Politician entries
+    from politician.models import Politician
+    linked_campaignx_we_vote_id_updated = Politician.objects \
+        .filter(linked_campaignx_we_vote_id__iexact=campaignx2_we_vote_id) \
+        .update(linked_campaignx_we_vote_id=campaignx1_we_vote_id)
+
+    # ##################################
     # Migrate campaignx owners
     campaignx1_owner_organization_we_vote_id_list = []
     campaignx1_owner_voter_we_vote_id_list = []

--- a/campaign/views_admin.py
+++ b/campaign/views_admin.py
@@ -1656,11 +1656,12 @@ def campaignx_merge_process_view(request):
                                     '&show_this_year_of_campaignx_entries=' + str(campaignx_year) +
                                     '&state_code=' + str(state_code))
 
-    if remove_duplicate_process:
-        return HttpResponseRedirect(reverse('campaign:find_and_merge_duplicate_campaignx_entries', args=()) +
-                                    "?google_civic_election_id=" + str(google_civic_election_id) +
-                                    '&campaignx_year=' + str(campaignx_year) +
-                                    "&state_code=" + str(state_code))
+    # To be implemented
+    # if remove_duplicate_process:
+    #     return HttpResponseRedirect(reverse('campaign:find_and_merge_duplicate_campaignx_entries', args=()) +
+    #                                 "?google_civic_election_id=" + str(google_civic_election_id) +
+    #                                 '&campaignx_year=' + str(campaignx_year) +
+    #                                 "&state_code=" + str(state_code))
 
     return HttpResponseRedirect(reverse('campaign:campaignx_edit', args=(campaignx1_on_stage.id,)))
 

--- a/politician/models.py
+++ b/politician/models.py
@@ -83,6 +83,7 @@ POLITICIAN_UNIQUE_IDENTIFIERS = [
     'is_battleground_race_2025',
     'is_battleground_race_2026',
     'last_name',
+    'linked_campaignx_we_vote_id',
     'lis_id',
     'maplight_id',
     'middle_name',

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -1757,6 +1757,9 @@ def politician_edit_process_view(request):
     youtube_url = request.POST.get('youtube_url', False)
     # is_battleground_race_ values taken in below
 
+    from campaign.controllers import update_campaignx_from_politician
+    campaignx_manager = CampaignXManager()
+
     # Check to see if this politician already exists
     politician_on_stage_found = False
     politician_on_stage = Politician()
@@ -2026,6 +2029,15 @@ def politician_edit_process_view(request):
                 politician_on_stage.politician_email2 = politician_email2
             if politician_email3 is not False:
                 politician_on_stage.politician_email3 = politician_email3
+            if positive_value_exists(politician_on_stage.linked_campaignx_we_vote_id):
+                campaignx_results = campaignx_manager.retrieve_campaignx(
+                    campaignx_we_vote_id=politician_on_stage.linked_campaignx_we_vote_id)
+                if campaignx_results['campaignx_found']:
+                    # Continue below
+                    pass
+                elif campaignx_results['success']:
+                    # If the linked_campaignx_we_vote_id points to a campaignx that doesn't exist anymore, unlink
+                    politician_on_stage.linked_campaignx_we_vote_id = None
             if politician_name is not False:
                 politician_on_stage.politician_name = politician_name
             if politician_phone_number is not False:
@@ -2128,8 +2140,6 @@ def politician_edit_process_view(request):
             messages.add_message(request, messages.INFO, 'Politician saved.')
 
             if positive_value_exists(politician_on_stage.linked_campaignx_we_vote_id):
-                from campaign.controllers import update_campaignx_from_politician
-                campaignx_manager = CampaignXManager()
                 campaignx_results = campaignx_manager.retrieve_campaignx(
                     campaignx_we_vote_id=politician_on_stage.linked_campaignx_we_vote_id)
                 if campaignx_results['campaignx_found']:
@@ -2139,6 +2149,7 @@ def politician_edit_process_view(request):
                         campaignx = results['campaignx']
                         campaignx.date_last_updated_from_politician = localtime(now()).date()
                         campaignx.save()
+
             # Find current representative for this politician
             representative_manager = RepresentativeManager()
             rep_results = representative_manager.retrieve_representative(

--- a/templates/politician/politician_merge.html
+++ b/templates/politician/politician_merge.html
@@ -292,6 +292,8 @@
 
 {% include "politician/politician_merge_one_field_decision.html" with field_name="we_vote_hosted_profile_image_url_large" field_label="We Vote Image (Large)" conflict_status=conflict_values.we_vote_hosted_profile_image_url_large politician1_field_value=politician_option1.we_vote_hosted_profile_image_url_large politician2_field_value=politician_option2.we_vote_hosted_profile_image_url_large politician1=politician_option1 politician2=politician_option2 %}
 
+{% include "politician/politician_merge_one_field_decision.html" with field_name="linked_campaignx_we_vote_id" field_label="Linked CampaignX" conflict_status=conflict_values.linked_campaignx_we_vote_id politician1_field_value=politician_option1.linked_campaignx_we_vote_id politician2_field_value=politician_option2.linked_campaignx_we_vote_id politician1=politician_option1 politician2=politician_option2 %}
+
     <tr>
         <td>Linked Candidates</td>
         <td>


### PR DESCRIPTION
Remove linked_politician_we_vote_id when saving a campaign, and the Politician entry doesn't exist. Trap more crashing bugs on campaignx_edit page.