### PR TITLE
Alternate auth for the twitter api usage stats

### DIFF
--- a/twitter/functions.py
+++ b/twitter/functions.py
@@ -95,7 +95,10 @@ def expand_twitter_public_metrics(twitter_dict):
 
 def retrieve_twitter_rate_limit_info():
     try:
-        auth = tweepy.OAuth2BearerHandler(TWITTER_BEARER_TOKEN)  # TODO this might need to be NOT bearer token based https://developer.twitter.com/en/docs/twitter-api/v1/rate-limits
+        # auth = tweepy.OAuth2BearerHandler(TWITTER_BEARER_TOKEN)  # Theory is that this auth only reports rate_limit_status for requests made with a bearer token
+        # See "This limit is considered completely separate from per-application Bearer Token limits."  At https://developer.twitter.com/en/docs/twitter-api/v1/rate-limits
+        auth = tweepy.OAuth2AppHandler(TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET)
+
         api = tweepy.API(auth)
         limits_json = api.rate_limit_status()   # March 2023, this api is not yet available in Twitter API V2
         # print(json.dumps(limits_json))

--- a/wevote_social/middleware.py
+++ b/wevote_social/middleware.py
@@ -34,10 +34,13 @@ class SocialMiddleware(object):
 
 
         if "/complete/twitter/" in request.path:
-            print('----- request.path: ', request.path)
-            # Bypass the state check in middleware for Twitter V2 API and the '/complete/twitter/' request ...
-            #   In this case unconditionally return a 200
+            print('MIDDLEWARE:request.path: ', request.path)
             print("MIDDLEWARE: object: " + str(request))
+            if 'redirect_state' in request.GET:
+                print("MIDDLEWARE: redirect_state: " + request.GET['redirect_state'])
+            else:
+                print("MIDDLEWARE: redirect_state: NO REDIRECT STATE RECEIVED (this is a problem)")
+
             print("MIDDLEWARE: headers: " + str(request.headers))
             print("MIDDLEWARE: session: " + str(self.attributes(request.session)))
             tok = request.GET['oauth_token'] if request.GET['oauth_token'] else ""
@@ -47,9 +50,12 @@ class SocialMiddleware(object):
             respURL = 'https://' + request.headers['Host'] + '/login_we_vote'
             print("MIDDLEWARE: respURL: " + respURL)
 
+            # Bypass the state check in middleware for Twitter V2 API and the '/complete/twitter/' request ...
+            #   In this case unconditionally return a 200
             # response = redirect(respURL)
-            # return response     # TODO FIX THIS RETURN
-            return HttpResponse()
+            # return response
+            # return HttpResponse()       TODO March 13, 2024 ... let fall through in all cases for now
+
 
         response = self.get_response(request)
     # def process_request(self, request):


### PR DESCRIPTION
We are currently showing zero twitter api usage, which is not correct
There is a line on https://developer.twitter.com/en/docs/twitter-api/v1/rate-limits That says about bearer token auth for the api call... "This limit is considered completely separate from per-application Bearer Token limits." 

So switched to auth based on TWITTER_CONSUMER_KEY and TWITTER_CONSUMER_SECRET as an experiment.

ALSO...
I noticed that redirect_state is now (mysteriously) included again in the redirect from twitter to 
https://api.wevoteusa.org/complete/twitter/?redirect_state=tXhUSmxXzuD8Z5ljtrjcT1bN7aBPjT7X&oauth_token=Ta-OGgAAAAABZ4LOAAABjjXbDZo&oauth_verifier=iqdtM4X8VqX69rz8XC0bh4FBSHYLMukL
So took out my code that attempted to deal with the lack of a redirect_state by returning a simulated response in middleware.com (and added some more logging), I suspect/hope that this will allow the sign in with twitter to work on the server. 