### PR TITLE
Fix to fast_retrieve is done

### DIFF
--- a/apis_v1/views/views_retrieve_tables.py
+++ b/apis_v1/views/views_retrieve_tables.py
@@ -28,6 +28,7 @@ def retrieve_sql_tables(request):  # retrieveSQLTables
     end = request.GET.get('end', '')
     voter_api_device_id = get_voter_api_device_id(request)
 
+    # print("retrieveSQLTables voter_api_device_id: ", voter_api_device_id)
     json_data = retrieve_sql_tables_as_csv(voter_api_device_id, table_name, start, end)
     return HttpResponse(json.dumps(json_data), content_type='application/json')
 

--- a/import_export_vertex/controllers.py
+++ b/import_export_vertex/controllers.py
@@ -33,7 +33,7 @@ def ask_google_vertex_a_question(question, text_to_search):
             project=GOOGLE_PROJECT_ID,
             location=VERTEX_SERVICE_ENDPOINT)
         t1 = time()
-        print('---- vertexai.init took {:.6f} seconds'.format(t1-t0))
+        # print('---- vertexai.init took {:.6f} seconds'.format(t1-t0))
 
         temperature = 0.2
         parameters = {
@@ -45,9 +45,9 @@ def ask_google_vertex_a_question(question, text_to_search):
         }
         model = TextGenerationModel.from_pretrained("text-bison")
         t2 = time()
-        print('---- TextGenerationModel took {:.6f} seconds'.format(t2-t1))
-
-        print(f'---- Question ==> \'{question}\' <==')
+        # print('---- TextGenerationModel took {:.6f} seconds'.format(t2-t1))
+        #
+        # print(f'---- Question ==> \'{question}\' <==')
         # text_to_search = "One name is George Washington and another name is Thomas Jefferson."
         # WITH PARAMETERS
         # response = model.predict(
@@ -66,17 +66,17 @@ def ask_google_vertex_a_question(question, text_to_search):
         if positive_value_exists(response_text):
             response_text_found = True
         t3 = time()
-        print('---- model.predict took {:.6f} seconds'.format(t3-t2))
-        print('---- total took {:.6f} seconds'.format(t3-t0))
-        print(f'---- Question query from Vertex Model: {response_text}')
-
-        #  Feel free to remove logging and print lines in this file
-        performance = "(Ok) ask_google_vertex_a_question Vertex init took {:.6f} seconds, ".format(t1-t0)
-        performance += "load model (text-bison) took {:.6f} seconds, ".format(t2-t1)
-        performance += "Question query took {:.6f} seconds, ".format(t3-t2)
-        performance += "total took {:.6f} seconds ".format(t3-t0)
-        print(performance)
-        status += performance
+        # print('---- model.predict took {:.6f} seconds'.format(t3-t2))
+        # print('---- total took {:.6f} seconds'.format(t3-t0))
+        # print(f'---- Question query from Vertex Model: {response_text}')
+        #
+        # #  Feel free to remove logging and print lines in this file
+        # performance = "(Ok) ask_google_vertex_a_question Vertex init took {:.6f} seconds, ".format(t1-t0)
+        # performance += "load model (text-bison) took {:.6f} seconds, ".format(t2-t1)
+        # performance += "Question query took {:.6f} seconds, ".format(t3-t2)
+        # performance += "total took {:.6f} seconds ".format(t3-t0)
+        # print(performance)
+        # status += performance
     except Exception as error_message:
         print(f"Error response from Vertex Model: {error_message}")
         status += "VERTEX_ERROR: {error_message} ".format(error_message=error_message)

--- a/retrieve_tables/controllers_master.py
+++ b/retrieve_tables/controllers_master.py
@@ -142,6 +142,10 @@ def retrieve_sql_tables_as_csv(voter_api_device_id, table_name, start, end):
                 # logger.error("experiment: retrieve_tables file contents: " + file.readline().strip())
                 file.seek(0)
                 csv_files[table_name] = file.read()
