### PR TITLE
Update dependencies for Python 3.12.2 (Part 2)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 boto3==1.34.66
 CacheControl==0.13.1
 cloudscraper==1.2.68
-cryptography==42.0.5
+cryptography==3.4.8
+# cryptography==41.0.7  # Does not seem compatible with Python 3.9
 dj-database-url==0.5.0
 dj-static==0.0.6
 Django==3.2.25
@@ -32,7 +33,7 @@ nameparser==1.1.3
 oauth2client==4.1.3
 oauthlib==3.2.2
 phonenumbers==8.13.26
-Pillow==10.2.0
+Pillow==9.4.0
 psycopg2-binary==2.9.3
 py3dns==4.0.1
 pyasn1==0.4.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
-boto3==1.26.46
+boto3==1.34.66
 CacheControl==0.13.1
 cloudscraper==1.2.68
 cryptography==3.4.8
 # cryptography==41.0.7  # Does not seem compatible with Python 3.9
 dj-database-url==0.5.0
 dj-static==0.0.6
-Django==3.2.24
-# django-allow-cidr==0.7.1
+Django==3.2.25
 django-background-tasks==1.2.5
 django-bootstrap3==15.0.0
 django-cors-headers==3.7.0
@@ -36,7 +35,7 @@ oauthlib==3.2.2
 phonenumbers==8.13.26
 Pillow==9.4.0
 psycopg2-binary==2.9.3
-py3dns==3.2.1
+py3dns==4.0.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pygeoip==0.3.2
@@ -45,20 +44,20 @@ PyJWT==2.8.0
 pyparsing==2.4.7
 python-dateutil~=2.8.2
 python-magic==0.4.24  # Requires "brew install libmagic" or "brew upgrade libmagic" or "pip install libmagic"
-python3-openid -e git+git://github.com/wevote/python3-openid.git@master#egg=python3-openid
+python3-openid @ git+https://github.com/wevote/python3-openid.git@master#egg=python3-openid
 pytz==2021.1
 requests==2.31.0
 requests-oauthlib==1.3.0
 robot-detection==0.4
 rsa==4.7.2
-selenium==4.15.1
+ruff==0.2.2
 sendgrid==6.9.7
 simplejson==3.17.2
-six==1.14.0
+six==1.16.0
 social-auth-app-django==5.0.0
 social-auth-core==4.2.0
 static3==0.7.0
-stripe==2.58.0
+stripe==8.7.0
 tweepy==4.14.0
 twilio==7.8.2
 uritemplate==3.0.1
@@ -67,6 +66,6 @@ user-agents==1.1.0
 validate-email==1.3
 wikipedia==1.4.0
 xmltodict==0.12.0
-certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
+certifi>=2024.2.2 # Want to update continuously to the latest.  Root Certificates used by Requests in Python
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
-setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
+setuptools>=68.0.0 # Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ cryptography==3.4.8
 dj-database-url==0.5.0
 dj-static==0.0.6
 Django==3.2.25
-# django-allow-cidr==0.7.1
 django-background-tasks==1.2.5
 django-bootstrap3==15.0.0
 django-cors-headers==3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cryptography==3.4.8
 # cryptography==41.0.7  # Does not seem compatible with Python 3.9
 dj-database-url==0.5.0
 dj-static==0.0.6
-Django==3.2.25
+Django==3.2.24
 # django-allow-cidr==0.7.1
 django-background-tasks==1.2.5
 django-bootstrap3==15.0.0
@@ -51,7 +51,7 @@ requests==2.31.0
 requests-oauthlib==1.3.0
 robot-detection==0.4
 rsa==4.7.2
-ruff==0.2.2
+selenium==4.15.1
 sendgrid==6.9.7
 simplejson==3.17.2
 six==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,6 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.2.2
 sendgrid==6.9.7
-setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
 simplejson==3.17.2
 six==1.14.0
 social-auth-app-django==5.0.0
@@ -70,3 +69,4 @@ wikipedia==1.4.0
 xmltodict==0.12.0
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.2.2
 sendgrid==6.9.7
-# setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
+setuptools>69.0.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
 simplejson==3.17.2
 six==1.14.0
 social-auth-app-django==5.0.0
@@ -70,4 +70,4 @@ wikipedia==1.4.0
 xmltodict==0.12.0
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
-setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
+#setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cryptography==3.4.8
 dj-database-url==0.5.0
 dj-static==0.0.6
 Django==3.2.25
