### PR TITLE
More data stored to twitterapi counter to better understand the Twitter rate limit problem

### DIFF
--- a/apis_v1/urls.py
+++ b/apis_v1/urls.py
@@ -171,6 +171,7 @@ urlpatterns = [
               issues_under_ballot_items_retrieve_view, name='issuesUnderBallotItemsRetrieveView'),
       re_path(r'^issuesSyncOut/', issues_sync_out_view, name='issuesSyncOutView'),
       re_path(r'^logToCloudWatch/$', views_donation.log_to_cloudwatch_view, name='log_to_cloudwatch'),
+      re_path(r'^logEnvironmentToCloudWatch/$', views_misc.log_environment_to_cloudwatch_view, name='log_to_cloudwatch'),
       re_path(r'^measureRetrieve/', views_measure.measure_retrieve_view, name='measureRetrieveView'),
       re_path(r'^measuresSyncOut/', measures_sync_out_view, name='measuresSyncOutView'),
       re_path(r'^measureListForUpcomingElectionsRetrieve/',

--- a/apis_v1/views/views_misc.py
+++ b/apis_v1/views/views_misc.py
@@ -154,3 +154,20 @@ def search_all_view(request):  # searchAll
         'search_results':           search_results,
     }
     return HttpResponse(json.dumps(json_data), content_type='application/json')
+
+
+def log_environment_to_cloudwatch_view(request):            # logEnvironmentToCloudWatch
+    # Log environment_variables.json to CloudWatch WeVoteServer Python logs
+    f = open('config/environment_variables.json')
+    data = json.load(f)
+    for row in data:
+        if '_comment' not in row:
+            print(f'environment - \'{row}\' = \'{data[row]}\'')
+
+    f.close()
+    results = {
+        'status': 'environment variables have been logged to CloudWatch',
+        'success': 'true'
+    }
+
+    return HttpResponse(json.dumps(results), content_type='application/json')

--- a/import_export_twitter/controllers.py
+++ b/import_export_twitter/controllers.py
@@ -36,7 +36,8 @@ from position.controllers import update_all_position_details_from_candidate, \
 from representative.models import Representative, RepresentativeManager
 from twitter.functions import convert_twitter_user_object_data_to_we_vote_dict, expand_twitter_public_metrics, \
     expand_twitter_entities, retrieve_twitter_user_info
-from twitter.models import TwitterApiCounterManager, TwitterLinkPossibility, TwitterUserManager
+from twitter.models import TwitterApiCounterManager, TwitterLinkPossibility, TwitterUserManager, \
+    create_detailed_counter_entry
 from voter.models import VoterManager
 from voter_guide.models import VoterGuideListManager
 from wevote_functions.functions import convert_to_int, extract_twitter_handle_from_text_string, \
@@ -1403,13 +1404,7 @@ def retrieve_possible_twitter_handles(candidate):
     # auth = tweepy.OAuthHandler(TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET)
     # auth.set_access_token(TWITTER_ACCESS_TOKEN, TWITTER_ACCESS_TOKEN_SECRET)
     # api = tweepy.API(auth, timeout=20)
