### PR TITLE
Updated candidate change tracking, and extended to politician_edit. Added more volunteer tasks that add to volunteer scorecard. When we try to retrieve a twitter handle which isn't found, we create a local TwitterUser cache now (a stub), so we know to not keep checking until the "freshness" expires.

### DIFF
--- a/image/controllers.py
+++ b/image/controllers.py
@@ -25,7 +25,8 @@ from twitter.models import TwitterUserManager
 from voter.models import VoterManager, VoterDeviceLink, VoterDeviceLinkManager, VoterAddressManager, Voter
 from voter_guide.models import VoterGuideManager
 from wevote_functions.functions import positive_value_exists, convert_to_int
-from .functions import analyze_remote_url, analyze_image_file, analyze_image_in_memory
+from .functions import analyze_remote_url, analyze_image_file, analyze_image_in_memory, \
+    change_default_profile_image_if_needed
 from .models import WeVoteImageManager, WeVoteImage, \
     CHOSEN_FAVICON_NAME, CHOSEN_LOGO_NAME, CHOSEN_SOCIAL_SHARE_IMAGE_NAME, \
     FACEBOOK_PROFILE_IMAGE_NAME, FACEBOOK_BACKGROUND_IMAGE_NAME, \
@@ -4866,74 +4867,67 @@ def organize_object_photo_fields_based_on_image_type_currently_active(
     # Now move selected field into master politician image
     if uploaded_image_exists and \
             object_with_photo_fields.profile_image_type_currently_active == PROFILE_IMAGE_TYPE_UPLOADED:
-        object_with_photo_fields.we_vote_hosted_profile_image_url_large = \
-            object_with_photo_fields.we_vote_hosted_profile_uploaded_image_url_large
-        object_with_photo_fields.we_vote_hosted_profile_image_url_medium = \
-            object_with_photo_fields.we_vote_hosted_profile_uploaded_image_url_medium
-        object_with_photo_fields.we_vote_hosted_profile_image_url_tiny = \
-            object_with_photo_fields.we_vote_hosted_profile_uploaded_image_url_tiny
-        profile_image_default_updated = True
-        save_changes = True
+        results = change_default_profile_image_if_needed(
+            object_with_photo_fields=object_with_photo_fields,
+            new_profile_image_key='we_vote_hosted_profile_uploaded_image_url')
+        if results['save_changes']:
+            object_with_photo_fields = results['object_with_photo_fields']
+            profile_image_default_updated = True
+            save_changes = True
     elif ballotpedia_image_exists and \
-         object_with_photo_fields.profile_image_type_currently_active == PROFILE_IMAGE_TYPE_BALLOTPEDIA:
-        object_with_photo_fields.we_vote_hosted_profile_image_url_large = \
-            object_with_photo_fields.we_vote_hosted_profile_ballotpedia_image_url_large
-        object_with_photo_fields.we_vote_hosted_profile_image_url_medium = \
-            object_with_photo_fields.we_vote_hosted_profile_ballotpedia_image_url_medium
-        object_with_photo_fields.we_vote_hosted_profile_image_url_tiny = \
-            object_with_photo_fields.we_vote_hosted_profile_ballotpedia_image_url_tiny
-        profile_image_default_updated = True
-        save_changes = True
+            object_with_photo_fields.profile_image_type_currently_active == PROFILE_IMAGE_TYPE_BALLOTPEDIA:
+        results = change_default_profile_image_if_needed(
+            object_with_photo_fields=object_with_photo_fields,
+            new_profile_image_key='we_vote_hosted_profile_ballotpedia_image_url')
+        if results['save_changes']:
+            object_with_photo_fields = results['object_with_photo_fields']
+            profile_image_default_updated = True
+            save_changes = True
     elif twitter_image_exists and \
             object_with_photo_fields.profile_image_type_currently_active == PROFILE_IMAGE_TYPE_TWITTER:
-        object_with_photo_fields.we_vote_hosted_profile_image_url_large = \
-            object_with_photo_fields.we_vote_hosted_profile_twitter_image_url_large
-        object_with_photo_fields.we_vote_hosted_profile_image_url_medium = \
-            object_with_photo_fields.we_vote_hosted_profile_twitter_image_url_medium
-        object_with_photo_fields.we_vote_hosted_profile_image_url_tiny = \
-            object_with_photo_fields.we_vote_hosted_profile_twitter_image_url_tiny
-        profile_image_default_updated = True
-        save_changes = True
+        results = change_default_profile_image_if_needed(
+            object_with_photo_fields=object_with_photo_fields,
+            new_profile_image_key='we_vote_hosted_profile_twitter_image_url')
+        if results['save_changes']:
+            object_with_photo_fields = results['object_with_photo_fields']
+            profile_image_default_updated = True
+            save_changes = True
     elif facebook_image_exists and \
             object_with_photo_fields.profile_image_type_currently_active == PROFILE_IMAGE_TYPE_FACEBOOK:
-        object_with_photo_fields.we_vote_hosted_profile_image_url_large = \
-            object_with_photo_fields.we_vote_hosted_profile_facebook_image_url_large
-        object_with_photo_fields.we_vote_hosted_profile_image_url_medium = \
-            object_with_photo_fields.we_vote_hosted_profile_facebook_image_url_medium
-        object_with_photo_fields.we_vote_hosted_profile_image_url_tiny = \
-            object_with_photo_fields.we_vote_hosted_profile_facebook_image_url_tiny
-        profile_image_default_updated = True
-        save_changes = True
+        results = change_default_profile_image_if_needed(
+            object_with_photo_fields=object_with_photo_fields,
+            new_profile_image_key='we_vote_hosted_profile_facebook_image_url')
+        if results['save_changes']:
+            object_with_photo_fields = results['object_with_photo_fields']
+            profile_image_default_updated = True
+            save_changes = True
     elif linkedin_image_exists and \
-         object_with_photo_fields.profile_image_type_currently_active == PROFILE_IMAGE_TYPE_LINKEDIN:
-        object_with_photo_fields.we_vote_hosted_profile_image_url_large = \
-            object_with_photo_fields.we_vote_hosted_profile_linkedin_image_url_large
-        object_with_photo_fields.we_vote_hosted_profile_image_url_medium = \
-            object_with_photo_fields.we_vote_hosted_profile_linkedin_image_url_medium
-        object_with_photo_fields.we_vote_hosted_profile_image_url_tiny = \
-            object_with_photo_fields.we_vote_hosted_profile_linkedin_image_url_tiny
-        profile_image_default_updated = True
-        save_changes = True
+            object_with_photo_fields.profile_image_type_currently_active == PROFILE_IMAGE_TYPE_LINKEDIN:
+        results = change_default_profile_image_if_needed(
+            object_with_photo_fields=object_with_photo_fields,
+            new_profile_image_key='we_vote_hosted_profile_linkedin_image_url')
+        if results['save_changes']:
+            object_with_photo_fields = results['object_with_photo_fields']
+            profile_image_default_updated = True
+            save_changes = True
     elif wikipedia_image_exists and \
-         object_with_photo_fields.profile_image_type_currently_active == PROFILE_IMAGE_TYPE_WIKIPEDIA:
-        object_with_photo_fields.we_vote_hosted_profile_image_url_large = \
-            object_with_photo_fields.we_vote_hosted_profile_wikipedia_image_url_large
-        object_with_photo_fields.we_vote_hosted_profile_image_url_medium = \
-            object_with_photo_fields.we_vote_hosted_profile_wikipedia_image_url_medium
-        object_with_photo_fields.we_vote_hosted_profile_image_url_tiny = \
-            object_with_photo_fields.we_vote_hosted_profile_wikipedia_image_url_tiny
-        profile_image_default_updated = True
-        save_changes = True
+            object_with_photo_fields.profile_image_type_currently_active == PROFILE_IMAGE_TYPE_WIKIPEDIA:
+        results = change_default_profile_image_if_needed(
+            object_with_photo_fields=object_with_photo_fields,
+            new_profile_image_key='we_vote_hosted_profile_wikipedia_image_url')
+        if results['save_changes']:
+            object_with_photo_fields = results['object_with_photo_fields']
+            profile_image_default_updated = True
+            save_changes = True
     elif vote_usa_image_exists and \
             object_with_photo_fields.profile_image_type_currently_active == PROFILE_IMAGE_TYPE_VOTE_USA:
-        object_with_photo_fields.we_vote_hosted_profile_image_url_large = \
-            object_with_photo_fields.we_vote_hosted_profile_vote_usa_image_url_large
-        object_with_photo_fields.we_vote_hosted_profile_image_url_medium = \
-            object_with_photo_fields.we_vote_hosted_profile_vote_usa_image_url_medium
-        object_with_photo_fields.we_vote_hosted_profile_image_url_tiny = \
-            object_with_photo_fields.we_vote_hosted_profile_vote_usa_image_url_tiny
-        profile_image_default_updated = True
-        save_changes = True
+        results = change_default_profile_image_if_needed(
+            object_with_photo_fields=object_with_photo_fields,
+            new_profile_image_key='we_vote_hosted_profile_vote_usa_image_url')
+        if results['save_changes']:
+            object_with_photo_fields = results['object_with_photo_fields']
+            profile_image_default_updated = True
+            save_changes = True
 
     results = {
         'success':                          success,

--- a/image/functions.py
+++ b/image/functions.py
@@ -113,3 +113,52 @@ def analyze_image_in_memory(image_in_memory):
         'image_format':                 image_format.lower() if image_format is not None else image_format
     }
     return results
+
+
+def change_default_profile_image_if_needed(
+        object_with_photo_fields=None,
+        new_profile_image_key=''):
+    at_least_one_change = False
+    new_profile_image_key_large = ''
+    new_profile_image_key_medium = ''
+    new_profile_image_key_tiny = ''
+    save_changes = False
+    status = ''
+    success = True
+
+    if not hasattr(object_with_photo_fields, 'we_vote_hosted_profile_image_url_large'):
+        status += "NOT_VALID_OBJECT_WITH_PHOTO_FIELDS "
+        success = False
+    try:
+        new_profile_image_key_large = new_profile_image_key + "_large"
+        if not hasattr(object_with_photo_fields, new_profile_image_key_large):
+            status += "MISSING_NEW_PROFILE_IMAGE_URL_LARGE_ATTRIBUTE "
+            success = False
+        new_profile_image_key_medium = new_profile_image_key + "_medium"
+        new_profile_image_key_tiny = new_profile_image_key + "_tiny"
+    except Exception as e:
+        status += "NEW_PROFILE_IMAGE_KEY_PROBLEM: " + str(e) + " "
+        success = False
+    if success:
+        new_profile_image_value_large = getattr(object_with_photo_fields, new_profile_image_key_large)
+        if new_profile_image_value_large != object_with_photo_fields.we_vote_hosted_profile_image_url_large:
+            object_with_photo_fields.we_vote_hosted_profile_image_url_large = new_profile_image_value_large
+            at_least_one_change = True
+        new_profile_image_value_medium = getattr(object_with_photo_fields, new_profile_image_key_medium)
+        if new_profile_image_value_medium != object_with_photo_fields.we_vote_hosted_profile_image_url_medium:
+            object_with_photo_fields.we_vote_hosted_profile_image_url_medium = new_profile_image_value_medium
+            at_least_one_change = True
+        new_profile_image_value_tiny = getattr(object_with_photo_fields, new_profile_image_key_tiny)
+        if new_profile_image_value_tiny != object_with_photo_fields.we_vote_hosted_profile_image_url_tiny:
+            object_with_photo_fields.we_vote_hosted_profile_image_url_tiny = new_profile_image_value_tiny
+            at_least_one_change = True
+        if at_least_one_change:
+            save_changes = True
+
+    results = {
+        'object_with_photo_fields': object_with_photo_fields,
+        'save_changes':             save_changes,
+        'status':                   status,
+        'success':                  success,
+    }
+    return results

--- a/import_export_twitter/controllers.py
+++ b/import_export_twitter/controllers.py
@@ -487,9 +487,9 @@ def twitter_identity_retrieve_for_api(twitter_handle, voter_device_id=''):  # tw
     #             owner_found = True
     #             status = "OWNER_OF_THIS_TWITTER_HANDLE_FOUND-CANDIDATE"
 
-    twitter_handle_format_valid = True
-    if len(twitter_handle) > 15:
-        twitter_handle_format_valid = False
+    from twitter.functions import is_valid_twitter_handle_format
+    twitter_handle_format_valid = is_valid_twitter_handle_format(twitter_handle)
+    if not twitter_handle_format_valid:
         status += "TWITTER_HANDLE_TOO_LONG "
 
     if twitter_handle_format_valid and not positive_value_exists(owner_found):
@@ -721,6 +721,7 @@ def refresh_twitter_candidate_details(candidate, use_cached_data_if_within_x_day
     results = retrieve_fresh_enough_twitter_user_for_handle(
         candidate_id=candidate.id,
         candidate_we_vote_id=candidate.we_vote_id,
+        editable_object_needed=False,
         twitter_handle=candidate.candidate_twitter_handle,
         use_cached_data_if_within_x_days=use_cached_data_if_within_x_days)
     if not results['success']:
@@ -730,6 +731,11 @@ def refresh_twitter_candidate_details(candidate, use_cached_data_if_within_x_day
         status += results['status']
         twitter_user_found = results['twitter_user_found']
         twitter_user_updated = results['twitter_user_updated']
+
+        # twitter_handle_updates_failing = results['twitter_handle_updates_failing'] \
+        #     if 'twitter_handle_updates_failing' in results else False
+        # if not twitter_handle_updates_failing:  # We actually do want to propagate the twitter_handle_updates_failing
+
         # Now update all places where we use this twitter_handle
         twitter_user = results['twitter_user']
         refresh_results = save_fresh_twitter_details(twitter_user=twitter_user, update_all=True)
@@ -772,6 +778,7 @@ def refresh_twitter_politician_details(politician, use_cached_data_if_within_x_d
     # Note that retrieve_fresh_enough_twitter_user_for_handle only updates politicians in upcoming elections,
     #  and not politicians in past elections
     results = retrieve_fresh_enough_twitter_user_for_handle(
+        editable_object_needed=False,
         politician_id=politician.id,
         politician_we_vote_id=politician.we_vote_id,
         twitter_handle=politician.politician_twitter_handle,
@@ -783,6 +790,11 @@ def refresh_twitter_politician_details(politician, use_cached_data_if_within_x_d
         status += results['status']
         twitter_user_found = results['twitter_user_found']
         twitter_user_updated = results['twitter_user_updated']
+
+        # twitter_handle_updates_failing = results['twitter_handle_updates_failing'] \
+        #     if 'twitter_handle_updates_failing' in results else False
+        # if not twitter_handle_updates_failing:  # We actually do want to propagate the twitter_handle_updates_failing
+
         # Now update all places where we use this twitter_handle
         twitter_user = results['twitter_user']
         refresh_results = save_fresh_twitter_details(twitter_user=twitter_user, update_all=True)
@@ -821,6 +833,7 @@ def refresh_twitter_representative_details(representative, use_cached_data_if_wi
         return results
 
     results = retrieve_fresh_enough_twitter_user_for_handle(
+        editable_object_needed=False,
         representative_id=representative.id,
         representative_we_vote_id=representative.we_vote_id,
         twitter_handle=representative.representative_twitter_handle,
@@ -832,6 +845,11 @@ def refresh_twitter_representative_details(representative, use_cached_data_if_wi
         status += results['status']
         twitter_user_found = results['twitter_user_found']
         twitter_user_updated = results['twitter_user_updated']
+
+        # twitter_handle_updates_failing = results['twitter_handle_updates_failing'] \
+        #     if 'twitter_handle_updates_failing' in results else False
+        # if not twitter_handle_updates_failing:  # We actually do want to propagate the twitter_handle_updates_failing
+
         # Now update all places where we use this twitter_handle
         twitter_user = results['twitter_user']
         refresh_results = save_fresh_twitter_details(twitter_user=twitter_user, update_all=True)
@@ -1017,6 +1035,7 @@ def update_twitter_user_list_from_twitter_response_list(twitter_dict_list=[]):
 def retrieve_fresh_enough_twitter_user_for_handle(
         candidate_id='',
         candidate_we_vote_id='',
+        editable_object_needed=False,
         organization_id='',
         organization_we_vote_id='',
         politician_id='',
@@ -1044,7 +1063,7 @@ def retrieve_fresh_enough_twitter_user_for_handle(
     status = ""
     success = True
     use_cached_data_if_within_x_days = convert_to_int(use_cached_data_if_within_x_days)
-    twitter_handle_update_failed = False
+    twitter_handle_updates_failing = False
     twitter_user = None
     twitter_user_found = False
     twitter_user_updated = False
@@ -1062,7 +1081,11 @@ def retrieve_fresh_enough_twitter_user_for_handle(
         return results
 
     # Check the Twitter data we have cached locally
-    results = twitter_user_manager.retrieve_twitter_user(twitter_handle=twitter_handle, read_only=False)
+    first_retrieve_read_only = not editable_object_needed
+    retrieve_latest_data_from_twitter = False
+    retrieve_twitter_user_editable = not first_retrieve_read_only
+    results = twitter_user_manager.retrieve_twitter_user(twitter_handle=twitter_handle,
+                                                         read_only=first_retrieve_read_only)
     if results['twitter_user_found']:
         twitter_user = results['twitter_user']
         twitter_user_found = results['twitter_user_found']
@@ -1074,12 +1097,23 @@ def retrieve_fresh_enough_twitter_user_for_handle(
                 retrieve_latest_data_from_twitter = False
             else:
                 retrieve_latest_data_from_twitter = True
+                if first_retrieve_read_only:
+                    retrieve_twitter_user_editable = True
         else:
             retrieve_latest_data_from_twitter = True
-    else:
+            if not first_retrieve_read_only:
+                retrieve_twitter_user_editable = True
+    elif results['success']:
         retrieve_latest_data_from_twitter = True
 
+    if retrieve_twitter_user_editable:
+        results = twitter_user_manager.retrieve_twitter_user(twitter_handle=twitter_handle, read_only=False)
+        if results['twitter_user_found']:
+            twitter_user = results['twitter_user']
+            twitter_user_found = results['twitter_user_found']
+
     if retrieve_latest_data_from_twitter:
+        save_twitter_images_locally = False
         status += "REACHING_OUT_TO_TWITTER: " + str(twitter_handle) + " "
         twitter_api_counter_manager = TwitterApiCounterManager()
         results = retrieve_twitter_user_info(
@@ -1091,7 +1125,7 @@ def retrieve_fresh_enough_twitter_user_for_handle(
         if not results['success']:
             success = False
         if results['twitter_user_not_found_in_twitter'] or results['twitter_user_suspended_by_twitter']:
-            twitter_handle_update_failed = True
+            twitter_handle_updates_failing = True
             status += "HANDLE_NOT_FOUND_OR_SUSPENDED "
             success = False
             # This is updating the twitter_user above, if it exists
@@ -1104,15 +1138,37 @@ def retrieve_fresh_enough_twitter_user_for_handle(
                     success = False
         elif results['success']:
             status += "DETAILS_RETRIEVED_FROM_TWITTER "
-            twitter_dict = results['twitter_dict']
-            twitter_user_id = twitter_dict['id'] if 'id' in twitter_dict else 0
-
-            # Get original image url for cache original size image
-            try:
-                twitter_profile_image_url_https = we_vote_image_manager.twitter_profile_image_url_https_original(
-                    twitter_dict['profile_image_url'])
-            except Exception as e:
-                twitter_profile_image_url_https = ''
+            if not results['twitter_handle_found']:
+                status += "SAVE_TWITTER_HANDLE_STUB "
+                twitter_handle_updates_failing = True
+                twitter_dict = {
+                    'twitter_handle_updates_failing': True,
+                    'username': twitter_handle,
+                }
+                twitter_user_id = 0
+                # We want to create a new Twitter user locally, so we can prevent additional calls within 30 days
+                save_twitter_user_results = twitter_user_manager.update_or_create_twitter_user(
+                    twitter_dict=twitter_dict,
+                    twitter_id=twitter_user_id,
+                )
+                if save_twitter_user_results['success']:
+                    twitter_user = save_twitter_user_results['twitter_user']
+                    twitter_user_found = save_twitter_user_results['twitter_user_found']
+                    twitter_user_updated = True
+                else:
+                    status += save_twitter_user_results['status']
+                    success = False
+            else:
+                twitter_dict = results['twitter_dict']
+                twitter_user_id = twitter_dict['id'] if 'id' in twitter_dict else 0
+                # Get original image url for cache original size image
+                try:
+                    twitter_profile_image_url_https = we_vote_image_manager.twitter_profile_image_url_https_original(
+                        twitter_dict['profile_image_url'])
+                    save_twitter_images_locally = True
+                except Exception as e:
+                    twitter_profile_image_url_https = ''
+        if save_twitter_images_locally:
             # 2024-01-27 No longer supported by Twitter
             # try:
             #     twitter_profile_background_image_url_https = twitter_dict['profile_background_image_url_https'] \
@@ -1150,7 +1206,6 @@ def retrieve_fresh_enough_twitter_user_for_handle(
             if not positive_value_exists(cache_results['success']):
                 success = False
                 status += cache_results['status']
-
             save_twitter_user_results = twitter_user_manager.update_or_create_twitter_user(
                 twitter_dict=twitter_dict,
                 twitter_id=twitter_user_id,
@@ -1164,6 +1219,7 @@ def retrieve_fresh_enough_twitter_user_for_handle(
                 twitter_user = save_twitter_user_results['twitter_user']
                 twitter_user_found = save_twitter_user_results['twitter_user_found']
                 twitter_user_updated = True
+                twitter_handle_updates_failing = twitter_user.twitter_handle_updates_failing
             else:
                 status += save_twitter_user_results['status']
                 success = False
@@ -1172,7 +1228,7 @@ def retrieve_fresh_enough_twitter_user_for_handle(
         'cached_image_dict':            cached_image_dict,
         'success':                      success,
         'status':                       status,
-        'twitter_handle_update_failed': twitter_handle_update_failed,
+        'twitter_handle_updates_failing': twitter_handle_updates_failing,
         'twitter_dict':                 twitter_dict,
         'twitter_user':                 twitter_user,
         'twitter_user_found':           twitter_user_found,
@@ -1340,6 +1396,7 @@ def refresh_twitter_organization_details(organization, use_cached_data_if_within
     #     status += "ORGANIZATION_TWITTER_DETAILS_NOT_CLEARED_FROM_DB "
 
     results = retrieve_fresh_enough_twitter_user_for_handle(
+        editable_object_needed=False,
         organization_id=organization.id,
         organization_we_vote_id=organization.we_vote_id,
         twitter_handle=organization.organization_twitter_handle,
@@ -1351,6 +1408,11 @@ def refresh_twitter_organization_details(organization, use_cached_data_if_within
         status += results['status']
         twitter_user_found = results['twitter_user_found']
         twitter_user_updated = results['twitter_user_updated']
+
+        # twitter_handle_updates_failing = results['twitter_handle_updates_failing'] \
+        #     if 'twitter_handle_updates_failing' in results else False
+        # if not twitter_handle_updates_failing:  # We actually do want to propagate the twitter_handle_updates_failing
+
         # Now update all places where we use this twitter_handle
         twitter_user = results['twitter_user']
         refresh_results = save_fresh_twitter_details(twitter_user=twitter_user, update_all=True)

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -1245,6 +1245,12 @@
 
 </form>
 
+{% if change_log_list %}
+    <br />
+<div class="form-group">
+    {% include "candidate/change_log_list.html" with change_log_list=change_log_list %}
+</div>
+{% endif %}
 
 
 {% if duplicate_politician_list %}

--- a/templates/volunteer_task/performance_list.html
+++ b/templates/volunteer_task/performance_list.html
@@ -71,14 +71,23 @@
             {% if team_performance_dict.candidates_created %}
             &nbsp;&nbsp;&nbsp;Candidates Created<br />
             {% endif %}
+            {% if team_performance_dict.politicians_augmented %}
+            &nbsp;&nbsp;&nbsp;Candidates / Politicians Augmented<br />
+            {% endif %}
             {% if team_performance_dict.politicians_deduplicated %}
             &nbsp;&nbsp;&nbsp;Candidates / Politicians Deduplicated<br />
+            {% endif %}
+            {% if team_performance_dict.politicians_photo_added %}
+            &nbsp;&nbsp;&nbsp;Candidates / Politicians Photos Added<br />
             {% endif %}
             {% if team_performance_dict.positions_saved %}
             &nbsp;&nbsp;&nbsp;Opinions/Endorsements Saved<br />
             {% endif %}
             {% if team_performance_dict.position_comments_saved %}
             &nbsp;&nbsp;&nbsp;Opinion/Endorsement Comments Saved<br />
+            {% endif %}
+            {% if team_performance_dict.politicians_requested_changes %}
+            &nbsp;&nbsp;&nbsp;Politicians Requested Changes<br />
             {% endif %}
             {% if team_performance_dict.voter_guide_possibilities_created %}
             &nbsp;&nbsp;&nbsp;Voter Guides Saved<br />
@@ -91,14 +100,23 @@
             {% if team_performance_dict.candidates_created %}{# Show row if any candidates_created #}
             {{ team_one_date_dict.candidates_created|display_nothing_if_zero }}<br />
             {% endif %}
+            {% if team_performance_dict.politicians_augmented %}
+            {{ team_one_date_dict.politicians_augmented|display_nothing_if_zero }}<br />
+            {% endif %}
             {% if team_performance_dict.politicians_deduplicated %}
             {{ team_one_date_dict.politicians_deduplicated|display_nothing_if_zero }}<br />
+            {% endif %}
+            {% if team_performance_dict.politicians_photo_added %}
+            {{ team_one_date_dict.politicians_photo_added|display_nothing_if_zero }}<br />
             {% endif %}
             {% if team_performance_dict.positions_saved %}
             {{ team_one_date_dict.positions_saved|display_nothing_if_zero }}<br />
             {% endif %}
             {% if team_performance_dict.position_comments_saved %}
             {{ team_one_date_dict.position_comments_saved|display_nothing_if_zero }}<br />
+            {% endif %}
+            {% if team_performance_dict.politicians_requested_changes %}
+            {{ team_one_date_dict.politicians_requested_changes|display_nothing_if_zero }}<br />
             {% endif %}
             {% if team_performance_dict.voter_guide_possibilities_created %}
             {{ team_one_date_dict.voter_guide_possibilities_created|display_nothing_if_zero }}<br />
@@ -111,8 +129,14 @@
             {% if team_performance_dict.candidates_created %}
             {{ team_performance_dict.candidates_created }}<br />
             {% endif %}
+            {% if team_performance_dict.politicians_augmented %}
+            {{ team_performance_dict.politicians_augmented }}<br />
+            {% endif %}
             {% if team_performance_dict.politicians_deduplicated %}
             {{ team_performance_dict.politicians_deduplicated }}<br />
+            {% endif %}
+            {% if team_performance_dict.politicians_photo_added %}
+            {{ team_performance_dict.politicians_photo_added }}<br />
             {% endif %}
             {% if team_performance_dict.positions_saved %}
             {{ team_performance_dict.positions_saved }}<br />
@@ -120,10 +144,19 @@
             {% if team_performance_dict.position_comments_saved %}
             {{ team_performance_dict.position_comments_saved }}<br />
             {% endif %}
+            {% if team_performance_dict.politicians_requested_changes %}
+            {{ team_performance_dict.politicians_requested_changes }}<br />
+            {% endif %}
             {% if team_performance_dict.voter_guide_possibilities_created %}
             {{ team_performance_dict.voter_guide_possibilities_created }}<br />
             {% endif %}
         </td>
+    </tr>
+    <tr> {# Visual spacer #}
+        <td colspan="12"><p>
+            &nbsp;<br />
+            &nbsp;<br />
+        </p></td>
     </tr>
 {% endif %}
 
@@ -164,14 +197,23 @@
             {% if voter_dict.candidates_created %}
             &nbsp;&nbsp;&nbsp;Candidates Created<br />
             {% endif %}
+            {% if voter_dict.politicians_augmented %}
+            &nbsp;&nbsp;&nbsp;Candidates / Politicians Augmented<br />
+            {% endif %}
             {% if voter_dict.politicians_deduplicated %}
             &nbsp;&nbsp;&nbsp;Candidates / Politicians Deduplicated<br />
+            {% endif %}
+            {% if voter_dict.politicians_photo_added %}
+            &nbsp;&nbsp;&nbsp;Candidates / Politicians Photos Added<br />
             {% endif %}
             {% if voter_dict.positions_saved %}
             &nbsp;&nbsp;&nbsp;Opinions/Endorsements Saved<br />
             {% endif %}
             {% if voter_dict.position_comments_saved %}
             &nbsp;&nbsp;&nbsp;Opinion/Endorsement Comments Saved<br />
+            {% endif %}
+            {% if voter_dict.politicians_requested_changes %}
+            &nbsp;&nbsp;&nbsp;Politicians Requested Changes<br />
             {% endif %}
             {% if voter_dict.voter_guide_possibilities_created %}
             &nbsp;&nbsp;&nbsp;Voter Guides Saved<br />
@@ -186,14 +228,23 @@
             {% if voter_dict.candidates_created %}{# Show row if any candidates_created #}
             {{ voter_one_date_dict.candidates_created|display_nothing_if_zero }}<br />
             {% endif %}
+            {% if voter_dict.politicians_augmented %}
+            {{ voter_one_date_dict.politicians_augmented|display_nothing_if_zero }}<br />
+            {% endif %}
             {% if voter_dict.politicians_deduplicated %}
             {{ voter_one_date_dict.politicians_deduplicated|display_nothing_if_zero }}<br />
+            {% endif %}
+            {% if voter_dict.politicians_photo_added %}
+            {{ voter_one_date_dict.politicians_photo_added|display_nothing_if_zero }}<br />
             {% endif %}
             {% if voter_dict.positions_saved %}
             {{ voter_one_date_dict.positions_saved|display_nothing_if_zero }}<br />
             {% endif %}
             {% if voter_dict.position_comments_saved %}
             {{ voter_one_date_dict.position_comments_saved|display_nothing_if_zero }}<br />
+            {% endif %}
+            {% if voter_dict.politicians_requested_changes %}
+            {{ voter_one_date_dict.politicians_requested_changes|display_nothing_if_zero }}<br />
             {% endif %}
             {% if voter_dict.voter_guide_possibilities_created %}
             {{ voter_one_date_dict.voter_guide_possibilities_created|display_nothing_if_zero }}<br />
@@ -208,14 +259,23 @@
             {% if voter_dict.candidates_created %}
             {{ voter_dict.candidates_created }}<br />
             {% endif %}
+            {% if voter_dict.politicians_augmented %}
+            {{ voter_dict.politicians_augmented }}<br />
+            {% endif %}
             {% if voter_dict.politicians_deduplicated %}
             {{ voter_dict.politicians_deduplicated }}<br />
+            {% endif %}
+            {% if voter_dict.politicians_photo_added %}
+            {{ voter_dict.politicians_photo_added }}<br />
             {% endif %}
             {% if voter_dict.positions_saved %}
             {{ voter_dict.positions_saved }}<br />
             {% endif %}
             {% if voter_dict.position_comments_saved %}
             {{ voter_dict.position_comments_saved }}<br />
+            {% endif %}
+            {% if voter_dict.politicians_requested_changes %}
+            {{ voter_dict.politicians_requested_changes }}<br />
             {% endif %}
             {% if voter_dict.voter_guide_possibilities_created %}
             {{ voter_dict.voter_guide_possibilities_created }}<br />

--- a/templates/voter/voter_list.html
+++ b/templates/voter/voter_list.html
@@ -181,7 +181,7 @@
             <th>Tw / Apple / Email / Phone</th>
             <th>Opt In</th>
             <th style='text-align: right'>Contributions</th>
-            <th>Roles</th>
+            <th>Roles / Teams</th>
             <th>Voter Images</th>
         </tr>
       </thead>
@@ -255,6 +255,7 @@
                 {{ voter.amount_spent }}
             </td>
             <td>
+            <!-- Roles / Teams //-->
             <!-- Is site administrator? //-->
             {% if voter.is_admin %}Admin, {% else %}{% endif %}
             {% if voter.is_analytics_admin %}Analytics_Admin, {% else %}{% endif %}

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -1225,6 +1225,8 @@ class TwitterUserManager(models.Manager):
             twitter_id = twitter_dict['id'] if 'id' in twitter_dict else None
             twitter_location = twitter_dict['location'] if 'location' in twitter_dict else ""
             twitter_name = twitter_dict['name'] if 'name' in twitter_dict else ""
+            twitter_handle_updates_failing = twitter_dict['twitter_handle_updates_failing'] \
+                if 'twitter_handle_updates_failing' in twitter_dict else False
 
             # Twitter API v2 removed these fields
             if positive_value_exists(cached_twitter_profile_background_image_url_https):
@@ -1255,6 +1257,7 @@ class TwitterUserManager(models.Manager):
                 twitter_description=twitter_description,
                 twitter_followers_count=twitter_followers_count,
                 twitter_handle=twitter_handle,
+                twitter_handle_updates_failing=twitter_handle_updates_failing,
                 twitter_id=twitter_id,
                 twitter_location=twitter_location,
                 twitter_name=twitter_name,
@@ -1412,7 +1415,10 @@ class TwitterUserManager(models.Manager):
                 if twitter_dict['location'] != twitter_user.twitter_location:
                     twitter_user.twitter_location = twitter_dict['location']
                     values_changed = True
-
+            if 'twitter_handle_updates_failing' in twitter_dict:
+                if twitter_dict['twitter_handle_updates_failing'] != twitter_user.twitter_handle_updates_failing:
+                    twitter_user.twitter_handle_updates_failing = twitter_dict['twitter_handle_updates_failing']
+                    values_changed = True
             if values_changed:
                 try:
                     twitter_user.date_last_updated_from_twitter = localtime(now()).date()
@@ -1435,7 +1441,7 @@ class TwitterUserManager(models.Manager):
             return results
 
         else:
-            # Twitter user does not exist so create new twitter user with latest twitter details
+            # Twitter user does not exist so create new Twitter user with latest twitter details
             twitter_save_results = self.save_new_twitter_user_from_twitter_json(
                 twitter_dict,
                 cached_twitter_profile_image_url_https,

--- a/volunteer_task/models.py
+++ b/volunteer_task/models.py
@@ -183,14 +183,17 @@ class VolunteerWeeklyMetrics(models.Model):
     # We store YYYYMMDD as an integer for very fast lookup (ex/ "20170901" for September, 1, 2017)
     #  And this end-of-week date is Sunday from ISO 8601 Standard
     end_of_week_date_integer = models.PositiveIntegerField(null=True, db_index=True)
-    candidates_created = models.PositiveIntegerField(null=True)
-    politicians_deduplicated = models.PositiveIntegerField(null=True)
-    positions_saved = models.PositiveIntegerField(null=True)
-    position_comments_saved = models.PositiveIntegerField(null=True)
+    candidates_created = models.PositiveIntegerField(default=0)
+    politicians_augmented = models.PositiveIntegerField(default=0)
+    politicians_deduplicated = models.PositiveIntegerField(default=0)
+    politicians_photo_added = models.PositiveIntegerField(default=0)
+    politicians_requested_changes = models.PositiveIntegerField(default=0)
+    positions_saved = models.PositiveIntegerField(default=0)
+    position_comments_saved = models.PositiveIntegerField(default=0)
     # We create this unique identifier to we can prevent duplicates: voter_we_vote_id + "-" + end_of_week_date_integer
     voter_date_unique_string = models.CharField(max_length=255, null=True, db_index=True, unique=True)
     voter_display_name = models.CharField(max_length=255, null=True, db_index=True)
-    voter_guide_possibilities_created = models.PositiveIntegerField(null=True)
+    voter_guide_possibilities_created = models.PositiveIntegerField(default=0)
     voter_we_vote_id = models.CharField(max_length=255, null=True, db_index=True)
 
 

--- a/volunteer_task/views_admin.py
+++ b/volunteer_task/views_admin.py
@@ -87,7 +87,10 @@ def performance_list_view(request):
         if end_of_week_date_integer not in actions_completed_dict[voter_we_vote_id]:
             actions_completed_dict[voter_we_vote_id][end_of_week_date_integer] = {
                 'candidates_created': one_person_one_week.candidates_created,
+                'politicians_augmented': one_person_one_week.politicians_augmented,
                 'politicians_deduplicated': one_person_one_week.politicians_deduplicated,
+                'politicians_photo_added': one_person_one_week.politicians_photo_added,
+                'politicians_requested_changes': one_person_one_week.politicians_requested_changes,
                 'positions_saved': one_person_one_week.positions_saved,
                 'position_comments_saved': one_person_one_week.position_comments_saved,
                 'voter_guide_possibilities_created': one_person_one_week.voter_guide_possibilities_created,
@@ -95,7 +98,10 @@ def performance_list_view(request):
         if end_of_week_date_integer not in team_actions_completed_dict:
             team_actions_completed_dict[end_of_week_date_integer] = {
                 'candidates_created': 0,
+                'politicians_augmented': 0,
                 'politicians_deduplicated': 0,
+                'politicians_photo_added': 0,
+                'politicians_requested_changes': 0,
                 'positions_saved': 0,
                 'position_comments_saved': 0,
                 'voter_guide_possibilities_created': 0,
@@ -104,9 +110,18 @@ def performance_list_view(request):
             'candidates_created':
                 team_actions_completed_dict[end_of_week_date_integer]['candidates_created'] +
                 one_person_one_week.candidates_created,
+            'politicians_augmented':
+                team_actions_completed_dict[end_of_week_date_integer]['politicians_augmented'] +
+                one_person_one_week.politicians_augmented,
             'politicians_deduplicated':
                 team_actions_completed_dict[end_of_week_date_integer]['politicians_deduplicated'] +
                 one_person_one_week.politicians_deduplicated,
+            'politicians_photo_added':
+                team_actions_completed_dict[end_of_week_date_integer]['politicians_photo_added'] +
+                one_person_one_week.politicians_photo_added,
+            'politicians_requested_changes':
+                team_actions_completed_dict[end_of_week_date_integer]['politicians_requested_changes'] +
+                one_person_one_week.politicians_requested_changes,
             'positions_saved':
                 team_actions_completed_dict[end_of_week_date_integer]['positions_saved'] +
                 one_person_one_week.positions_saved,
@@ -122,22 +137,30 @@ def performance_list_view(request):
 
     # ########################################
     # Work on individual Volunteer statistics
+    weekly_metrics_fields = [
+        'candidates_created', 'politicians_augmented', 'politicians_deduplicated',
+        'politicians_photo_added', 'politicians_requested_changes', 'positions_saved',
+        'position_comments_saved', 'voter_guide_possibilities_created',
+    ]
     for voter_we_vote_id in voter_we_vote_id_list:
         # Set these values to true if we have any tasks completed in any of the weeks we are displaying
         individual_performance_dict[voter_we_vote_id]['voter_display_name'] = \
             voter_display_name_by_voter_we_vote_id_dict[voter_we_vote_id]
-        individual_performance_dict[voter_we_vote_id]['candidates_created'] = 0
-        individual_performance_dict[voter_we_vote_id]['politicians_deduplicated'] = 0
-        individual_performance_dict[voter_we_vote_id]['positions_saved'] = 0
-        individual_performance_dict[voter_we_vote_id]['position_comments_saved'] = 0
-        individual_performance_dict[voter_we_vote_id]['voter_guide_possibilities_created'] = 0
+        for weekly_metric_key in weekly_metrics_fields:
+            individual_performance_dict[voter_we_vote_id][weekly_metric_key] = 0
         individual_performance_dict[voter_we_vote_id]['volunteer_task_total'] = 0
         for end_of_week_date_integer in end_of_week_date_integer_list:
             if end_of_week_date_integer in actions_completed_dict[voter_we_vote_id]:
                 candidates_created = \
                     actions_completed_dict[voter_we_vote_id][end_of_week_date_integer]['candidates_created']
+                politicians_augmented = \
+                    actions_completed_dict[voter_we_vote_id][end_of_week_date_integer]['politicians_augmented']
                 politicians_deduplicated = \
                     actions_completed_dict[voter_we_vote_id][end_of_week_date_integer]['politicians_deduplicated']
+                politicians_photo_added = \
+                    actions_completed_dict[voter_we_vote_id][end_of_week_date_integer]['politicians_photo_added']
+                politicians_requested_changes = \
+                    actions_completed_dict[voter_we_vote_id][end_of_week_date_integer]['politicians_requested_changes']
                 positions_saved = \
                     actions_completed_dict[voter_we_vote_id][end_of_week_date_integer]['positions_saved']
                 position_comments_saved = \
@@ -145,18 +168,25 @@ def performance_list_view(request):
                 voter_guide_possibilities_created = \
                     actions_completed_dict[voter_we_vote_id][end_of_week_date_integer]['voter_guide_possibilities_created']
                 volunteer_task_total = \
-                    candidates_created + politicians_deduplicated + positions_saved + \
+                    candidates_created + politicians_augmented + politicians_deduplicated + politicians_photo_added + \
+                    politicians_requested_changes + positions_saved + \
                     position_comments_saved + voter_guide_possibilities_created
             else:
                 candidates_created = 0
+                politicians_augmented = 0
                 politicians_deduplicated = 0
+                politicians_photo_added = 0
+                politicians_requested_changes = 0
                 positions_saved = 0
                 position_comments_saved = 0
                 voter_guide_possibilities_created = 0
                 volunteer_task_total = 0
             individual_performance_dict[voter_we_vote_id][end_of_week_date_integer] = {
                 'candidates_created': candidates_created,
+                'politicians_augmented': politicians_augmented,
                 'politicians_deduplicated': politicians_deduplicated,
+                'politicians_photo_added': politicians_photo_added,
+                'politicians_requested_changes': politicians_requested_changes,
                 'positions_saved': positions_saved,
                 'position_comments_saved': position_comments_saved,
                 'volunteer_task_total': volunteer_task_total,
@@ -166,9 +196,19 @@ def performance_list_view(request):
             if candidates_created > 0:
                 individual_performance_dict[voter_we_vote_id]['candidates_created'] += candidates_created
                 individual_performance_dict[voter_we_vote_id]['volunteer_task_total'] += candidates_created
+            if politicians_augmented > 0:
+                individual_performance_dict[voter_we_vote_id]['politicians_augmented'] += politicians_augmented
+                individual_performance_dict[voter_we_vote_id]['volunteer_task_total'] += politicians_augmented
             if politicians_deduplicated > 0:
                 individual_performance_dict[voter_we_vote_id]['politicians_deduplicated'] += politicians_deduplicated
                 individual_performance_dict[voter_we_vote_id]['volunteer_task_total'] += politicians_deduplicated
+            if politicians_photo_added > 0:
+                individual_performance_dict[voter_we_vote_id]['politicians_photo_added'] += politicians_photo_added
+                individual_performance_dict[voter_we_vote_id]['volunteer_task_total'] += politicians_photo_added
+            if politicians_requested_changes > 0:
+                individual_performance_dict[voter_we_vote_id]['politicians_requested_changes'] += \
+                    politicians_requested_changes
+                individual_performance_dict[voter_we_vote_id]['volunteer_task_total'] += politicians_requested_changes
             if positions_saved > 0:
                 individual_performance_dict[voter_we_vote_id]['positions_saved'] += positions_saved
                 individual_performance_dict[voter_we_vote_id]['volunteer_task_total'] += positions_saved
@@ -192,18 +232,21 @@ def performance_list_view(request):
     # Now work on Team statistics
     team_performance_dict['team_name'] = volunteer_team_name
     # Below, set these values to true if we have any tasks completed in any of the weeks we are displaying
-    team_performance_dict['candidates_created'] = 0
-    team_performance_dict['politicians_deduplicated'] = 0
-    team_performance_dict['positions_saved'] = 0
-    team_performance_dict['position_comments_saved'] = 0
-    team_performance_dict['voter_guide_possibilities_created'] = 0
+    for weekly_metric_key in weekly_metrics_fields:
+        team_performance_dict[weekly_metric_key] = 0
     team_performance_dict['volunteer_task_total'] = 0
     for end_of_week_date_integer in end_of_week_date_integer_list:
         if end_of_week_date_integer in team_actions_completed_dict:
             candidates_created = \
                 team_actions_completed_dict[end_of_week_date_integer]['candidates_created']
+            politicians_augmented = \
+                team_actions_completed_dict[end_of_week_date_integer]['politicians_augmented']
             politicians_deduplicated = \
                 team_actions_completed_dict[end_of_week_date_integer]['politicians_deduplicated']
+            politicians_photo_added = \
+                team_actions_completed_dict[end_of_week_date_integer]['politicians_photo_added']
+            politicians_requested_changes = \
+                team_actions_completed_dict[end_of_week_date_integer]['politicians_requested_changes']
             positions_saved = \
                 team_actions_completed_dict[end_of_week_date_integer]['positions_saved']
             position_comments_saved = \
@@ -211,18 +254,25 @@ def performance_list_view(request):
             voter_guide_possibilities_created = \
                 team_actions_completed_dict[end_of_week_date_integer]['voter_guide_possibilities_created']
             volunteer_task_total = \
-                candidates_created + politicians_deduplicated + positions_saved + \
+                candidates_created + politicians_augmented + politicians_deduplicated + politicians_photo_added + \
+                politicians_requested_changes + positions_saved + \
                 position_comments_saved + voter_guide_possibilities_created
         else:
             candidates_created = 0
+            politicians_augmented = 0
             politicians_deduplicated = 0
+            politicians_photo_added = 0
+            politicians_requested_changes = 0
             positions_saved = 0
             position_comments_saved = 0
             voter_guide_possibilities_created = 0
             volunteer_task_total = 0
         team_performance_dict[end_of_week_date_integer] = {
             'candidates_created': candidates_created,
+            'politicians_augmented': politicians_augmented,
             'politicians_deduplicated': politicians_deduplicated,
+            'politicians_photo_added': politicians_photo_added,
+            'politicians_requested_changes': politicians_requested_changes,
             'positions_saved': positions_saved,
             'position_comments_saved': position_comments_saved,
             'volunteer_task_total': volunteer_task_total,
@@ -232,9 +282,18 @@ def performance_list_view(request):
         if candidates_created > 0:
             team_performance_dict['candidates_created'] += candidates_created
             team_performance_dict['volunteer_task_total'] += candidates_created
+        if politicians_augmented > 0:
+            team_performance_dict['politicians_augmented'] += politicians_augmented
+            team_performance_dict['volunteer_task_total'] += politicians_augmented
         if politicians_deduplicated > 0:
             team_performance_dict['politicians_deduplicated'] += politicians_deduplicated
             team_performance_dict['volunteer_task_total'] += politicians_deduplicated
+        if politicians_photo_added > 0:
+            team_performance_dict['politicians_photo_added'] += politicians_photo_added
+            team_performance_dict['volunteer_task_total'] += politicians_photo_added
+        if politicians_requested_changes > 0:
+            team_performance_dict['politicians_requested_changes'] += politicians_requested_changes
+            team_performance_dict['volunteer_task_total'] += politicians_requested_changes
         if positions_saved > 0:
             team_performance_dict['positions_saved'] += positions_saved
             team_performance_dict['volunteer_task_total'] += positions_saved


### PR DESCRIPTION
Updated candidate change tracking, and extended to politician_edit. Added more volunteer tasks that add to volunteer scorecard. When we try to retrieve a twitter handle which isn't found, we create a local TwitterUser cache now (a stub), so we know to not keep checking until the "freshness" expires.