-jango-background-tasks==1.2.5
+django-background-tasks==1.2.5
 django-bootstrap3==15.0.0
 django-cors-headers==3.7.0
 django-crispy-forms==1.12.0
@@ -52,7 +52,7 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.2.2
 sendgrid==6.9.7
-setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in 3.12, but still needed by some slow to update packages)
+setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
 simplejson==3.17.2
 six==1.14.0
 social-auth-app-django==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,7 @@ cryptography==3.4.8
 dj-database-url==0.5.0
 dj-static==0.0.6
 Django==3.2.25
-# django-allow-cidr==0.7.1
-django-background-tasks==1.2.5
+jango-background-tasks==1.2.5
 django-bootstrap3==15.0.0
 django-cors-headers==3.7.0
 django-crispy-forms==1.12.0
@@ -53,7 +52,7 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.2.2
 sendgrid==6.9.7
-setuptools>=69.0.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
+setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
 simplejson==3.17.2
 six==1.14.0
 social-auth-app-django==5.0.0
@@ -70,4 +69,4 @@ wikipedia==1.4.0
 xmltodict==0.12.0
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
-#setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 boto3==1.34.66
 CacheControl==0.13.1
 cloudscraper==1.2.68
-cryptography==3.4.8
-# cryptography==41.0.7  # Does not seem compatible with Python 3.9
+cryptography==42.0.5
 dj-database-url==0.5.0
 dj-static==0.0.6
 Django==3.2.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.46
+boto3==1.34.66
 CacheControl==0.13.1
 cloudscraper==1.2.68
 cryptography==3.4.8
@@ -36,7 +36,7 @@ oauthlib==3.2.2
 phonenumbers==8.13.26
 Pillow==9.4.0
 psycopg2-binary==2.9.3
-py3dns==4.0.1
+py3dns==3.2.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pygeoip==0.3.2
@@ -53,13 +53,12 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.2.2
 sendgrid==6.9.7
-setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
 simplejson==3.17.2
-six==1.14.0
+six==1.16.0
 social-auth-app-django==5.0.0
 social-auth-core==4.2.0
 static3==0.7.0
-stripe==2.58.0
+stripe==8.7.0
 tweepy==4.14.0
 twilio==7.8.2
 uritemplate==3.0.1
@@ -68,6 +67,7 @@ user-agents==1.1.0
 validate-email==1.3
 wikipedia==1.4.0
 xmltodict==0.12.0
-certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
+certifi>=2024.2.2 # Want to update continuously to the latest.  Root Certificates used by Requests (within Python)
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
-setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
+setuptools>=68.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,6 @@ user-agents==1.1.0
 validate-email==1.3
 wikipedia==1.4.0
 xmltodict==0.12.0
-certifi>=2024.2.2 # Want to update continuously to the latest.  Root Certificates used by Requests in Python
+certifi>=2024.2.2 # Want to update continuously to the latest Root Certificates used by Requests in Python
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=68.0.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ cryptography==3.4.8
 dj-database-url==0.5.0
 dj-static==0.0.6
 Django==3.2.25
+# django-allow-cidr==0.7.1
 django-background-tasks==1.2.5
 django-bootstrap3==15.0.0
 django-cors-headers==3.7.0
@@ -35,7 +36,7 @@ oauthlib==3.2.2
 phonenumbers==8.13.26
 Pillow==9.4.0
 psycopg2-binary==2.9.3
-py3dns==4.0.1
+py3dns==3.2.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pygeoip==0.3.2
@@ -52,7 +53,6 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.2.2
 sendgrid==6.9.7
-setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
 simplejson==3.17.2
 six==1.14.0
 social-auth-app-django==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.46
+boto3==1.34.66
 CacheControl==0.13.1
 cloudscraper==1.2.68
 cryptography==3.4.8
@@ -70,4 +70,3 @@ wikipedia==1.4.0
 xmltodict==0.12.0
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
-setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.2.2
 sendgrid==6.9.7
-setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
+setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in 3.12, but still needed by some slow to update packages)
 simplejson==3.17.2
 six==1.14.0
 social-auth-app-django==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.34.66
+boto3==1.26.46
 CacheControl==0.13.1
 cloudscraper==1.2.68
 cryptography==3.4.8
@@ -6,6 +6,7 @@ cryptography==3.4.8
 dj-database-url==0.5.0
 dj-static==0.0.6
 Django==3.2.25
