### PR TITLE
TEAM REVIEW wv-211 form inputs on the same line

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+"ruff.lint.args":
+["--extend-select=PLR6301",
+"--preview"]
+}

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -147,7 +147,7 @@
     </div>
 </div>
 
-<div class="form-group" style="height: 64px;">
+<div class="form-group">
     <label for="politician_name_id" class="col-sm-3 control-label">
         Politician Name
         {% if politician.supporters_count %}
@@ -186,20 +186,26 @@
     </div>
 </div>
 
-<div class="form-group">
-    <label for="first_name_id" class="col-sm-3 control-label">First Name</label>
-    <div class="col-sm-8">
-        <input type="text" name="first_name" id="first_name_id" class="form-control"
-               value="{% if politician %}{{ politician.first_name|default_if_none:"" }}{% else %}{{ first_name|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="first_name_id" class="col control-label">First Name</label>
+			<div class="col">
+				<input type="text" name="first_name" id="first_name_id" class="form-control"
+					value="{% if politician %}{{ politician.first_name|default_if_none:"" }}{% else %}{{ first_name|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 
-<div class="form-group">
-    <label for="middle_name_id" class="col-sm-3 control-label">Middle Name</label>
-    <div class="col-sm-8">
-        <input type="text" name="middle_name" id="middle_name_id" class="form-control"
-               value="{% if politician %}{{ politician.middle_name|default_if_none:"" }}{% else %}{{ middle_name|default_if_none:"" }}{% endif %}" />
-    </div>
+	<div class="col">
+		<div class="form-group row">
+			<label for="middle_name_id" class="col control-label">Middle Name</label>
+			<div class="col">
+				<input type="text" name="middle_name" id="middle_name_id" class="form-control"
+					value="{% if politician %}{{ politician.middle_name|default_if_none:"" }}{% else %}{{ middle_name|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
 <div class="form-group">

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -283,7 +283,7 @@
 <div class="row">
 	<div class="col">
 		<div class="form-group row">
-			<label for="google_civic_candidate_name_id" class="col control-label u-no-break">Politician Name (for Google Civic matching)</label>
+			<label for="google_civic_candidate_name_id" class="pl-3 control-label u-no-break">Politician Name (for Google Civic matching)</label>
 			<div class="col">
 				<input type="text" name="google_civic_candidate_name" id="google_civic_candidate_name_id" class="form-control"
 					value="{% if politician %}{{ politician.google_civic_candidate_name|default_if_none:"" }}{% else %}{{ google_civic_candidate_name|default_if_none:"" }}{% endif %}" />
@@ -293,7 +293,7 @@
 
 	<div class="col">
 		<div class="form-group row">
-			<label for="google_civic_candidate_name2_id" class="col control-label u-no-break">Politician Name 2 (for Google Civic matching)</label>
+			<label for="google_civic_candidate_name2_id" class="control-label u-no-break">Politician Name 2 (for Google Civic matching)</label>
 			<div class="col">
 				<input type="text" name="google_civic_candidate_name2" id="google_civic_candidate_name2_id" class="form-control"
 					value="{% if politician %}{{ politician.google_civic_candidate_name2|default_if_none:"" }}{% else %}{{ google_civic_candidate_name2|default_if_none:"" }}{% endif %}" />

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -44,7 +44,7 @@
         Politician Photo Choice<br />
         <span style="color: darkgray">{{ politician.profile_image_type_currently_active }}</span>
     </label>