-    try:
-        logger.error("import_export_twitter/controllers.py 1406: session: client = tweepy.Client() candidate_name: ",
-                     candidate.candidate_name)
-    except Exception as excpt:
-        logger.error("import_export_twitter/controllers.py 1406: session: client = tweepy.Client() "
-                     "TRIED TO GET candidate name ", str(excpt))
-
+    print("tweepy client init. (WeVote) in retrieve_possible_twitter_handles")
     client = tweepy.Client(
         bearer_token=TWITTER_BEARER_TOKEN,
         consumer_key=TWITTER_CONSUMER_KEY,
@@ -1425,10 +1420,14 @@ def retrieve_possible_twitter_handles(candidate):
     try:
         # Use Twitter API call counter to track the number of queries we are doing each day
         google_civic_api_counter_manager = TwitterApiCounterManager()
-        google_civic_api_counter_manager.create_counter_entry('search_users')
+        # google_civic_api_counter_manager.create_counter_entry('search_users')
 
         # DALE 2024-01-19 search_users NOT supported by tweepy yet, but Twitter API 2 seems to
         # support it: https://developer.twitter.com/en/docs/twitter-api/users/search/api-reference/get-users-search
+        print("tweepy client.search_users in retrieve_possible_twitter_handles -- search_term:", search_term)
+        create_detailed_counter_entry(
+            'search_users', 'retrieve_possible_twitter_handles',
+            {'search_term': search_term,  'candidate_name': candidate.candidate_name, 'disambiguator': 1})
         search_results = client.search_users(q=search_term, page=1)
         # TODO ADD SUPPORT FOR: one_result = expand_twitter_public_metrics(one_result)
         search_results.sort(key=lambda possible_candidate: possible_candidate.followers_count, reverse=True)
@@ -1463,6 +1462,11 @@ def retrieve_possible_twitter_handles(candidate):
         try:
             # DALE 2024-01-19 search_users NOT supported by tweepy yet, but Twitter API 2 seems to
             # support it: https://developer.twitter.com/en/docs/twitter-api/users/search/api-reference/get-users-search
+            print("tweepy client.search_users in retrieve_possible_twitter_handles -- modified_search_term:",
+                  modified_search_term)
+            create_detailed_counter_entry(
+                'search_users', 'retrieve_possible_twitter_handles',
+                {'search_term': modified_search_term, 'candidate_name': candidate.candidate_name, 'disambiguator': 2})
             modified_search_results = client.search_users(q=modified_search_term, page=1)
             # TODO ADD SUPPORT FOR: one_result = expand_twitter_public_metrics(one_result)
             modified_search_results.sort(key=lambda possible_candidate: possible_candidate.followers_count, reverse=True)
@@ -1485,6 +1489,11 @@ def retrieve_possible_twitter_handles(candidate):
         try:
             # DALE 2024-01-19 search_users NOT supported by tweepy yet, but Twitter API 2 seems to
             # support it: https://developer.twitter.com/en/docs/twitter-api/users/search/api-reference/get-users-search
+            print("tweepy client.search_users in retrieve_possible_twitter_handles -- modified_search_term_2:",
+                  modified_search_term_2)
+            create_detailed_counter_entry(
+                'search_users', 'retrieve_possible_twitter_handles',
+                {'search_term': modified_search_term_2, 'candidate_name': candidate.candidate_name, 'disambiguator': 3})
             modified_search_results_2 = client.search_users(q=modified_search_term_2, page=1)
             # TODO ADD SUPPORT FOR: one_result = expand_twitter_public_metrics(one_result)
             modified_search_results_2.sort(key=lambda possible_candidate: possible_candidate.followers_count, reverse=True)
@@ -2586,17 +2595,19 @@ def twitter_oauth1_user_handler_for_api(voter_device_id, oauth_token, oauth_veri
     # This is part of leg 3 of 3-legged OAuth flow
 
     try:
+        print("tweepy OAuth1UserHandler (WeVote) in twitter_oauth1_user_handler_for_api -- oauth_token:", oauth_token)
         oauth1_user_handler = tweepy.OAuth1UserHandler(TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET)
         oauth1_user_handler.request_token = {
             "oauth_token": TWITTER_ACCESS_TOKEN,
             "oauth_token_secret": TWITTER_ACCESS_TOKEN_SECRET,
         }
-        print('oauth1_user_handler.get_authorization_url(): ', oauth1_user_handler.get_authorization_url())
+        # print('oauth1_user_handler.get_authorization_url(): ', oauth1_user_handler.get_authorization_url())
 
         request_token = oauth1_user_handler.request_token["oauth_token"]
         request_secret = oauth1_user_handler.request_token["oauth_token_secret"]
-        print('request_token, request_secret: ', request_token, request_secret)
+        # print('request_token, request_secret: ', request_token, request_secret)
 
+        print("tweepy OAuth1UserHandler (voter) in twitter_oauth1_user_handler_for_api -- oauth_token:", oauth_token)
         voters_oauth1_user_handler = tweepy.OAuth1UserHandler(
             request_token, request_secret,
             callback=None
@@ -2611,9 +2622,9 @@ def twitter_oauth1_user_handler_for_api(voter_device_id, oauth_token, oauth_veri
                 oauth_verifier
             )
         )
-        print('voters_access_token, voters_access_token_secret: ', voters_access_token, voters_access_token_secret)
+        # print('voters_access_token, voters_access_token_secret: ', voters_access_token, voters_access_token_secret)
 
-        logger.error("import_export_twitter/controllers.py 2616: session: client = tweepy.Client()")
+        print("tweepy client init. (voter) in twitter_oauth1_user_handler_for_api -- oauth_token:", oauth_token)
         client = tweepy.Client(
             consumer_key=TWITTER_CONSUMER_KEY,
             consumer_secret=TWITTER_CONSUMER_SECRET,
@@ -2621,6 +2632,8 @@ def twitter_oauth1_user_handler_for_api(voter_device_id, oauth_token, oauth_veri
             access_token_secret=voters_access_token_secret
         )
 
+        print("tweepy client get_me (voter) in twitter_oauth1_user_handler_for_api -- oauth_token:", oauth_token)
+        create_detailed_counter_entry('get_me', 'twitter_oauth1_user_handler_for_api', {'text': oauth_token})
         me = client.get_me(user_fields=['id', 'username', 'created_at', 'location', 'description', 'verified',
                                         'profile_image_url'])  # 'followers_count', 'friends_count', 'profile_banner_url',
         # print(me.data)
@@ -2746,6 +2759,7 @@ def twitter_sign_in_start_for_api(voter_device_id, return_url, cordova):  # twit
 
     try:
         # We take the Consumer Key and the Consumer Secret, and request a token & token_secret
+        print("tweepy OAuthHandler (WeVote) in twitter_sign_in_start_for_api -- voter.we_vote_id:", voter.we_vote_id)
         auth = tweepy.OAuthHandler(TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET, callback_url)
         twitter_authorization_url = auth.get_authorization_url()
         request_token_dict = auth.request_token
@@ -2896,6 +2910,8 @@ def twitter_sign_in_request_access_token_for_api(voter_device_id,
     twitter_voters_access_token_secret_secret = ''
     try:
         # We take the Request Token, Request Secret, and OAuth Verifier and request an access_token
+        print("tweepy OAuthHandler (WeVote) in twitter_sign_in_request_access_token_for_api -- incoming_request_token:",
+              incoming_request_token)
         auth = tweepy.OAuthHandler(TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET)
         auth.request_token = {'oauth_token': twitter_auth_response.twitter_request_token,
                               'oauth_token_secret': twitter_auth_response.twitter_request_secret}
@@ -3032,13 +3048,16 @@ def twitter_sign_in_request_voter_info_for_api(voter_device_id, return_url):
 
     try:
         # March 2024, now using Twitter V2 API
-        logger.error("import_export_twitter/controllers.py 3035: session: client = tweepy.Client()")
+        print("tweepy init (WeVote) in twitter_sign_in_request_voter_info_for_api")
         client = tweepy.Client(
             consumer_key=TWITTER_CONSUMER_KEY,
             consumer_secret=TWITTER_CONSUMER_SECRET,
             access_token=TWITTER_ACCESS_TOKEN,
             access_token_secret=TWITTER_ACCESS_TOKEN_SECRET
         )
+
+        print("tweepy client get_me (WeVote) in twitter_sign_in_request_voter_info_for_api")
+        create_detailed_counter_entry('get_me', 'twitter_sign_in_request_voter_info_for_api', {'text': 'For WeVote'})
 
         tweepy_user_object = client.get_me()
         twitter_dict = tweepy_user_object.data

--- a/import_export_twitter/views.py
+++ b/import_export_twitter/views.py
@@ -5,10 +5,6 @@
 # See also WeVoteServer/twitter/views.py for routines that manage internal twitter data
 
 from config.base import get_environment_variable
-from django.http import HttpResponseRedirect
-import tweepy
-from voter.models import VoterManager
-from wevote_functions.functions import positive_value_exists
 
 TWITTER_CONSUMER_KEY = get_environment_variable("TWITTER_CONSUMER_KEY")
 TWITTER_CONSUMER_SECRET = get_environment_variable("TWITTER_CONSUMER_SECRET")

--- a/organization/controllers.py
+++ b/organization/controllers.py
@@ -33,7 +33,7 @@ from position.controllers import delete_positions_for_organization, move_positio
     update_position_entered_details_from_organization
 from position.models import PositionListManager
 from stripe_donations.controllers import move_donation_info_to_another_organization
-from twitter.models import TwitterUserManager
+from twitter.models import TwitterUserManager, create_detailed_counter_entry
 from voter.models import fetch_voter_id_from_voter_device_link, VoterManager, Voter
 from voter_guide.models import VoterGuide, VoterGuideManager, VoterGuideListManager
 from wevote_functions.functions import convert_to_int, \
@@ -604,6 +604,8 @@ def organization_retrieve_tweets_from_twitter(organization_we_vote_id):
 
     # December 2021: Using the Twitter 1.1 API for user_timeline, since it is not yet available in 2.0
     # https://developer.twitter.com/en/docs/twitter-api/migrate/twitter-api-endpoint-map
+    print("tweepy OAuthHandler (Old API, probably in deprecated code) in organization_retrieve_tweets_from_twitter"
+          " -- organization_we_vote_id: ", organization_we_vote_id)
     auth = tweepy.OAuthHandler(TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET)
     auth.set_access_token(TWITTER_ACCESS_TOKEN, TWITTER_ACCESS_TOKEN_SECRET)
     api = tweepy.API(auth)
@@ -613,6 +615,12 @@ def organization_retrieve_tweets_from_twitter(organization_we_vote_id):
     try:
         organization_twitter_id = organization_manager.fetch_twitter_handle_from_organization_we_vote_id(
             organization_we_vote_id)
+        print("tweepy api.user_timeline (Old API, probably in deprecated code) in "
+              "organization_retrieve_tweets_from_twitter -- organization_we_vote_id: ", organization_we_vote_id)
+        create_detailed_counter_entry('user_timeline', 'organization_retrieve_tweets_from_twitter',
+                                      {'voter_we_vote_id': organization_we_vote_id,
+                                       'text': 'Suspect that this code is deprecated'})
+
         new_tweets = api.user_timeline(username=organization_twitter_id)
     except tweepy.errors.HTTPException as e:
         status = "ORGANIZATION_RETRIEVE_TWEETS_FROM_TWITTER_AUTH_FAIL_HTTPException: " + str(e) + " "

--- a/twitter/functions.py
+++ b/twitter/functions.py
@@ -7,6 +7,7 @@ import tweepy
 import wevote_functions.admin
 from config.base import get_environment_variable
 from exception.models import handle_exception
+from twitter.models import create_detailed_counter_entry
 from wevote_functions.functions import positive_value_exists
 
 logger = wevote_functions.admin.get_logger(__name__)
@@ -102,22 +103,13 @@ def retrieve_twitter_user_info(twitter_user_id=0, twitter_handle='', twitter_api
     twitter_user_suspended_by_twitter = False
     write_to_server_logs = False
 
-    # December 2021: Using the Twitter 1.1 API for OAuthHandler, since all other 2.0 apis that we need are not
-    # yet available.
-    # auth = tweepy.OAuthHandler(TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET)
-    # auth.set_access_token(TWITTER_ACCESS_TOKEN, TWITTER_ACCESS_TOKEN_SECRET)
-    #
-    # api = tweepy.API(auth, timeout=10)
-    logger.error("twitter/functions 111: session: client = tweepy.Client() twitter_handle: ", twitter_handle)
+    print("tweepy client init. in retrieve_twitter_user_info -- twitter_handle: ", twitter_handle)
     client = tweepy.Client(
         bearer_token=TWITTER_BEARER_TOKEN,
         consumer_key=TWITTER_CONSUMER_KEY,
         consumer_secret=TWITTER_CONSUMER_SECRET,
         access_token=TWITTER_ACCESS_TOKEN,
         access_token_secret=TWITTER_ACCESS_TOKEN_SECRET)
-    # client = tweepy.Client(
-    #     bearer_token=TWITTER_BEARER_TOKEN,
-    # )
 
     # Strip out the twitter handles "False" or "None"
     if twitter_handle is False:
@@ -136,9 +128,12 @@ def retrieve_twitter_user_info(twitter_user_id=0, twitter_handle='', twitter_api
     try:
         if positive_value_exists(twitter_handle):
             # Use Twitter API call counter to track the number of queries we are doing each day
-            if hasattr(twitter_api_counter_manager, 'create_counter_entry'):
-                twitter_api_counter_manager.create_counter_entry('get_user')
+            # if hasattr(twitter_api_counter_manager, 'create_counter_entry'):
+            #     twitter_api_counter_manager.create_counter_entry('get_user')
 
+            print("tweepy client get_user #1 in retrieve_twitter_user_info -- twitter_handle: ", twitter_handle)
+            create_detailed_counter_entry('get_user', 'retrieve_twitter_user_info',
+                                          {'username': twitter_handle, 'disambiguator': 1})
             twitter_user = client.get_user(
                 username=twitter_handle,
                 user_fields=[
@@ -172,10 +167,13 @@ def retrieve_twitter_user_info(twitter_user_id=0, twitter_handle='', twitter_api
             # status += 'TWITTER_HANDLE_SUCCESS-' + str(twitter_handle) + " "
         elif positive_value_exists(twitter_user_id):
             # Use Twitter API call counter to track the number of queries we are doing each day
-            if hasattr(twitter_api_counter_manager, 'create_counter_entry'):
-                twitter_api_counter_manager.create_counter_entry('get_user')
+            # if hasattr(twitter_api_counter_manager, 'create_counter_entry'):
+            #     twitter_api_counter_manager.create_counter_entry('get_user')
 
             # twitter_user = api.get_user(user_id=twitter_user_id)
+            print("tweepy client get_user #2 in retrieve_twitter_user_info -- twitter_handle: ", twitter_handle)
+            create_detailed_counter_entry('get_user', 'retrieve_twitter_user_info',
+                                          {'username': twitter_handle, 'disambiguator': 2, 'text': twitter_user_id})
             twitter_user = client.get_user(id=twitter_user_id)
             try:
                 twitter_dict = convert_twitter_user_object_data_to_we_vote_dict(twitter_user.data)
@@ -198,6 +196,9 @@ def retrieve_twitter_user_info(twitter_user_id=0, twitter_handle='', twitter_api
         success = False
         status += 'TWITTER_RATE_LIMIT_ERROR: ' + str(rate_limit_error) + " "
         handle_exception(rate_limit_error, logger=logger, exception_message=status)
+        # March 7, 2024 TODO:  We might be able to get useful info in this situation
+        #  https://docs.tweepy.org/en/stable/api.html#tweepy.API.rate_limit_status
+        # https://developer.twitter.com/en/docs/twitter-api/v1/developer-utilities/rate-limit-status/api-reference/get-application-rate_limit_status
     except tweepy.errors.HTTPException as error_instance:
         if 'User not found.' in error_instance.api_messages:
             status += 'TWITTER_USER_NOT_FOUND_ON_TWITTER: ' + str(error_instance) + ' '
@@ -273,7 +274,7 @@ def retrieve_twitter_user_info_from_handles_list(
 
     if retrieve_from_twitter:
         try:
-            logger.error("twitter/functions.py 278: session: client = tweepy.Client()")
+            print("tweepy client init in retrieve_twitter_user_info_from_handles_list")
             client = tweepy.Client(
                 bearer_token=TWITTER_BEARER_TOKEN,
                 consumer_key=TWITTER_CONSUMER_KEY,
@@ -282,9 +283,12 @@ def retrieve_twitter_user_info_from_handles_list(
                 access_token_secret=TWITTER_ACCESS_TOKEN_SECRET)
 
             # Use Twitter API call counter to track the number of queries we are doing each day
-            if hasattr(google_civic_api_counter_manager, 'create_counter_entry'):
-                google_civic_api_counter_manager.create_counter_entry('get_users')
+            # if hasattr(google_civic_api_counter_manager, 'create_counter_entry'):
+            #     google_civic_api_counter_manager.create_counter_entry('get_users')
 
+            create_detailed_counter_entry('get_users', 'retrieve_twitter_user_info_from_handles_list',
+                                          {'text': "".join(twitter_handles_list)})
+            print("tweepy client get_users in retrieve_twitter_user_info_from_handles_list")
             twitter_response = client.get_users(
                 usernames=twitter_handles_list,
                 user_fields=[

--- a/wevote_social/middleware.py
+++ b/wevote_social/middleware.py
@@ -10,7 +10,6 @@ from types import FunctionType
 from django.http import HttpResponse
 
 import wevote_functions.admin
-from config.base import get_environment_variable
 from wevote_social.facebook import FacebookAPI
 
 logger = wevote_functions.admin.get_logger(__name__)
@@ -33,14 +32,9 @@ class SocialMiddleware(object):
         # Code to be executed for each request before
         # the view (and later middleware) are called.
 
-        print('----- request.path: ', request.path)
-        if 'siteConfigurationRetrieve' in request.path:
-            print('----- TWITTER_CONSUMER_KEY:', get_environment_variable("TWITTER_CONSUMER_KEY"),
-                  ' - TWITTER_CONSUMER_SECRET:', get_environment_variable("TWITTER_CONSUMER_SECRET"),
-                  ' - TWITTER_ACCESS_TOKEN:', get_environment_variable("TWITTER_ACCESS_TOKEN"),
-                  ' - TWITTER_ACCESS_TOKEN_SECRET:',  get_environment_variable("TWITTER_ACCESS_TOKEN_SECRET"))
 
         if "/complete/twitter/" in request.path:
+            print('----- request.path: ', request.path)
             # Bypass the state check in middleware for Twitter V2 API and the '/complete/twitter/' request ...
             #   In this case unconditionally return a 200
             print("MIDDLEWARE: object: " + str(request))
@@ -50,10 +44,6 @@ class SocialMiddleware(object):
             ver = request.GET['oauth_verifier'] if request.GET['oauth_verifier'] else ""
             resp = 'https://wevotedeveloper.com:3000/twittersigninprocess?oauth_token=' + tok + '&oauth_verifier=' + ver
             print("MIDDLEWARE: uresp: " + resp)
-            logger.error("MIDDLEWARE: uresp: " + resp)
-            logger.error("MIDDLEWARE: object: " + str(request))
-            logger.error("MIDDLEWARE: headers: " + str(request.headers))
-            logger.error("MIDDLEWARE: session: " + str(self.attributes(request.session)))
 
             # response = redirect(uresp)
             # return response     # TODO FIX THIS RETURN


### PR DESCRIPTION
There are a number of temporary print() everywhere we use the API to do OAuth, in case we are getting charged for those too.

The rate limit problem has to be solved before I can make much headway on Sign In With Twitter in production.
Twitter sign-in worked on my local a week ago, and now it doesn't -- I'll keep working on that.