+# django-allow-cidr==0.7.1
 django-background-tasks==1.2.5
 django-bootstrap3==15.0.0
 django-cors-headers==3.7.0
@@ -44,7 +45,7 @@ PyJWT==2.8.0
 pyparsing==2.4.7
 python-dateutil~=2.8.2
 python-magic==0.4.24  # Requires "brew install libmagic" or "brew upgrade libmagic" or "pip install libmagic"
-python3-openid @ git+https://github.com/wevote/python3-openid.git@master#egg=python3-openid
+python3-openid -e git+git://github.com/wevote/python3-openid.git@master#egg=python3-openid
 pytz==2021.1
 requests==2.31.0
 requests-oauthlib==1.3.0
@@ -52,12 +53,13 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.2.2
 sendgrid==6.9.7
+setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
 simplejson==3.17.2
-six==1.16.0
+six==1.14.0
 social-auth-app-django==5.0.0
 social-auth-core==4.2.0
 static3==0.7.0
-stripe==8.7.0
+stripe==2.58.0
 tweepy==4.14.0
 twilio==7.8.2
 uritemplate==3.0.1
@@ -66,6 +68,6 @@ user-agents==1.1.0
 validate-email==1.3
 wikipedia==1.4.0
 xmltodict==0.12.0
-certifi>=2024.2.2 # Want to update continuously to the latest Root Certificates used by Requests in Python
+certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
-setuptools>=68.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,6 @@ user-agents==1.1.0
 validate-email==1.3
 wikipedia==1.4.0
 xmltodict==0.12.0
-certifi>=2024.2.2 # Want to update continuously to the latest.  Root Certificates used by Requests (within Python)
+certifi>=2024.2.2 # Want to update continuously to the latest.  Root Certificates used by Requests in Python
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=68.0.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.34.66
+boto3==1.26.46
 CacheControl==0.13.1
 cloudscraper==1.2.68
 cryptography==3.4.8
@@ -53,7 +53,7 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.2.2
 sendgrid==6.9.7
-setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
+# setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
 simplejson==3.17.2
 six==1.14.0
 social-auth-app-django==5.0.0
@@ -70,3 +70,4 @@ wikipedia==1.4.0
 xmltodict==0.12.0
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.2.2
 sendgrid==6.9.7
-setuptools>69.0.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
+setuptools>=69.0.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
 simplejson==3.17.2
 six==1.14.0
 social-auth-app-django==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ PyJWT==2.8.0
 pyparsing==2.4.7
 python-dateutil~=2.8.2
 python-magic==0.4.24  # Requires "brew install libmagic" or "brew upgrade libmagic" or "pip install libmagic"
-python3-openid -e git+git://github.com/wevote/python3-openid.git@master#egg=python3-openid
+python3-openid @ git+https://github.com/wevote/python3-openid.git@master#egg=python3-openid
 pytz==2021.1
 requests==2.31.0
 requests-oauthlib==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,4 +69,3 @@ xmltodict==0.12.0
 certifi>=2024.2.2 # Want to update continuously to the latest.  Root Certificates used by Requests (within Python)
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=68.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ oauthlib==3.2.2
 phonenumbers==8.13.26
 Pillow==9.4.0
 psycopg2-binary==2.9.3
-py3dns==3.2.1
+py3dns==4.0.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pygeoip==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,7 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.2.2
 sendgrid==6.9.7
+setuptools==69.2.0     # (Deprecated in Py 3.10, AND removed in Py 3.12, but still needed by some slow to update packages) "Deprecated in Python 3.10 by PEP 632 “Deprecate distutils module”. For projects still using distutils and cannot be updated to something else, the setuptools project can be installed: it still provides distutils. (Contributed by Victor Stinner in gh-92584.)"
 simplejson==3.17.2
 six==1.14.0
 social-auth-app-django==5.0.0
@@ -69,4 +70,3 @@ wikipedia==1.4.0
 xmltodict==0.12.0
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 protobuf>=3.18.3 # not directly required, pinned by Snyk to avoid a vulnerability
-setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ nameparser==1.1.3
 oauth2client==4.1.3
 oauthlib==3.2.2
 phonenumbers==8.13.26
-Pillow==9.4.0
+Pillow==10.2.0
 psycopg2-binary==2.9.3
 py3dns==4.0.1
 pyasn1==0.4.8


### PR DESCRIPTION
Some more depencies that you only run into when running `python manage.py makemigrations`

See https://wevoteusa.atlassian.net/jira/software/projects/WV/issues/WV-327