### PR TITLE
Show the twitter api usage stats displays date in local timezone

### DIFF
--- a/templates/admin_tools/statistics_summary.html
+++ b/templates/admin_tools/statistics_summary.html
@@ -197,7 +197,8 @@
   <script>
     const lim = $('#limit');
     const unlim = $('#unlimited');
-    const twitter_api_limits = JSON.parse($('input#twitter_api_limits').val());
+    const json_limits = $('input#twitter_api_limits').val()
+    const twitter_api_limits = JSON.parse(json_limits);
     // for testing ... twitter_api_limits[6]['remaining'] = 25;
 
     function showAPIRows() {

--- a/twitter/functions.py
+++ b/twitter/functions.py
@@ -5,6 +5,7 @@ import json
 from datetime import datetime
 
 import tweepy
+from dateutil.tz import tz
 
 import wevote_functions.admin
 from config.base import get_environment_variable
@@ -101,11 +102,20 @@ def retrieve_twitter_rate_limit_info():
         output = []
         for key, value in limits_json['resources'].items():
             for endpoint, value2 in value.items():
+                from_zone = tz.tzutc()
+                to_zone = tz.tzlocal()
+                utc_naive = datetime.fromtimestamp(value2['reset'])
+                utc_dt = utc_naive.replace(tzinfo=from_zone)
+                local_dt = utc_dt.astimezone(to_zone)
+                local_tz = datetime.utcnow().astimezone().tzinfo
+                local_tzname = local_tz.tzname(local_dt)
+                reset = local_dt.strftime("%Y-%m-%d  %H:%M:%S") + "  " + local_tzname
+
                 output.append({
                     'endpoint': endpoint,
                     'limit': value2['limit'],
                     'remaining': value2['remaining'],
-                    'reset': str(datetime.fromtimestamp(value2['reset']))
+                    'reset': reset,
                 })
         return json.dumps(output)
     except Exception as e:

--- a/twitter/functions.py
+++ b/twitter/functions.py
@@ -95,7 +95,7 @@ def expand_twitter_public_metrics(twitter_dict):
 
 def retrieve_twitter_rate_limit_info():
     try:
-        auth = tweepy.OAuth2BearerHandler(TWITTER_BEARER_TOKEN)
+        auth = tweepy.OAuth2BearerHandler(TWITTER_BEARER_TOKEN)  # TODO this might need to be NOT bearer token based https://developer.twitter.com/en/docs/twitter-api/v1/rate-limits
         api = tweepy.API(auth)
         limits_json = api.rate_limit_status()   # March 2023, this api is not yet available in Twitter API V2
         # print(json.dumps(limits_json))


### PR DESCRIPTION
This api call relies on the TWITTER_BEARER_TOKEN being configured for the correct account.
Maybe the stats are only based on BEARER_TOKEN requests, which we have none.  I'll try the other OAuth 1.0a tomorrow.