+                # table_st = csv_files[table_name]
+                # for i in range(0, 100000, 150):    # c type for loop for(i=0; i < 10000; i+= 150)
+                #     print(table_str[i:i+150])
+
                 file.close()
                 # logger.error("experiment: after file close, status " + status)
                 if "exported" not in status:

--- a/templates/admin_tools/sync_data_with_master_dashboard.html
+++ b/templates/admin_tools/sync_data_with_master_dashboard.html
@@ -11,8 +11,9 @@
         If you are loading election data for the first time to your local postgres, press the "FAST LOAD" button below, and within about
         twenty-five minutes, it will have loaded and stored all the election data we have for all elections and for all the states.
         <br>
-        <span style="font-weight: bold;"> Note April 1, 2024: a temporary bug has created 10k+ duplicated ballot_ballotitem entries,
-            so this fast load will take about twice as long (approximately 45 minutes) to complete on a fast setup. (At least until the records are deduped.)
+        <span style="font-weight: bold;"> Note April 1, 2024: a temporary bug has created a million duplicated ballotitem entries,
+            so this fast load will take about two or three times as long to complete on a fast setup.
+            (Until the ballotitem records are deduped, plan on this taking about 60 minutes to complete.)
         </span>
 
         <input type="hidden" id="started_fast_update" name="started_fast_update" value="false">
@@ -289,7 +290,7 @@
         const res = regex.exec(document.cookie);
         if (res && res.length > 1) {
             const voterApiDeviceId = res && res[1];
-            console.log('getDeviceId voter_api_device_id: ',voterApiDeviceId);
+            {#console.log('getDeviceId voter_api_device_id: ',voterApiDeviceId);#}
             return voterApiDeviceId;
         }
         console.log('ERROR: getApiDeviceId called with out a voter_api_device_id cookie');
@@ -353,7 +354,7 @@
       let startedOriginalElement = document.getElementById('started_original_update');
       let startedOriginal = startedOriginalElement ? startedOriginalElement.value : "no";
 
-      console.log("started sync_data---- ", startedOriginal, startedFastUpdate.val());
+      {#console.log("started sync_data---- ", startedOriginal, startedFastUpdate.val());#}
       if (startedOriginal === 'start') {
         $.ajax({
           type: "GET",
@@ -430,7 +431,10 @@
             fastLoadButton.html("DONE: Successfully loaded election data from the master server").css('background-color', 'MEDIUMSPRINGGREEN');
             startedFastUpdate.val("false");
             progress.val(100);
-            completion.text('Complete')
+            const t1 = new Date().getTime();
+            const dt = t1 - t0;
+            const minutes = Math.trunc(dt/60000);
+            completion.text('Completed in ' + minutes + ' minutes');
             },
           error: function(XMLHttpRequest, textStatus, errorThrown) {
             fastLoadButton.html("FAILURE: Look at the local Python console log to figure out what went wrong").css('background-color', 'LIGHTCORAL');

--- a/templates/apis_v1/api_doc_page.html
+++ b/templates/apis_v1/api_doc_page.html
@@ -4,8 +4,8 @@
     {% load static %}
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1" name="viewport" />
-    <link href="//fonts.googleapis.com/css?family=Roboto:300,400,400italic,500,500italic,700,700italic|Roboto+Mono:400,500,700|Material+Icons" rel="stylesheet" />
-    <link href="{% static "apis_v1/apis_v1.css" %}" rel="stylesheet" />
+    <link href="//fonts.googleapis.com/css?family=Roboto:300,400,400italic,500,500italic,700,700italic|Roboto+Mono:400,500,700|Material+Icons" rel="stylesheet" type="text/css"/>
+    <link href="{% static "apis_v1/apis_v1.css" %}" rel="stylesheet" type="text/css" />
     <meta content="We Vote API Server" property="og:site_name" />
     <meta content="website" property="og:type" />
     <meta content="en" property="og:locale" />


### PR DESCRIPTION
candidate_candidatecampaign had grown to so many columns, that we were either crashing or timing out for a 502 on the retrieveSQLTables api request.
Logging to AWS at CloudWatch /ecs/wevote-api does not work for retrieveSQLTables, which made this harder to figure out.