### PR TITLE
Another css href url fix #4

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -261,7 +261,7 @@ USE_TZ = True
 AUTH_USER_MODEL = 'voter.Voter'
 
 # Static files (CSS, JavaScript, Images) Django 5+
-STATIC_URL = 'static/'
+STATIC_URL = 'apis_v1/static/'
 
 # # Static files (CSS, JavaScript, Images)  Django 1.11 - 3.nn
 # # https://docs.djangoproject.com/en/1.11/howto/static-files/ calls loading static files from the project


### PR DESCRIPTION
Path experiment for Django V5 way of serving static files. 

Both before and after this change, all the icons/css/svgs came up fine, when running on my Mac.