### PR TITLE
Switch over from PDF2HTML docker installed project to Apache Tika (also installed by docker)

### DIFF
--- a/admin_tools/views.py
+++ b/admin_tools/views.py
@@ -17,13 +17,12 @@ from candidate.models import CandidateCampaign, CandidateManager
 from config.base import get_environment_variable, LOGIN_URL
 from election.controllers import elections_import_from_sample_file
 from election.models import Election
-from email_outbound.models import EmailAddress, SendGridApiCounterManager
+from email_outbound.models import EmailAddress
 from follow.models import FollowOrganizationList
 from friend.models import CurrentFriend, FriendManager, SuggestedFriend
 from import_export_ctcl.models import CTCLApiCounterManager
 from import_export_facebook.models import FacebookLinkToVoter, FacebookManager
 from import_export_google_civic.models import GoogleCivicApiCounterManager
-from import_export_targetsmart.models import TargetSmartApiCounterManager
 from import_export_vote_usa.models import VoteUSAApiCounterManager
 from measure.models import ContestMeasure, ContestMeasureManager
 from office.controllers import offices_import_from_sample_file
@@ -43,7 +42,7 @@ from voter.models import Voter, VoterAddress, VoterAddressManager, VoterDeviceLi
 from wevote_functions.functions import convert_to_int, delete_voter_api_device_id_cookie, generate_voter_device_id, \
     get_voter_api_device_id, positive_value_exists, set_voter_api_device_id, STATE_CODE_MAP
 from wevote_functions.utils import get_node_version, get_postgres_version, get_python_version, get_git_commit_hash, \
-    get_git_commit_date
+    get_git_commit_date, get_java_version
 
 BALLOT_ITEMS_SYNC_URL = get_environment_variable("BALLOT_ITEMS_SYNC_URL")  # ballotItemsSyncOut
 BALLOT_RETURNED_SYNC_URL = get_environment_variable("BALLOT_RETURNED_SYNC_URL")  # ballotReturnedSyncOut
