### PR TITLE
WV-103_add Friends Only checkbox

### DIFF
--- a/templates/position/position_list.html
+++ b/templates/position/position_list.html
@@ -55,7 +55,6 @@
       <input type="checkbox" name="show_all_elections" id="show_all_elections_id" value="1"
              {% if show_all_elections %}checked{% endif %} /> Include Past Elections
     </label>
-    &nbsp;&nbsp;&nbsp;&nbsp;
 
     {% if election_years_available %}
     <select id="show_this_year_of_elections_id" name="show_this_year_of_elections">
@@ -85,17 +84,28 @@
             show all states</a>
         {% endif %}
     {% endif %}{# End of if state_list #}
-    &nbsp;&nbsp;&nbsp;&nbsp;
+
     <label for="show_statistics_id">
       <input type="checkbox" name="show_statistics" id="show_statistics_id" value="1"
              {% if show_statistics %}checked{% endif %} /> Show Statistics
     </label>
-    &nbsp;&nbsp;&nbsp;&nbsp;
+
+    {# wv-103: provide "Friends only" checkbox for admin users #}
+    {% if show_admin_options %}
+        <label for="show_friends_only_id">
+          <input type="checkbox" name="show_friends_only" id="show_friends_only_id" value="1"
+                 {% if show_friends_only %}checked{% endif %} /> Show Friends Only
+        </label>
+    {% endif %}
+    {# end wv-103 #}
+
     <br />
+
     {% if position_search %}
         <a href="{% url 'position:position_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
              clear search</a>&nbsp;
     {% endif %}
+
     <input type="text" name="position_search" id="position_search_id" value="{{ position_search }}" />
     <input type="submit" value="Search for positions" />
 </form>
@@ -195,6 +205,13 @@
             this.form.submit();
         });
     });
+    {# wv-103: "Friends only" check box for admin users #}
+    $(function() {
+        $('#show_friends_only_id').change(function() {
+            this.form.submit();
+        });
+    });
+    {# end wv-103 #}
     $(function() {
         $('#show_statistics_id').change(function() {
             this.form.submit();


### PR DESCRIPTION
In the file templates/position/position_list.html:
1. Add a checkbox labeled "Friends Only" that is visible only when the user role='admin'

In the file position/views_admin.py:
1. Add an attribute named "show_admin_options" and default to False. Change the value to True if the user is assigned the role 'admin'
2. Change page behavior so only Public opinions are displayed unless the Friends Only box is checked.
3. Change the page behavior to only display Friends opinions when the users role='admin' and the Friends Only box is checked.
4. Set maximum rows of output to 20.
5. Add the same conditions for displaying Public or Friends Only statistics when the Show Statistics box is checked.