### PR TITLE
Experiment to allow the production servers to ignore the 'state' requirement on the unneeded /complete/twitter/ redirect return.

### DIFF
--- a/wevote_social/middleware.py
+++ b/wevote_social/middleware.py
@@ -24,6 +24,10 @@ class SocialMiddleware(object):
         # Code to be executed for each request before
         # the view (and later middleware) are called.
 
+        if "/complete/twitter/" in request.path:
+            # Bypass the state check in middleware for Twitter V2 API and the '/complete/twitter/' request
+            return HttpResponse()
+
         response = self.get_response(request)
     # def process_request(self, request):
         if hasattr(request, 'user'):

--- a/wevote_social/middleware.py
+++ b/wevote_social/middleware.py
@@ -25,7 +25,8 @@ class SocialMiddleware(object):
         # the view (and later middleware) are called.
 
         if "/complete/twitter/" in request.path:
-            # Bypass the state check in middleware for Twitter V2 API and the '/complete/twitter/' request
+            # Bypass the state check in middleware for Twitter V2 API and the '/complete/twitter/' request ...
+            #   In this case unconditionally return a 200
             return HttpResponse()
 
         response = self.get_response(request)


### PR DESCRIPTION
This code path is not invoked on my local python and WebApp servers which are both running in the same domain, 'wevotedeveloper.com'.  

My theory is that since the WebApp and Python API servers are running in different domains, the redirect requires state information to be stored in the WSGIServer so different threads can share that state.  For what ever reason, the state is not being shared in this case, and since the /complete/twitter/ is not needed for the way I have implemented OAuth1.0a for twitter, I'm just sending a 200 back for this request.

This change is highly specific to /complete/twitter/ and should not effect anything else.

**Test note:**
Previously failing urls

https://wevotedeveloper.com:8000/complete/twitter/?oauth_token=RV9icQAAAAABZ4LOAAABjgbYebE&oauth_verifier=E6gZxL8I4TCTFmlCXOyZViSxFR3d2j2j

https://api.wevoteusa.org/complete/twitter/?oauth_token=mhQWRQAAAAABZ4LOAAABjgsAMVI&oauth_verifier=pjMxFXtpgFAvtPt0yVNdQOStieJTC4p2