@@ -114,6 +113,7 @@ def admin_home_view(request):
     template_values = {
         'google_civic_election_id':           google_civic_election_id,
         'python_version':                     get_python_version(),
+        'java_version_list':                  get_java_version(),
         'node_version':                       get_node_version(),
         'git_commit_hash':                    get_git_commit_hash(False),
         'git_commit_hash_url':                get_git_commit_hash(True),

--- a/apis_v1/urls.py
+++ b/apis_v1/urls.py
@@ -127,6 +127,8 @@ urlpatterns = [
       re_path(r'^fastLoadStatusRetrieve/', views_retrieve_tables.fast_load_status_retrieve_view,
               name='fastLoadStatusRetrieve'),
       re_path(r'retrieveSQLTables/', views_retrieve_tables.retrieve_sql_tables, name='retrieveSQLTables'),
+      re_path(r'retrieveSQLTablesRowCount/', views_retrieve_tables.retrieve_sql_tables_row_count,
+              name='retrieveSQLTablesRowCount'),
       re_path(r'^friendInvitationByEmailSend/',
               views_friend.friend_invitation_by_email_send_view, name='friendInvitationByEmailSendView'),
       re_path(r'^friendInvitationByEmailVerify/',

--- a/apis_v1/views/views_retrieve_tables.py
+++ b/apis_v1/views/views_retrieve_tables.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse
 
 import wevote_functions.admin
 from config.base import get_environment_variable
-from retrieve_tables.controllers import retrieve_sql_tables_as_csv, fast_load_status_retrieve
+from retrieve_tables.controllers import retrieve_sql_tables_as_csv, fast_load_status_retrieve, get_total_row_count
 from wevote_functions.functions import get_voter_device_id
 
 logger = wevote_functions.admin.get_logger(__name__)
@@ -28,6 +28,14 @@ def retrieve_sql_tables(request):  # retrieveSQLTables
 
     json_data = retrieve_sql_tables_as_csv(voter_device_id, table, start, end)
     return HttpResponse(json.dumps(json_data), content_type='application/json')
+
+
+def retrieve_sql_tables_row_count(request):  # retrieveSQLTablesRowCount
+    json_data = {
+        'rowCount': str(get_total_row_count())
+    }
+    return HttpResponse(json.dumps(json_data), content_type='application/json')
+
 
 def fast_load_status_retrieve_view(request):   # fastLoadStatusRetrieve
     return fast_load_status_retrieve(request)

--- a/config/environment_variables-template.json
+++ b/config/environment_variables-template.json
@@ -169,6 +169,9 @@
   "_comment":                       "import_export_targetsmart",
   "TARGETSMART_API_KEY":            "",
 
+  "_comment":                       "Apache Tika Server (Docker Deployed), Localhost url different if not local PC/Mac",
+  "TIKA_SERVER_URL":                "http://localhost:9998",
+
   "_comment":                       "import_export_theunitedstatesio",
   "LEGISLATORS_CURRENT_CSV_FILE":   "import_export_theunitedstatesio/import_data/legislators-current.csv",
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,6 +57,7 @@ setuptools==65.5.1    # Deprecated in Py 3.10, AND removed in Py 3.12, but still
 social-auth-app-django==5.0.0
 social-auth-core==4.2.0
 stripe==8.7.0
+tika==2.6.0
 tweepy==4.14.0
 twilio==7.8.2
 uritemplate==3.0.1

--- a/retrieve_tables/controllers.py
+++ b/retrieve_tables/controllers.py
@@ -62,6 +62,11 @@ LOCAL_TMP_PATH = '/tmp/'
 
 
 def get_total_row_count():
+    """
+    Returns the total row count of tables to be fetched from the MASTER server
+    Runs on the Master server
+    :return: the number of rows
+    """
     conn = psycopg2.connect(
         database=get_environment_variable('DATABASE_NAME'),
         user=get_environment_variable('DATABASE_USER'),
@@ -93,6 +98,7 @@ def get_total_row_count():
 
 def retrieve_sql_tables_as_csv(voter_device_id, table_name, start, end):
     """
+    Runs on the Master server
     Extract one of the approximately 21 allowable database tables to CSV (pipe delimited) and send it to the
     developer's local WeVoteServer instance
     limit is used to specify a number of rows to return (this is the SQL LIMIT clause), non-zero or ignored
@@ -231,6 +237,7 @@ def save_off_database():
 def retrieve_sql_files_from_master_server(request):
     """
     Get the json data, and create new entries in the developers local database
+    Runs on the Local server (developer's Mac)
     :return:
     """
     status = ''
@@ -249,7 +256,8 @@ def retrieve_sql_files_from_master_server(request):
     # verify_bool = not ('localhost' in host or '127.0.0.1' in host or 'wevotedeveloper.com' in host)
     response = requests.get(host + '/apis/v1/fastLoadStatusRetrieve',
                             params={ "initialize": True, "voter_device_id": voter_device_id }, verify=False)
-    # print("response from master server ", str(response))
+    # print("fastLoadStatusRetrieve request to master server ", host + '/apis/v1/fastLoadStatusRetrieve')
+    # print("fastLoadStatusRetrieve response from master server ", str(response))
 
     for table_name in allowable_tables:
         print('Starting on the ' + table_name + ' table, requesting up to 500,000 rows')
@@ -406,7 +414,7 @@ def retrieve_sql_files_from_master_server(request):
 # We don't check every field for garbage, although maybe we should...
 # Since the error reporting in the python console is pretty good, you should be able to figure out what field has
 # garbage in it.
-# Because we export to csv (comma separated values) files, that end up the the WeVoterServer root dir, you can stop
+# Because we export to csv (comma separated values) files, that end up the WeVoterServer root dir, you can stop
 # processing with the debugger, open the csv files in Excel, and get a decent view of what is happening.  The diagnostic
 # function dump_row_col_labels_and_errors(table_name, header, row, '2000060') also is really good at figuring out what
 # field has problems, and it dumps the field numbers and names which helps determine what row processing functions need
@@ -416,6 +424,9 @@ def retrieve_sql_files_from_master_server(request):
 # hint: temporarily comment out some lines in allowable_tables, so you can get to the problem table quicker
 # hint: Access https://pg.admin.wevote.us/  (view access to the production server Postgres) can really help, ask Dale
 def csv_file_to_clean_csv_file2(table_name):
+    """
+    Runs on the Master server
+    """
     csv_rows = []
     with open(os.path.join(LOCAL_TMP_PATH, table_name + '.csvTemp'), 'r') as csv_file2:
         line_reader = csv.reader(csv_file2, delimiter='|')
@@ -599,6 +610,22 @@ def csv_file_to_clean_csv_file2(table_name):
     csv_file.close()
     return header
 
+def get_row_count_from_master_server():
+    """
+    Runs on the local server (Developer's Mac)
+    """
+    try:
+        host = 'https://api.wevoteusa.org/'
+        response = requests.get(host + '/apis/v1/retrieveSQLTablesRowCount')
+        if response.status_code == 200:
+            count = int(response.json()['rowCount'])
+            return count
+        logger.error("retrieveSQLTablesRowCount received HTTP response " + str(response.status_code))
+        return -1
+    except Exception as e:
+        logger.error("retrieveSQLTablesRowCount row count error ", str(e))
+        return -1
+
 
 def fast_load_status_retrieve(request):   # fastLoadStatusRetrieve
     initialize = positive_value_exists(request.GET.get('initialize', False))
@@ -614,7 +641,7 @@ def fast_load_status_retrieve(request):   # fastLoadStatusRetrieve
 
     try:
         if initialize:
-            total = get_total_row_count()
+            total = get_row_count_from_master_server()
             started = datetime.now(tz=timezone.utc)
             RetrieveTableState.objects.update_or_create(
                 voter_device_id=voter_device_id,

--- a/templates/admin_tools/index.html
+++ b/templates/admin_tools/index.html
@@ -187,10 +187,6 @@
             <td>{{ python_version }}</td>
         </tr>
         <tr>
-            <td>Node:</td>
-            <td>{{ node_version }}</td>
-        </tr>
-        <tr>
             <td>Postgres:&nbsp;&nbsp;</td>
             <td>{{ postgres_version }}</td>
         </tr>
@@ -200,6 +196,20 @@
                 <a id="gitLink" href={{git_commit_hash_url}} target="_blank">{{git_commit_hash}}</a>
                 <span style="padding-left: 40px;">({{git_commit_date}})</span>
             </td>
+        </tr>
+        {% for line in java_version_list %}
+            <tr>
+            {% if forloop.counter == 1 %}
+                <td>Java:</td>
+            {% else %}
+                <td> </td>
+            {% endif %}
+                <td>{{ line }}</td>
+            </tr>
+        {% endfor %}
+        <tr>
+            <td>Node:</td>
+            <td>{{ node_version }}</td>
         </tr>
      </table>
 </p>

--- a/wevote_functions/utils.py
+++ b/wevote_functions/utils.py
@@ -64,6 +64,18 @@ def get_git_commit_date():
         return 'Not found: ' + str(e)
 
 
+def get_java_version():
+    java_version_list = ['Java not installed']
+    try:
+        version = os.popen('java --version').read()
+        if version.endswith('\n'):
+            version = version[:-1]
+        java_version_list = version.split('\n')   # Some Java implementations have multi-line versions
+    except:
+        pass
+    return java_version_list
+
+
 def get_python_version():
     version = os.popen('python --version').read().strip().replace('Python', '')
     print('Python version: ' + version)    # Something like 'Python 3.7.2'


### PR DESCRIPTION
So that the Chrome Extension can process PDF forms since PDF2HTML was abandoned
Tika is accurate and fast, but does not retain complex page formatting or links to images like PDF2HTML did.  Tika should be good enough.

Requires Apache Tika to be installed on the production servers
see https://wevoteusa.atlassian.net/jira/software/projects/WV/issues/WV-358