-    <div class="col-sm-8">
+    <div class="col-sm-9">
     {# UNKNOWN IMAGE #}
         <span style="float: left; padding: 8px 20px 0 0;">
             <input type="radio" name="profile_image_type_currently_active" value="UNKNOWN"
@@ -137,7 +137,7 @@
 
 <div class="form-group">
     <label for="first_name_id" class="col-sm-3 control-label">Background Color</label>
-    <div class="col-sm-8">
+    <div class="col-sm-9">
         
         <input type="text" name="profile_image_background_color" id="profile_image_background_color_id" class="form-control"
                value="{% if politician %}{{ politician.profile_image_background_color|default_if_none:"" }}{% else %}{{ profile_image_background_color|default_if_none:"" }}{% endif %}" />
@@ -154,7 +154,7 @@
             <div class="u-no-break" style="color: darkgray; font-size: 10px;">supporters_count: {{ politician.supporters_count }}</div>
         {% endif %}
     </label>
-    <div class="col-sm-8">
+    <div class="col-sm-9">
         <input type="text" name="politician_name" id="politician_name_id" class="form-control pol_name_text"
                value="{% if politician %}{{ politician.politician_name|default_if_none:"" }}{% else %}{{ politician_name|default_if_none:"" }}{% endif %}" />
         {% if politician %}
@@ -208,17 +208,45 @@
 	</div>
 </div>
 
-<div class="form-group">
-    <label for="last_name_id" class="col-sm-3 control-label">Last Name</label>
-    <div class="col-sm-8">
-        <input type="text" name="last_name" id="last_name_id" class="form-control"
-               value="{% if politician %}{{ politician.last_name|default_if_none:"" }}{% else %}{{ last_name|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="last_name_id" class="col control-label">Last Name</label>
+			<div class="col">
+				<input type="text" name="last_name" id="last_name_id" class="form-control"
+					value="{% if politician %}{{ politician.last_name|default_if_none:"" }}{% else %}{{ last_name|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="seo_friendly_path_id" class="col control-label">
+				SEO Friendly Path
+				{% if politician.seo_friendly_path %}
+					<a href="{{ web_app_root_url }}/{{ politician.seo_friendly_path }}/-/" target="_blank">
+					<span class="glyphicon glyphicon-new-window"></span>
+					</a>
+				{% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="seo_friendly_path" id="seo_friendly_path_id" class="form-control"
+					value="{% if politician %}{{ politician.seo_friendly_path|default_if_none:"" }}{% else %}{{ seo_friendly_path|default_if_none:"" }}{% endif %}" />
+			{% if path_list %}
+				{% include "politician/seo_friendly_path_list.html" with path_list=path_list %}
+			{% else %}
+				<div style="color: darkgray">
+				No alternate URL paths found.
+				</div>
+			{% endif %}
+			</div>
+		</div>
+	</div>
 </div>
 
 <div class="form-group">
     <label for="gender_id" class="col-sm-3 control-label">Gender</label>
-    <div class="col-sm-8 u-no-break">
+    <div class="col-sm-9 u-no-break">
         <div>
         <span style="border: 1px solid #ccc; border-radius: 4px; padding: 10px 6px 10px 10px">
             <input type="radio" name="gender" id="gender_unknown_id" value="U"
@@ -242,228 +270,273 @@
     </div>
 </div>
 
-<div class="form-group">
-    <label for="seo_friendly_path_id" class="col-sm-3 control-label">
-        SEO Friendly Path
-        {% if politician.seo_friendly_path %}
-            <a href="{{ web_app_root_url }}/{{ politician.seo_friendly_path }}/-/" target="_blank">
-            <span class="glyphicon glyphicon-new-window"></span>
-            </a>
-        {% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="seo_friendly_path" id="seo_friendly_path_id" class="form-control"
-               value="{% if politician %}{{ politician.seo_friendly_path|default_if_none:"" }}{% else %}{{ seo_friendly_path|default_if_none:"" }}{% endif %}" />
-    {% if path_list %}
-        {% include "politician/seo_friendly_path_list.html" with path_list=path_list %}
-    {% else %}
-        <div style="color: darkgray">
-        No alternate URL paths found.
-        </div>
-    {% endif %}
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="google_civic_candidate_name_id" class="col control-label u-no-break">Politician Name (for Google Civic matching)</label>
+			<div class="col">
+				<input type="text" name="google_civic_candidate_name" id="google_civic_candidate_name_id" class="form-control"
+					value="{% if politician %}{{ politician.google_civic_candidate_name|default_if_none:"" }}{% else %}{{ google_civic_candidate_name|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="google_civic_candidate_name2_id" class="col control-label u-no-break">Politician Name 2 (for Google Civic matching)</label>
+			<div class="col">
+				<input type="text" name="google_civic_candidate_name2" id="google_civic_candidate_name2_id" class="form-control"
+					value="{% if politician %}{{ politician.google_civic_candidate_name2|default_if_none:"" }}{% else %}{{ google_civic_candidate_name2|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="google_civic_candidate_name_id" class="col-sm-3 control-label u-no-break">Politician Name (for Google Civic matching)</label>
-    <div class="col-sm-8">
-        <input type="text" name="google_civic_candidate_name" id="google_civic_candidate_name_id" class="form-control"
-               value="{% if politician %}{{ politician.google_civic_candidate_name|default_if_none:"" }}{% else %}{{ google_civic_candidate_name|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="google_civic_candidate_name3_id" class="col control-label u-no-break">Politician Name 3 (for Google Civic matching)</label>
+			<div class="col">
+				<input type="text" name="google_civic_candidate_name3" id="google_civic_candidate_name3_id" class="form-control"
+					value="{% if politician %}{{ politician.google_civic_candidate_name3|default_if_none:"" }}{% else %}{{ google_civic_candidate_name3|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="ballotpedia_politician_name_id" class="col control-label">Name from Ballotpedia</label>
+			<div class="col">
+				<input type="text" name="ballotpedia_politician_name" id="ballotpedia_politician_name_id" class="form-control"
+					value="{% if politician %}{{ politician.ballotpedia_politician_name|default_if_none:"" }}{% else %}{{ ballotpedia_politician_name|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="google_civic_candidate_name2_id" class="col-sm-3 control-label u-no-break">Politician Name 2 (for Google Civic matching)</label>
-    <div class="col-sm-8">
-        <input type="text" name="google_civic_candidate_name2" id="google_civic_candidate_name2_id" class="form-control"
-               value="{% if politician %}{{ politician.google_civic_candidate_name2|default_if_none:"" }}{% else %}{{ google_civic_candidate_name2|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="state_code_id" class="col control-label">State Code</label>
+			<div class="col">
+				<input type="text" name="state_code" id="state_code_id" class="form-control"
+					value="{% if politician %}{{ politician.state_code|default_if_none:"" }}{% else %}{{ state_code|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="political_party_id" class="col control-label">Politician Party</label>
+			<div class="col">
+				<input type="text" name="political_party" id="political_party_id" class="form-control"
+					value="{% if politician %}{{ politician.political_party|default_if_none:"" }}{% else %}{{ political_party|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="google_civic_candidate_name3_id" class="col-sm-3 control-label u-no-break">Politician Name 3 (for Google Civic matching)</label>
-    <div class="col-sm-8">
-        <input type="text" name="google_civic_candidate_name3" id="google_civic_candidate_name3_id" class="form-control"
-               value="{% if politician %}{{ politician.google_civic_candidate_name3|default_if_none:"" }}{% else %}{{ google_civic_candidate_name3|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="vote_usa_politician_id_id" class="col control-label">Vote USA Politician Id</label>
+			<div class="col">
+				<input type="text" name="vote_usa_politician_id" id="vote_usa_politician_id_id" class="form-control"
+					value="{% if politician %}{{ politician.vote_usa_politician_id|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_twitter_handle_id" class="col control-label">Twitter Handle</label>
+			<div class="col">
+				<input type="text" name="politician_twitter_handle" id="politician_twitter_handle_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_twitter_handle|default_if_none:"" }}{% else %}{{ politician_twitter_handle|default_if_none:"" }}{% endif %}" />
+			{% if politician.politician_twitter_handle %}
+				<input type="checkbox" name="twitter_handle_updates_failing" id="twitter_handle_updates_failing_id" value="1"
+						{% if politician.twitter_handle_updates_failing %}checked{% endif %} />
+				<label for="twitter_handle_updates_failing_id" style="font-weight: normal !important;">Twitter Handle Updates Failing{% if politician.twitter_handle_updates_failing %}. <span style="color: darkgray">Our automated Twitter data update script had trouble retrieving a handle. Uncheck when fixed.</span>{% endif %}</label><br />
+				<a href="https://twitter.com/{{ politician.politician_twitter_handle|iriencode }}"
+				target="_blank">View on Twitter <span class="glyphicon glyphicon-new-window"></span></a>&nbsp;&nbsp;&nbsp;
+				<a href="{% url 'import_export_twitter:refresh_twitter_politician_details' politician.id %}">Refresh Twitter Details</a><br />
+				Twitter Name: {{ politician.twitter_name }}<br />
+				Twitter Description: {{ politician.twitter_description }}<br />
+				Twitter Location: {{ politician.twitter_location }}<br />
+				Twitter Followers: {{ politician.twitter_followers_count|intcomma }}<br />
+			{% endif %}
+			{% if politician.twitter_url %}Twitter URL (from Google Civic): {{ politician.twitter_url }}{% endif %}
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="ballotpedia_politician_name_id" class="col-sm-3 control-label">Name from Ballotpedia</label>
-    <div class="col-sm-8">
-        <input type="text" name="ballotpedia_politician_name" id="ballotpedia_politician_name_id" class="form-control"
-               value="{% if politician %}{{ politician.ballotpedia_politician_name|default_if_none:"" }}{% else %}{{ ballotpedia_politician_name|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_twitter_handle2_id" class="col control-label">Twitter Handle 2</label>
+			<div class="col">
+				<input type="text" name="politician_twitter_handle2" id="politician_twitter_handle2_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_twitter_handle2|default_if_none:"" }}{% else %}{{ politician_twitter_handle2|default_if_none:"" }}{% endif %}" />
+			{% if politician.politician_twitter_handle2 %}
+				<input type="checkbox" name="twitter_handle2_updates_failing" id="twitter_handle2_updates_failing_id" value="1"
+						{% if politician.twitter_handle2_updates_failing %}checked{% endif %} />
+				<label for="twitter_handle2_updates_failing_id" style="font-weight: normal !important;">Twitter Handle 2 Updates Failing{% if politician.twitter_handle2_updates_failing %}. <span style="color: darkgray">Our automated Twitter data update script had trouble retrieving a handle. Uncheck when fixed.</span>{% endif %}</label><br />
+				<a href="https://twitter.com/{{ politician.politician_twitter_handle2|iriencode }}"
+				target="_blank">View on Twitter <span class="glyphicon glyphicon-new-window"></span></a>&nbsp;&nbsp;&nbsp;
+				<a href="{% url 'import_export_twitter:refresh_twitter_politician_details' politician.id %}?twitter_handle={{ politician.politician_twitter_handle2 }}">Make Primary Handle</a>
+			{% endif %}
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_twitter_handle3_id" class="col control-label">Twitter Handle 3</label>
+			<div class="col">
+				<input type="text" name="politician_twitter_handle3" id="politician_twitter_handle3_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_twitter_handle3|default_if_none:"" }}{% else %}{{ politician_twitter_handle3|default_if_none:"" }}{% endif %}" />
+			{% if politician.politician_twitter_handle3 %}
+				<a href="https://twitter.com/{{ politician.politician_twitter_handle3|iriencode }}"
+				target="_blank">View on Twitter <span class="glyphicon glyphicon-new-window"></span></a>&nbsp;&nbsp;&nbsp;
+				<a href="{% url 'import_export_twitter:refresh_twitter_politician_details' politician.id %}?twitter_handle={{ politician.politician_twitter_handle3 }}">Make Primary Handle</a>
+			{% endif %}
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="state_code_id" class="col-sm-3 control-label">State Code</label>
-    <div class="col-sm-8">
-        <input type="text" name="state_code" id="state_code_id" class="form-control"
-               value="{% if politician %}{{ politician.state_code|default_if_none:"" }}{% else %}{{ state_code|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_twitter_handle4_id" class="col control-label">Twitter Handle 4</label>
+			<div class="col">
+				<input type="text" name="politician_twitter_handle4" id="politician_twitter_handle4_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_twitter_handle4|default_if_none:"" }}{% else %}{{ politician_twitter_handle4|default_if_none:"" }}{% endif %}" />
+			{% if politician.politician_twitter_handle4 %}
+				<a href="https://twitter.com/{{ politician.politician_twitter_handle4|iriencode }}"
+				target="_blank">View on Twitter <span class="glyphicon glyphicon-new-window"></span></a>&nbsp;&nbsp;&nbsp;
+				<a href="{% url 'import_export_twitter:refresh_twitter_politician_details' politician.id %}?twitter_handle={{ politician.politician_twitter_handle4 }}">Make Primary Handle</a>
+			{% endif %}
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_twitter_handle5_id" class="col control-label">Twitter Handle 5</label>
+			<div class="col">
+				<input type="text" name="politician_twitter_handle5" id="politician_twitter_handle5_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_twitter_handle5|default_if_none:"" }}{% else %}{{ politician_twitter_handle5|default_if_none:"" }}{% endif %}" />
+			{% if politician.politician_twitter_handle5 %}
+				<a href="https://twitter.com/{{ politician.politician_twitter_handle5|iriencode }}"
+				target="_blank">View on Twitter <span class="glyphicon glyphicon-new-window"></span></a>&nbsp;&nbsp;&nbsp;
+				<a href="{% url 'import_export_twitter:refresh_twitter_politician_details' politician.id %}?twitter_handle={{ politician.politician_twitter_handle5 }}">Make Primary Handle</a>
+			{% endif %}
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="political_party_id" class="col-sm-3 control-label">Politician Party</label>
-    <div class="col-sm-8">
-        <input type="text" name="political_party" id="political_party_id" class="form-control"
-               value="{% if politician %}{{ politician.political_party|default_if_none:"" }}{% else %}{{ political_party|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_url_id" class="col control-label">
+				Politician Website
+				{% if politician.politician_url %}
+				<a href="{{ politician.politician_url }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+				{% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="politician_url" id="politician_url_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_url|default_if_none:"" }}{% else %}{{ politician_url|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_url2_id" class="col control-label">
+				Website 2
+				{% if politician.politician_url2 %}
+				<a href="{{ politician.politician_url2 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+				{% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="politician_url2" id="politician_url2_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_url2|default_if_none:"" }}{% else %}{{ politician_url2|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="vote_usa_politician_id_id" class="col-sm-3 control-label">Vote USA Politician Id</label>
-    <div class="col-sm-8">
-        <input type="text" name="vote_usa_politician_id" id="vote_usa_politician_id_id" class="form-control"
-               value="{% if politician %}{{ politician.vote_usa_politician_id|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_url3_id" class="col control-label">
+				Website 3
+				{% if politician.politician_url3 %}
+				<a href="{{ politician.politician_url3 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+				{% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="politician_url3" id="politician_url3_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_url3|default_if_none:"" }}{% else %}{{ politician_url3|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_url4_id" class="col control-label">
+				Website 4
+				{% if politician.politician_url4 %}
+				<a href="{{ politician.politician_url4 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+				{% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="politician_url4" id="politician_url4_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_url4|default_if_none:"" }}{% else %}{{ politician_url4|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="politician_twitter_handle_id" class="col-sm-3 control-label">Twitter Handle</label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_twitter_handle" id="politician_twitter_handle_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_twitter_handle|default_if_none:"" }}{% else %}{{ politician_twitter_handle|default_if_none:"" }}{% endif %}" />
-    {% if politician.politician_twitter_handle %}
-        <input type="checkbox" name="twitter_handle_updates_failing" id="twitter_handle_updates_failing_id" value="1"
-                {% if politician.twitter_handle_updates_failing %}checked{% endif %} />
-        <label for="twitter_handle_updates_failing_id" style="font-weight: normal !important;">Twitter Handle Updates Failing{% if politician.twitter_handle_updates_failing %}. <span style="color: darkgray">Our automated Twitter data update script had trouble retrieving a handle. Uncheck when fixed.</span>{% endif %}</label><br />
-        <a href="https://twitter.com/{{ politician.politician_twitter_handle|iriencode }}"
-           target="_blank">View on Twitter <span class="glyphicon glyphicon-new-window"></span></a>&nbsp;&nbsp;&nbsp;
-        <a href="{% url 'import_export_twitter:refresh_twitter_politician_details' politician.id %}">Refresh Twitter Details</a><br />
-        Twitter Name: {{ politician.twitter_name }}<br />
-        Twitter Description: {{ politician.twitter_description }}<br />
-        Twitter Location: {{ politician.twitter_location }}<br />
-        Twitter Followers: {{ politician.twitter_followers_count|intcomma }}<br />
-    {% endif %}
-    {% if politician.twitter_url %}Twitter URL (from Google Civic): {{ politician.twitter_url }}{% endif %}
-    </div>
-</div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_url5_id" class="col control-label">
+				Website 5
+				{% if politician.politician_url5 %}
+				<a href="{{ politician.politician_url5 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+				{% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="politician_url5" id="politician_url5_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_url5|default_if_none:"" }}{% else %}{{ politician_url5|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 
-<div class="form-group">
-    <label for="politician_twitter_handle2_id" class="col-sm-3 control-label">Twitter Handle 2</label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_twitter_handle2" id="politician_twitter_handle2_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_twitter_handle2|default_if_none:"" }}{% else %}{{ politician_twitter_handle2|default_if_none:"" }}{% endif %}" />
-    {% if politician.politician_twitter_handle2 %}
-        <input type="checkbox" name="twitter_handle2_updates_failing" id="twitter_handle2_updates_failing_id" value="1"
-                {% if politician.twitter_handle2_updates_failing %}checked{% endif %} />
-        <label for="twitter_handle2_updates_failing_id" style="font-weight: normal !important;">Twitter Handle 2 Updates Failing{% if politician.twitter_handle2_updates_failing %}. <span style="color: darkgray">Our automated Twitter data update script had trouble retrieving a handle. Uncheck when fixed.</span>{% endif %}</label><br />
-        <a href="https://twitter.com/{{ politician.politician_twitter_handle2|iriencode }}"
-           target="_blank">View on Twitter <span class="glyphicon glyphicon-new-window"></span></a>&nbsp;&nbsp;&nbsp;
-        <a href="{% url 'import_export_twitter:refresh_twitter_politician_details' politician.id %}?twitter_handle={{ politician.politician_twitter_handle2 }}">Make Primary Handle</a>
-    {% endif %}
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="politician_twitter_handle3_id" class="col-sm-3 control-label">Twitter Handle 3</label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_twitter_handle3" id="politician_twitter_handle3_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_twitter_handle3|default_if_none:"" }}{% else %}{{ politician_twitter_handle3|default_if_none:"" }}{% endif %}" />
-    {% if politician.politician_twitter_handle3 %}
-        <a href="https://twitter.com/{{ politician.politician_twitter_handle3|iriencode }}"
-           target="_blank">View on Twitter <span class="glyphicon glyphicon-new-window"></span></a>&nbsp;&nbsp;&nbsp;
-        <a href="{% url 'import_export_twitter:refresh_twitter_politician_details' politician.id %}?twitter_handle={{ politician.politician_twitter_handle3 }}">Make Primary Handle</a>
-    {% endif %}
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="politician_twitter_handle4_id" class="col-sm-3 control-label">Twitter Handle 4</label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_twitter_handle4" id="politician_twitter_handle4_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_twitter_handle4|default_if_none:"" }}{% else %}{{ politician_twitter_handle4|default_if_none:"" }}{% endif %}" />
-    {% if politician.politician_twitter_handle4 %}
-        <a href="https://twitter.com/{{ politician.politician_twitter_handle4|iriencode }}"
-           target="_blank">View on Twitter <span class="glyphicon glyphicon-new-window"></span></a>&nbsp;&nbsp;&nbsp;
-        <a href="{% url 'import_export_twitter:refresh_twitter_politician_details' politician.id %}?twitter_handle={{ politician.politician_twitter_handle4 }}">Make Primary Handle</a>
-    {% endif %}
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="politician_twitter_handle5_id" class="col-sm-3 control-label">Twitter Handle 5</label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_twitter_handle5" id="politician_twitter_handle5_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_twitter_handle5|default_if_none:"" }}{% else %}{{ politician_twitter_handle5|default_if_none:"" }}{% endif %}" />
-    {% if politician.politician_twitter_handle5 %}
-        <a href="https://twitter.com/{{ politician.politician_twitter_handle5|iriencode }}"
-           target="_blank">View on Twitter <span class="glyphicon glyphicon-new-window"></span></a>&nbsp;&nbsp;&nbsp;
-        <a href="{% url 'import_export_twitter:refresh_twitter_politician_details' politician.id %}?twitter_handle={{ politician.politician_twitter_handle5 }}">Make Primary Handle</a>
-    {% endif %}
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="politician_url_id" class="col-sm-3 control-label">
-        Politician Website
-        {% if politician.politician_url %}
-        <a href="{{ politician.politician_url }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
-        {% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_url" id="politician_url_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_url|default_if_none:"" }}{% else %}{{ politician_url|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="politician_url2_id" class="col-sm-3 control-label">
-        Website 2
-        {% if politician.politician_url2 %}
-        <a href="{{ politician.politician_url2 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
-        {% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_url2" id="politician_url2_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_url2|default_if_none:"" }}{% else %}{{ politician_url2|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="politician_url3_id" class="col-sm-3 control-label">
-        Website 3
-        {% if politician.politician_url3 %}
-        <a href="{{ politician.politician_url3 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
-        {% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_url3" id="politician_url3_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_url3|default_if_none:"" }}{% else %}{{ politician_url3|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="politician_url4_id" class="col-sm-3 control-label">
-        Website 4
-        {% if politician.politician_url4 %}
-        <a href="{{ politician.politician_url4 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
-        {% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_url4" id="politician_url4_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_url4|default_if_none:"" }}{% else %}{{ politician_url4|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="politician_url5_id" class="col-sm-3 control-label">
-        Website 5
-        {% if politician.politician_url5 %}
-        <a href="{{ politician.politician_url5 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
-        {% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_url5" id="politician_url5_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_url5|default_if_none:"" }}{% else %}{{ politician_url5|default_if_none:"" }}{% endif %}" />
-    </div>
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_contact_form_url_id" class="col control-label">
+				Politician Contact Form
+				{% if politician.politician_contact_form_url %}
+				<a href="{{ politician.politician_contact_form_url }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+				{% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="politician_contact_form_url" id="politician_contact_form_url_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_contact_form_url|default_if_none:"" }}{% else %}{{ politician_contact_form_url|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
 <div class="form-group">
     <label for="ballot_guide_official_statement_id" class="col-sm-3 control-label">Official Candidate Statement</label>
-    <div class="col-sm-8">
+    <div class="col-sm-9">
         <textarea name="ballot_guide_official_statement"
                   class="form-control animated"
                   id="ballot_guide_official_statement_id"
@@ -471,179 +544,214 @@
     </div>
 </div>
 
-<div class="form-group">
-    <label for="politician_contact_form_url_id" class="col-sm-3 control-label">
-        Politician Contact Form
-        {% if politician.politician_contact_form_url %}
-        <a href="{{ politician.politician_contact_form_url }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
-        {% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_contact_form_url" id="politician_contact_form_url_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_contact_form_url|default_if_none:"" }}{% else %}{{ politician_contact_form_url|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="facebook_url_id" class="col control-label">
+				Facebook URL
+				{% if politician.facebook_url %}
+				<a href="{{ politician.facebook_url }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+				{% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="facebook_url" id="facebook_url_id" class="form-control"
+					value="{% if politician %}{{ politician.facebook_url|default_if_none:"" }}{% else %}{{ facebook_url|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="facebook_url2_id" class="col control-label">
+				Facebook URL 2
+				{% if politician.facebook_url2 %}
+				<a href="{{ politician.facebook_url2 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+				{% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="facebook_url2" id="facebook_url2_id" class="form-control"
+					value="{% if politician %}{{ politician.facebook_url2|default_if_none:"" }}{% else %}{{ facebook_url2|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="facebook_url_id" class="col-sm-3 control-label">
-        Facebook URL
-        {% if politician.facebook_url %}
-        <a href="{{ politician.facebook_url }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
-        {% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="facebook_url" id="facebook_url_id" class="form-control"
-               value="{% if politician %}{{ politician.facebook_url|default_if_none:"" }}{% else %}{{ facebook_url|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="facebook_url3_id" class="col control-label">
+				Facebook URL 3
+				{% if politician.facebook_url3 %}
+				<a href="{{ politician.facebook_url3 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+				{% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="facebook_url3" id="facebook_url3_id" class="form-control"
+					value="{% if politician %}{{ politician.facebook_url3|default_if_none:"" }}{% else %}{{ facebook_url3|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="instagram_handle_id" class="col control-label">
+				Instagram Handle
+				{% if politician.instagram_handle %}
+				<a href="https://www.instagram.com/{{ politician.instagram_handle }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
+				{% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="instagram_handle" id="instagram_handle_id" class="form-control"
+					value="{% if politician %}{{ politician.instagram_handle|default_if_none:"" }}{% else %}{{ instagram_handle|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="facebook_url2_id" class="col-sm-3 control-label">
-        Facebook URL 2
-        {% if politician.facebook_url2 %}
-        <a href="{{ politician.facebook_url2 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
-        {% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="facebook_url2" id="facebook_url2_id" class="form-control"
-               value="{% if politician %}{{ politician.facebook_url2|default_if_none:"" }}{% else %}{{ facebook_url2|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_email_id" class="col control-label">Politician Email</label>
+			<div class="col">
+				<input type="text" name="politician_email" id="politician_email_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_email|default_if_none:"" }}{% else %}{{ politician_email|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_email2_id" class="col control-label">Email 2</label>
+			<div class="col">
+				<input type="text" name="politician_email2" id="politician_email2_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_email2|default_if_none:"" }}{% else %}{{ politician_email2|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="facebook_url3_id" class="col-sm-3 control-label">
-        Facebook URL 3
-        {% if politician.facebook_url3 %}
-        <a href="{{ politician.facebook_url3 }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
-        {% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="facebook_url3" id="facebook_url3_id" class="form-control"
-               value="{% if politician %}{{ politician.facebook_url3|default_if_none:"" }}{% else %}{{ facebook_url3|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_email3_id" class="col control-label">Email 3</label>
+			<div class="col">
+				<input type="text" name="politician_email3" id="politician_email3_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_email3|default_if_none:"" }}{% else %}{{ politician_email3|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_phone_number_id" class="col control-label">Politician Phone</label>
+			<div class="col">
+				<input type="text" name="politician_phone_number" id="politician_phone_number_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_phone_number|default_if_none:"" }}{% else %}{{ politician_phone_number|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="instagram_handle_id" class="col-sm-3 control-label">
-        Instagram Handle
-        {% if politician.instagram_handle %}
-        <a href="https://www.instagram.com/{{ politician.instagram_handle }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
-        {% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="instagram_handle" id="instagram_handle_id" class="form-control"
-               value="{% if politician %}{{ politician.instagram_handle|default_if_none:"" }}{% else %}{{ instagram_handle|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_phone_number2_id" class="col control-label">Phone 2</label>
+			<div class="col">
+				<input type="text" name="politician_phone_number2" id="politician_phone_number2_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_phone_number2|default_if_none:"" }}{% else %}{{ politician_phone_number2|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="politician_phone_number3_id" class="col control-label">Phone 3</label>
+			<div class="col">
+				<input type="text" name="politician_phone_number3" id="politician_phone_number3_id" class="form-control"
+					value="{% if politician %}{{ politician.politician_phone_number3|default_if_none:"" }}{% else %}{{ politician_phone_number3|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="politician_email_id" class="col-sm-3 control-label">Politician Email</label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_email" id="politician_email_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_email|default_if_none:"" }}{% else %}{{ politician_email|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="ballotpedia_politician_url_id" class="col control-label">
+				Ballotpedia Politician Page
+				{% if politician and politician.ballotpedia_politician_url %}(<a href="{{ politician.ballotpedia_politician_url }}" target="_blank">Go</a>){% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="ballotpedia_politician_url" id="ballotpedia_politician_url_id" class="form-control"
+					value="{% if politician %}{{ politician.ballotpedia_politician_url|default_if_none:"" }}{% else %}{{ ballotpedia_politician_url|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="wikipedia_url_id" class="col control-label">
+				Wikipedia Page
+				{% if politician and politician.wikipedia_url %}(<a href="{{ politician.wikipedia_url }}" target="_blank">Go</a>){% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="wikipedia_url" id="wikipedia_url_id" class="form-control"
+					value="{% if politician %}{{ politician.wikipedia_url|default_if_none:"" }}{% else %}{{ wikipedia_url|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="politician_email2_id" class="col-sm-3 control-label">Email 2</label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_email2" id="politician_email2_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_email2|default_if_none:"" }}{% else %}{{ politician_email2|default_if_none:"" }}{% endif %}" />
-    </div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="linkedin_url_id" class="col control-label">
+				LinkedIn
+				{% if politician and politician.linkedin_url %}(<a href="{{ politician.linkedin_url }}" target="_blank">Go</a>){% endif %}
+			</label>
+			<div class="col">
+				<input type="text" name="linkedin_url" id="linkedin_url_id" class="form-control"
+					value="{% if politician %}{{ politician.linkedin_url|default_if_none:"" }}{% else %}{{ linkedin_url|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="vote_smart_id_id" class="col control-label">Vote Smart Id</label>
+			<div class="col">
+				<input type="text" name="vote_smart_id" id="vote_smart_id_id" class="form-control"
+					value="{% if politician %}{{ politician.vote_smart_id|default_if_none:"" }}{% else %}{{ vote_smart_id|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
-<div class="form-group">
-    <label for="politician_email3_id" class="col-sm-3 control-label">Email 3</label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_email3" id="politician_email3_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_email3|default_if_none:"" }}{% else %}{{ politician_email3|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
+<div class="row">
+	<div class="col">
+		<div class="form-group row">
+			<label for="maplight_id_id" class="col control-label">MapLight Id</label>
+			<div class="col">
+				<input type="text" name="maplight_id" id="maplight_id_id" class="form-control"
+					value="{% if politician %}{{ politician.maplight_id|default_if_none:"" }}{% else %}{{ maplight_id|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 
-<div class="form-group">
-    <label for="politician_phone_number_id" class="col-sm-3 control-label">Politician Phone</label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_phone_number" id="politician_phone_number_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_phone_number|default_if_none:"" }}{% else %}{{ politician_phone_number|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="politician_phone_number2_id" class="col-sm-3 control-label">Phone 2</label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_phone_number2" id="politician_phone_number2_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_phone_number2|default_if_none:"" }}{% else %}{{ politician_phone_number2|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="politician_phone_number3_id" class="col-sm-3 control-label">Phone 3</label>
-    <div class="col-sm-8">
-        <input type="text" name="politician_phone_number3" id="politician_phone_number3_id" class="form-control"
-               value="{% if politician %}{{ politician.politician_phone_number3|default_if_none:"" }}{% else %}{{ politician_phone_number3|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="ballotpedia_politician_url_id" class="col-sm-3 control-label">
-        Ballotpedia Politician Page
-        {% if politician and politician.ballotpedia_politician_url %}(<a href="{{ politician.ballotpedia_politician_url }}" target="_blank">Go</a>){% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="ballotpedia_politician_url" id="ballotpedia_politician_url_id" class="form-control"
-               value="{% if politician %}{{ politician.ballotpedia_politician_url|default_if_none:"" }}{% else %}{{ ballotpedia_politician_url|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="wikipedia_url_id" class="col-sm-3 control-label">
-        Wikipedia Page
-        {% if politician and politician.wikipedia_url %}(<a href="{{ politician.wikipedia_url }}" target="_blank">Go</a>){% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="wikipedia_url" id="wikipedia_url_id" class="form-control"
-               value="{% if politician %}{{ politician.wikipedia_url|default_if_none:"" }}{% else %}{{ wikipedia_url|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="linkedin_url_id" class="col-sm-3 control-label">
-        LinkedIn
-        {% if politician and politician.linkedin_url %}(<a href="{{ politician.linkedin_url }}" target="_blank">Go</a>){% endif %}
-    </label>
-    <div class="col-sm-8">
-        <input type="text" name="linkedin_url" id="linkedin_url_id" class="form-control"
-               value="{% if politician %}{{ politician.linkedin_url|default_if_none:"" }}{% else %}{{ linkedin_url|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="vote_smart_id_id" class="col-sm-3 control-label">Vote Smart Id</label>
-    <div class="col-sm-8">
-        <input type="text" name="vote_smart_id" id="vote_smart_id_id" class="form-control"
-               value="{% if politician %}{{ politician.vote_smart_id|default_if_none:"" }}{% else %}{{ vote_smart_id|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="maplight_id_id" class="col-sm-3 control-label">MapLight Id</label>
-    <div class="col-sm-8">
-        <input type="text" name="maplight_id" id="maplight_id_id" class="form-control"
-               value="{% if politician %}{{ politician.maplight_id|default_if_none:"" }}{% else %}{{ maplight_id|default_if_none:"" }}{% endif %}" />
-    </div>
-</div>
-
-<div class="form-group">
-    <label for="birth_date_id" class="col-sm-3 control-label">Birthdate (format Feb. 16, 1955)</label>
-    <div class="col-sm-8">
-        <input type="text" name="birth_date" id="birth_date_id" class="form-control"
-               value="{% if politician %}{{ politician.birth_date|default_if_none:"" }}{% else %}{{ birth_date|default_if_none:"" }}{% endif %}" />
-    </div>
+	<div class="col">
+		<div class="form-group row">
+			<label for="birth_date_id" class="col control-label">Birthdate (format Feb. 16, 1955)</label>
+			<div class="col">
+				<input type="text" name="birth_date" id="birth_date_id" class="form-control"
+					value="{% if politician %}{{ politician.birth_date|default_if_none:"" }}{% else %}{{ birth_date|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
 <div class="form-group">
     <label for="youtube_url_id" class="col-sm-3 control-label">YouTube URL</label>
-    <div class="col-sm-8">
+    <div class="col-sm-9">
         <input type="text" name="youtube_url" id="youtube_url_id" class="form-control"
                value="{% if politician %}{{ politician.youtube_url|default_if_none:"" }}{% else %}{{ youtube_url|default_if_none:"" }}{% endif %}" />
     </div>

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -189,7 +189,7 @@
 <div class="row">
 	<div class="col">
 		<div class="form-group row">
-			<label for="first_name_id" class="col control-label">First Name</label>
+			<label for="first_name_id" class="pl-3 control-label">First Name</label>
 			<div class="col">
 				<input type="text" name="first_name" id="first_name_id" class="form-control"
 					value="{% if politician %}{{ politician.first_name|default_if_none:"" }}{% else %}{{ first_name|default_if_none:"" }}{% endif %}" />
@@ -199,17 +199,27 @@
 
 	<div class="col">
 		<div class="form-group row">
-			<label for="middle_name_id" class="col control-label">Middle Name</label>
+			<label for="middle_name_id" class="control-label">Middle Name</label>
 			<div class="col">
 				<input type="text" name="middle_name" id="middle_name_id" class="form-control"
 					value="{% if politician %}{{ politician.middle_name|default_if_none:"" }}{% else %}{{ middle_name|default_if_none:"" }}{% endif %}" />
 			</div>
 		</div>
 	</div>
+
+	<div class="col">
+		<div class="form-group row">
+			<label for="last_name_id" class="control-label">Last Name</label>
+			<div class="col">
+				<input type="text" name="last_name" id="last_name_id" class="form-control"
+					value="{% if politician %}{{ politician.last_name|default_if_none:"" }}{% else %}{{ last_name|default_if_none:"" }}{% endif %}" />
+			</div>
+		</div>
+	</div>
 </div>
 
 <div class="row">
-	<div class="col">
+	<!-- <div class="col">
 		<div class="form-group row">
 			<label for="last_name_id" class="col control-label">Last Name</label>
 			<div class="col">
@@ -217,7 +227,7 @@
 					value="{% if politician %}{{ politician.last_name|default_if_none:"" }}{% else %}{{ last_name|default_if_none:"" }}{% endif %}" />
 			</div>
 		</div>
-	</div>
+	</div> -->
 
 	<div class="col">
 		<div class="form-group row">


### PR DESCRIPTION
Pairs with [PR 2368](https://github.com/wevote/WeVoteServer/pull/2368). Can discuss preferred layout next meeting.

I was hoping the diff would show the individual changes better, but it's making it look like huge swaths of code were changed. For clarity all I did was wrap two `form-groups` at a time in a `row`. Then I wrapped each individual `form-group` within the `row` in a `col`. Finally I updated each individual `form group` to have class `row`. (row  -> col -> row)

![Screenshot from 2024-02-27 15-38-28](https://github.com/wevote/WeVoteServer/assets/89757407/ea0c1d8f-754d-4bd4-8790-c25d031a5dea)

In order to maintain the original left alignment, I had to remove the page break values on the labels and inputs (ie `col-sm-8`). I also had to update any full size form groups (ie ones that do not share the line with any other input) from `col-sm-8` to `col-sm-9` in order for the form to be neatly aligned on the right.

Please let me know if this is on the right track. Open to discussing which form groups should share lines and which should be on their own, or other alignment preferences. For example, I left candidate statement at full size:
![image](https://github.com/wevote/WeVoteServer/assets/89757407/acf294d4-2503-4961-9683-d20a23bc72ba)

