### PR TITLE
MERGE READY wv-317 Update candidate edit page to display form inputs on the same line

### DIFF
--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -351,20 +351,26 @@ th, td {
     </div>
 </div>
 
-<div class="form-group">
-    <label for="contest_office_name_id" class="col-sm-3 control-label">Contest Office Name (Cached)</label>
-    <div class="col-sm-8">
+<div class="row">
+<div class="col">
+<div class="row form-group">
+    <label for="contest_office_name_id" class="pl-4">Contest Office Name (Cached)</label>
+    <div class="col">
         <input type="text" name="contest_office_name" id="contest_office_name_id" class="form-control"
                value="{% if candidate %}{{ candidate.contest_office_name|default_if_none:"" }}{% else %}{{ contest_office_name|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="district_name_id" class="col-sm-3 control-label">District Name (Cached)</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="district_name_id" class="control-label">District Name (Cached)</label>
+    <div class="col">
         <input type="text" name="district_name" id="district_name_id" class="form-control"
                value="{% if candidate %}{{ candidate.district_name|default_if_none:"" }}{% else %}{{ district_name|default_if_none:"" }}{% endif %}" />
     </div>
+</div>
+</div>
 </div>
 
 {% if state_code_from_election == "" %}
@@ -425,52 +431,68 @@ th, td {
     </div>
 </div>
 
+<div class="row">
+<div class="col">
 <div class="form-group">
-    <label for="google_civic_candidate_name_id" class="col-sm-3 control-label">Candidate Name1 (for Google Civic matching)</label>
-    <div class="col-sm-8">
+    <label for="google_civic_candidate_name_id" class="pl-4 control-label">Candidate Name1 (for Google Civic matching)</label>
+    <div class="col">
         <input type="text" name="google_civic_candidate_name" id="google_civic_candidate_name_id" class="form-control"
                value="{% if candidate %}{{ candidate.google_civic_candidate_name|default_if_none:"" }}{% else %}{{ google_civic_candidate_name|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
+<div class="col">
 <div class="form-group">
-    <label for="google_civic_candidate_name2_id" class="col-sm-3 control-label">Candidate Name2 (for Google Civic matching)</label>
-    <div class="col-sm-8">
+    <label for="google_civic_candidate_name2_id" class="pl-4 control-label">Candidate Name2 (for Google Civic matching)</label>
+    <div class="col">
         <input type="text" name="google_civic_candidate_name2" id="google_civic_candidate_name2_id" class="form-control"
                value="{% if candidate %}{{ candidate.google_civic_candidate_name2|default_if_none:"" }}{% else %}{{ google_civic_candidate_name2|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
+<div class="col">
 <div class="form-group">
-    <label for="google_civic_candidate_name3_id" class="col-sm-3 control-label">Candidate Name3 (for Google Civic matching)</label>
-    <div class="col-sm-8">
+    <label for="google_civic_candidate_name3_id" class="pl-4 control-label">Candidate Name3 (for Google Civic matching)</label>
+    <div class="col">
         <input type="text" name="google_civic_candidate_name3" id="google_civic_candidate_name3_id" class="form-control"
                value="{% if candidate %}{{ candidate.google_civic_candidate_name3|default_if_none:"" }}{% else %}{{ google_civic_candidate_name3|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
+</div>
 
-<div class="form-group">
-    <label for="ballotpedia_candidate_name_id" class="col-sm-3 control-label">Candidate Name (from Ballotpedia)</label>
-    <div class="col-sm-8">
+<div class="row">
+<div class="col">
+<div class="row form-group">
+    <label for="ballotpedia_candidate_name_id" class="pl-4 control-label">Candidate Name (from Ballotpedia)</label>
+    <div class="col">
         <input type="text" name="ballotpedia_candidate_name" id="ballotpedia_candidate_name_id" class="form-control"
                value="{% if candidate %}{{ candidate.ballotpedia_candidate_name|default_if_none:"" }}{% else %}{{ ballotpedia_candidate_name|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="state_code_id" class="col-sm-3 control-label">Candidate State Code</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="state_code_id" class="control-label">Candidate State Code</label>
+    <div class="col">
         <input type="text" name="state_code" id="state_code_id" class="form-control"
                value="{% if candidate %}{{ candidate.state_code|default_if_none:"" }}{% else %}{{ state_code|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="party_id" class="col-sm-3 control-label">Candidate Party</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="party_id" class="control-label">Candidate Party</label>
+    <div class="col">
         <input type="text" name="party" id="party_id" class="form-control"
                value="{% if candidate %}{{ candidate.party|default_if_none:"" }}{% else %}{{ party|default_if_none:"" }}{% endif %}" />
     </div>
+</div>
+</div>
 </div>
 
 <div class="form-group">

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -495,32 +495,40 @@ th, td {
 </div>
 </div>
 
-<div class="form-group">
-    <label for="vote_usa_politician_id_id" class="col-sm-3 control-label">Vote USA Politician Id</label>
-    <div class="col-sm-8">
+<div class="row">
+<div class="col">
+<div class="row form-group">
+    <label for="vote_usa_politician_id_id" class="pl-4 control-label">Vote USA Politician Id</label>
+    <div class="col">
         <input type="text" name="vote_usa_politician_id" id="vote_usa_politician_id_id" class="form-control"
                value="{% if candidate %}{{ candidate.vote_usa_politician_id|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="vote_usa_office_id_id" class="col-sm-3 control-label">Vote USA Office Id</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="vote_usa_office_id_id" class="control-label">Vote USA Office Id</label>
+    <div class="col">
         <input type="text" name="vote_usa_office_id" id="vote_usa_office_id_id" class="form-control"
                value="{% if candidate %}{{ candidate.vote_usa_office_id|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
+</div>
 
 <a name="twitter_link_possibility_list" />
 
-<div class="form-group">
-    <label for="candidate_twitter_handle_id" class="col-sm-3 control-label">
+<div class="row">
+<div class="col">
+<div class="row form-group">
+    <label for="candidate_twitter_handle_id" class="pl-4 control-label">
         {% if candidate.we_vote_hosted_profile_twitter_image_url_tiny %}
             <img src='{{ candidate.we_vote_hosted_profile_twitter_image_url_tiny }}' />
         {% endif %}
         Twitter Handle
     </label>
-    <div class="col-sm-8">
+    <div class="col">
         <input type="text" name="candidate_twitter_handle" id="candidate_twitter_handle_id" class="form-control"
                value="{% if candidate %}{{ candidate.candidate_twitter_handle|default_if_none:"" }}{% else %}{{ candidate_twitter_handle|default_if_none:"" }}{% endif %}" />
     {% if candidate.candidate_twitter_handle %}
@@ -612,10 +620,12 @@ th, td {
     {% endif %}
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="candidate_twitter_handle2_id" class="col-sm-3 control-label">Twitter Handle 2</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="candidate_twitter_handle2_id" class="control-label">Twitter Handle 2</label>
+    <div class="col">
         <input type="text" name="candidate_twitter_handle2" id="candidate_twitter_handle2_id" class="form-control"
                value="{% if candidate %}{{ candidate.candidate_twitter_handle2|default_if_none:"" }}{% else %}{{ candidate_twitter_handle2|default_if_none:"" }}{% endif %}" />
     {% if candidate.candidate_twitter_handle2 %}
@@ -628,10 +638,12 @@ th, td {
     {% endif %}
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="candidate_twitter_handle3_id" class="col-sm-3 control-label">Twitter Handle 3</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="candidate_twitter_handle3_id" class="control-label">Twitter Handle 3</label>
+    <div class="col">
         <input type="text" name="candidate_twitter_handle3" id="candidate_twitter_handle3_id" class="form-control"
                value="{% if candidate %}{{ candidate.candidate_twitter_handle3|default_if_none:"" }}{% else %}{{ candidate_twitter_handle3|default_if_none:"" }}{% endif %}" />
     {% if candidate.candidate_twitter_handle3 %}
@@ -641,41 +653,49 @@ th, td {
     {% endif %}
     </div>
 </div>
+</div>
+</div>
 
-<div class="form-group">
-    <label for="candidate_url_id" class="col-sm-3 control-label">
+<div class="row">
+<div class="col">
+<div class="row form-group">
+    <label for="candidate_url_id" class="pl-4 control-label">
         Candidate Website
         {% if candidate.candidate_url %}
         <a href="{{ candidate.candidate_url }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
         {% endif %}
     </label>
-    <div class="col-sm-8">
+    <div class="col">
         <input type="text" name="candidate_url" id="candidate_url_id" class="form-control"
                value="{% if candidate %}{{ candidate.candidate_url|default_if_none:"" }}{% else %}{{ candidate_url|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="candidate_contact_form_url_id" class="col-sm-3 control-label">
+<div class="col">
+<div class="row form-group">
+    <label for="candidate_contact_form_url_id" class="control-label">
         Candidate Contact Form
         {% if candidate.candidate_contact_form_url %}
         <a href="{{ candidate.candidate_contact_form_url }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
         {% endif %}
     </label>
-    <div class="col-sm-8">
+    <div class="col">
         <input type="text" name="candidate_contact_form_url" id="candidate_contact_form_url_id" class="form-control"
                value="{% if candidate %}{{ candidate.candidate_contact_form_url|default_if_none:"" }}{% else %}{{ candidate_contact_form_url|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="facebook_url_id" class="col-sm-3 control-label">
+<div class="col">
+<div class="row form-group">
+    <label for="facebook_url_id" class="control-label">
         Facebook URL
         {% if candidate.facebook_url %}
         <a href="{{ candidate.facebook_url }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
         {% endif %}
     </label>
-    <div class="col-sm-8">
+    <div class="col">
         <input type="text" name="facebook_url" id="facebook_url_id" class="form-control"
                value="{% if candidate %}{{ candidate.facebook_url|default_if_none:"" }}{% else %}{{ facebook_url|default_if_none:"" }}{% endif %}" />
       {% if candidate.facebook_url %}
@@ -692,18 +712,22 @@ th, td {
       {% endif %}
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="instagram_handle_id" class="col-sm-3 control-label">
+<div class="col">
+<div class="row form-group">
+    <label for="instagram_handle_id" class="control-label">
         Instagram Handle
         {% if candidate.instagram_handle %}
         <a href="https://www.instagram.com/{{ candidate.instagram_handle }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
         {% endif %}
     </label>
-    <div class="col-sm-8">
+    <div class="col">
         <input type="text" name="instagram_handle" id="instagram_handle_id" class="form-control"
                value="{% if candidate %}{{ candidate.instagram_handle|default_if_none:"" }}{% else %}{{ instagram_handle|default_if_none:"" }}{% endif %}" />
     </div>
+</div>
+</div>
 </div>
 
 <div class="form-group">

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -46,8 +46,8 @@ th, td {
 {% endif %}
 <input name="submit_text" type="submit" value="{% if candidate %}Update Candidate{% else %}Save New Candidate{% endif %}" /></p>
 
-<div class="form-group" style="height: 60px;">
-    <label for="candidate_name_id" class="col-sm-3 control-label">
+<div class="row form-group" style="height: 60px;">
+    <label for="candidate_name_id" class="pl-4 control-label">
       Candidate Name
       {% if candidate %}
         <div>
@@ -70,7 +70,7 @@ th, td {
         {% endif %}
       {% endif %}
     </label>
-    <div class="col-sm-8">
+    <div class="col">
         <input type="text" name="candidate_name" id="candidate_name_id" class="form-control"
                value="{% if candidate %}{{ candidate.candidate_name|default_if_none:"" }}{% else %}{{ candidate_name|default_if_none:"" }}{% endif %}" />
         <div>
@@ -125,12 +125,12 @@ th, td {
 </div>
 
 
-<div class="form-group">
-    <label for="profile_image_type_currently_active_id" class="col-sm-3 control-label">
+<div class="row form-group">
+    <label for="profile_image_type_currently_active_id" class="pl-4 control-label">
         Candidate Photo Choice<br />
         <span style="color: darkgray">{{ candidate.profile_image_type_currently_active }}</span>
     </label>
-    <div class="col-sm-8">
+    <div class="col">
     {# UNKNOWN IMAGE #}
         <span style="float: left; padding: 8px 20px 0 0;">
             <input type="radio" name="profile_image_type_currently_active" value="UNKNOWN"
@@ -222,8 +222,8 @@ th, td {
 </div>
 
 <input type="hidden" name="google_civic_election_id" value="{% if candidate %}{{ candidate.google_civic_election_id }}{% else %}{{ google_civic_election_id }}{% endif %}">
-<div class="form-group">
-    <label for="google_civic_election_id_id" class="col-sm-3 control-label">
+<div class="row form-group">
+    <label for="google_civic_election_id_id" class="pl-4 control-label">
         Candidate to Office Link
         (<span onclick="showElement('candidate_to_office_link_table_add');" style="color: royalblue" >add</span>)
         <span style="color: slategray; font-weight: 400;">
@@ -279,7 +279,7 @@ th, td {
         {% endif %}
         </span>
     </label>
-    <div class="col-sm-8">
+    <div class="col">
     {% if office_name %}
         Adding Candidate to: {{ office_name }}
         <input type="hidden" name="contest_office_id" value="{{ contest_office_id }}">
@@ -385,9 +385,9 @@ th, td {
 
 
     {% if candidate %}
-<div class="form-group">
-    <label for="google_search_image_file_id" class="col-sm-3 control-label">Search Google for Links to Candidate</label>
-    <div class="col-sm-8">
+<div class="row form-group">
+    <label for="google_search_image_file_id" class="pl-4 control-label">Search Google for Links to Candidate</label>
+    <div class="col">
         (<a href="{% url 'google_custom_search:retrieve_possible_google_search_users' candidate.we_vote_id %}">retrieve possibilities from Google</a>)
     {% if google_search_possibility_list %}
         (<a href="{% url 'google_custom_search:delete_possible_google_search_users' candidate.we_vote_id %}">delete these possibilities</a>)
@@ -403,9 +403,9 @@ th, td {
 </div>
     {% endif %}
 
-<div class="form-group">
-    <label for="candidate_withdrawal_date_id" class="col-sm-3 control-label">Candidate Has Withdrawn From Election</label>
-    <div class="col-sm-8">
+<div class="row form-group">
+    <label for="candidate_withdrawal_date_id" class="pl-4 control-label">Candidate Has Withdrawn From Election</label>
+    <div class="col">
         <span style="float: left; padding: 8px 10px 0 0;">
             <input type="radio" name="withdrawn_from_election" value="True"
                 {% if candidate.withdrawn_from_election %} checked {% endif %}
@@ -790,9 +790,9 @@ th, td {
 </div>
 </div>
 
-<div class="form-group">
-    <label for="ballotpedia_candidate_summary_id" class="col-sm-3 control-label">Ballotpedia Candidate Summary</label>
-    <div class="col-sm-8">
+<div class="row form-group">
+    <label for="ballotpedia_candidate_summary_id" class="pl-4 control-label">Ballotpedia Candidate Summary</label>
+    <div class="col">
         <textarea name="ballotpedia_candidate_summary"
                   class="form-control animated"
                   id="ballotpedia_candidate_summary_id"
@@ -800,9 +800,9 @@ th, td {
     </div>
 </div>
 
-<div class="form-group">
-    <label for="ballot_guide_official_statement_id" class="col-sm-3 control-label">Official Candidate Statement</label>
-    <div class="col-sm-8">
+<div class="row form-group">
+    <label for="ballot_guide_official_statement_id" class="pl-4 control-label">Official Candidate Statement</label>
+    <div class="col">
         <textarea name="ballot_guide_official_statement"
                   class="form-control animated"
                   id="ballot_guide_official_statement_id"
@@ -896,11 +896,11 @@ th, td {
 </div>
 </div>
 
-<div class="form-group">
-    <label for="analysis_comment_id" class="col-sm-3 control-label">
+<div class="row form-group">
+    <label for="analysis_comment_id" class="pl-4 control-label">
         Candidate Analysis
     </label>
-    <div class="col-sm-8">
+    <div class="col">
         <textarea name="candidate_analysis_comment"
                   class="form-control animated"
                   id="candidate_analysis_comment_id"

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -730,50 +730,64 @@ th, td {
 </div>
 </div>
 
-<div class="form-group">
-    <label for="linkedin_url_id" class="col-sm-3 control-label">LinkedIn URL</label>
-    <div class="col-sm-8">
+<div class="row">
+<div class="col">
+<div class="row form-group">
+    <label for="linkedin_url_id" class="pl-4 control-label">LinkedIn URL</label>
+    <div class="col">
         <input type="text" name="linkedin_url" id="linkedin_url_id" class="form-control"
                value="{% if candidate %}{{ candidate.linkedin_url|default_if_none:"" }}{% else %}{{ linkedin_url|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="candidate_email_id" class="col-sm-3 control-label">Candidate Email</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="candidate_email_id" class="control-label">Candidate Email</label>
+    <div class="col">
         <input type="text" name="candidate_email" id="candidate_email_id" class="form-control"
                value="{% if candidate %}{{ candidate.candidate_email|default_if_none:"" }}{% else %}{{ candidate_email|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="candidate_phone_id" class="col-sm-3 control-label">Candidate Phone</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="candidate_phone_id" class="control-label">Candidate Phone</label>
+    <div class="col">
         <input type="text" name="candidate_phone" id="candidate_phone_id" class="form-control"
                value="{% if candidate %}{{ candidate.candidate_phone|default_if_none:"" }}{% else %}{{ candidate_phone|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
+</div>
 
-<div class="form-group">
-    <label for="ballotpedia_candidate_url_id" class="col-sm-3 control-label">
+<div class="row">
+<div class="col">
+<div class="row form-group">
+    <label for="ballotpedia_candidate_url_id" class="pl-4 control-label">
         Ballotpedia Candidate Page
         {% if candidate and candidate.ballotpedia_candidate_url %}(<a href="{{ candidate.ballotpedia_candidate_url }}" target="_blank">Go</a>){% endif %}
     </label>
-    <div class="col-sm-8">
+    <div class="col">
         <input type="text" name="ballotpedia_candidate_url" id="ballotpedia_candidate_url_id" class="form-control"
                value="{% if candidate %}{{ candidate.ballotpedia_candidate_url|default_if_none:"" }}{% else %}{{ ballotpedia_candidate_url|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="wikipedia_url_id" class="col-sm-3 control-label">
+<div class="col">
+<div class="row form-group">
+    <label for="wikipedia_url_id" class="control-label">
         Wikipedia URL
         {% if candidate and candidate.wikipedia_url %}(<a href="{{ candidate.wikipedia_url }}" target="_blank">Go</a>){% endif %}
     </label>
-    <div class="col-sm-8">
+    <div class="col">
         <input type="text" name="wikipedia_url" id="wikipedia_url_id" class="form-control"
                value="{% if candidate %}{{ candidate.wikipedia_url|default_if_none:"" }}{% else %}{{ wikipedia_url|default_if_none:"" }}{% endif %}" />
     </div>
+</div>
+</div>
 </div>
 
 <div class="form-group">
@@ -796,56 +810,71 @@ th, td {
     </div>
 </div>
 
-<div class="form-group">
-    <label for="ballotpedia_race_id_id" class="col-sm-3 control-label">Ballotpedia Race Id</label>
-    <div class="col-sm-8">
+<div class="row">
+<div class="col">
+<div class="row form-group">
+    <label for="ballotpedia_race_id_id" class="pl-4 control-label">Ballotpedia Race Id</label>
+    <div class="col">
         <input type="text" name="ballotpedia_race_id" id="ballotpedia_race_id_id" class="form-control"
                value="{% if candidate %}{{ candidate.ballotpedia_race_id|default_if_none:"" }}{% else %}{{ ballotpedia_race_id|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="ballotpedia_office_id_id" class="col-sm-3 control-label">Ballotpedia Office Held Id</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="ballotpedia_office_id_id" class="control-label">Ballotpedia Office Held Id</label>
+    <div class="col">
         <input type="text" name="ballotpedia_office_id" id="ballotpedia_office_id_id" class="form-control"
                value="{% if candidate %}{{ candidate.ballotpedia_office_id|default_if_none:"" }}{% else %}{{ ballotpedia_office_id|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="ballotpedia_candidate_id_id" class="col-sm-3 control-label">Ballotpedia Candidate Id</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="ballotpedia_candidate_id_id" class="control-label">Ballotpedia Candidate Id</label>
+    <div class="col">
         <input type="text" name="ballotpedia_candidate_id" id="ballotpedia_candidate_id_id" class="form-control"
                value="{% if candidate %}{{ candidate.ballotpedia_candidate_id|default_if_none:"" }}{% else %}{{ ballotpedia_candidate_id|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="ballotpedia_person_id_id" class="col-sm-3 control-label">Ballotpedia Person Id</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="ballotpedia_person_id_id" class="control-label">Ballotpedia Person Id</label>
+    <div class="col">
         <input type="text" name="ballotpedia_person_id" id="ballotpedia_person_id_id" class="form-control"
                value="{% if candidate %}{{ candidate.ballotpedia_person_id|default_if_none:"" }}{% else %}{{ ballotpedia_person_id|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
+</div>
 
-<div class="form-group">
-    <label for="photo_url_from_vote_usa_id" class="col-sm-3 control-label">
+<div class="row">
+<div class="col">
+<div class="row form-group">
+    <label for="photo_url_from_vote_usa_id" class="pl-4 control-label">
         {% if candidate.photo_url_from_vote_usa %}
             <img src='{{ candidate.photo_url_from_vote_usa }}' height="48" />
         {% endif %}
         Vote USA Image</label>
-    <div class="col-sm-8">
+    <div class="col">
         <input type="text" name="photo_url_from_vote_usa" id="photo_url_from_vote_usa_id" class="form-control"
                value="{% if candidate %}{{ candidate.photo_url_from_vote_usa|default_if_none:"" }}{% endif %}" />
     </div>
 </div>
+</div>
 
-<div class="form-group">
-    <label for="vote_smart_id_id" class="col-sm-3 control-label">Vote Smart Id</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="vote_smart_id_id" class="control-label">Vote Smart Id</label>
+    <div class="col">
         <input type="text" name="vote_smart_id" id="vote_smart_id_id" class="form-control"
                value="{% if candidate %}{{ candidate.vote_smart_id|default_if_none:"" }}{% else %}{{ vote_smart_id|default_if_none:"" }}{% endif %}" />
     </div>
+</div>
 </div>
 
 {#<div class="form-group">#}
@@ -856,12 +885,15 @@ th, td {
 {#    </div>#}
 {#</div>#}
 
-<div class="form-group">
-    <label for="youtube_url_id" class="col-sm-3 control-label">YouTube URL</label>
-    <div class="col-sm-8">
+<div class="col">
+<div class="row form-group">
+    <label for="youtube_url_id" class="control-label">YouTube URL</label>
+    <div class="col">
         <input type="text" name="youtube_url" id="youtube_url_id" class="form-control"
                value="{% if candidate %}{{ candidate.youtube_url|default_if_none:"" }}{% else %}{{ youtube_url|default_if_none:"" }}{% endif %}" />
     </div>
+</div>
+</div>
 </div>
 
 <div class="form-group">

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -387,7 +387,7 @@ th, td {
     {% if candidate %}
 <div class="row form-group">
     <label for="google_search_image_file_id" class="pl-4 control-label">Search Google for Links to Candidate</label>
-    <div class="col">
+    <div class="col d-flex align-items-end">
         (<a href="{% url 'google_custom_search:retrieve_possible_google_search_users' candidate.we_vote_id %}">retrieve possibilities from Google</a>)
     {% if google_search_possibility_list %}
         (<a href="{% url 'google_custom_search:delete_possible_google_search_users' candidate.we_vote_id %}">delete these possibilities</a>)
@@ -404,7 +404,7 @@ th, td {
     {% endif %}
 
 <div class="row form-group">
-    <label for="candidate_withdrawal_date_id" class="pl-4 control-label">Candidate Has Withdrawn From Election</label>
+    <label for="candidate_withdrawal_date_id" class="pl-4 control-label  d-flex align-items-end">Candidate Has Withdrawn From Election</label>
     <div class="col">
         <span style="float: left; padding: 8px 10px 0 0;">
             <input type="radio" name="withdrawn_from_election" value="True"
@@ -686,10 +686,12 @@ th, td {
     </div>
 </div>
 </div>
+</div>
 
+<div class="row">
 <div class="col">
 <div class="row form-group">
-    <label for="facebook_url_id" class="control-label">
+    <label for="facebook_url_id" class="pl-4 control-label">
         Facebook URL
         {% if candidate.facebook_url %}
         <a href="{{ candidate.facebook_url }}" target="_blank"><span class="glyphicon glyphicon-new-window"></span></a>
@@ -876,6 +878,7 @@ th, td {
     </div>
 </div>
 </div>
+</div>
 
 {#<div class="form-group">#}
 {#    <label for="maplight_id_id" class="col-sm-3 control-label">MapLight Id</label>#}
@@ -885,15 +888,12 @@ th, td {
 {#    </div>#}
 {#</div>#}
 
-<div class="col">
 <div class="row form-group">
-    <label for="youtube_url_id" class="control-label">YouTube URL</label>
+    <label for="youtube_url_id" class="pl-4 control-label">YouTube URL</label>
     <div class="col">
         <input type="text" name="youtube_url" id="youtube_url_id" class="form-control"
                value="{% if candidate %}{{ candidate.youtube_url|default_if_none:"" }}{% else %}{{ youtube_url|default_if_none:"" }}{% endif %}" />
     </div>
-</div>
-</div>
 </div>
 
 <div class="row form-group">

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -404,7 +404,7 @@ th, td {
     {% endif %}
 
 <div class="row form-group">
-    <label for="candidate_withdrawal_date_id" class="pl-4 control-label  d-flex align-items-end">Candidate Has Withdrawn From Election</label>
+    <label for="candidate_withdrawal_date_id" class="pl-4 control-label  d-flex align-items-center">Candidate Has Withdrawn From Election</label>
     <div class="col">
         <span style="float: left; padding: 8px 10px 0 0;">
             <input type="radio" name="withdrawn_from_election" value="True"


### PR DESCRIPTION
Update 3/22/24: Moved `Facebook URL` and `Instagram Handle` form groups to their own line, moved `YouTube URL` to its own line, and fixed alignment of `Candidate Has Withdrawn From Election` so that all labels and inputs are vertically centered/aligned with each other.

![image](https://github.com/wevote/WeVoteServer/assets/89757407/0df5f32b-9962-45fe-8165-f8034322f156)
![image](https://github.com/wevote/WeVoteServer/assets/89757407/87f948c5-2eaf-432c-bcc4-62a9454bd3c6)


