### PR TITLE
WV-450 redirected to readonly DB [MERGE READY]

### DIFF
--- a/politician/models.py
+++ b/politician/models.py
@@ -1951,6 +1951,7 @@ class PoliticianManager(models.Manager):
 #             politician_entry.delete()
 
     @staticmethod
+    # Cannot be readonly because method being used in other methods to read & write.
     def retrieve_politician_list(
             limit_to_this_state_code="",
             politician_we_vote_id_list=[],
@@ -1968,9 +1969,6 @@ class PoliticianManager(models.Manager):
         politician_list_found = False
 
         try:
-            # WV-450: switch to using readonly DB, instead of conditional logic
-            # politician_query = Politician.objects.using('readonly').all()
-
             if positive_value_exists(read_only):
                 politician_query = Politician.objects.using('readonly').all()
             else:

--- a/politician/models.py
+++ b/politician/models.py
@@ -1954,7 +1954,7 @@ class PoliticianManager(models.Manager):
     def retrieve_politician_list(
             limit_to_this_state_code="",
             politician_we_vote_id_list=[],
-            read_only=True,
+            read_only=False,
     ):
         """
 

--- a/politician/models.py
+++ b/politician/models.py
@@ -1954,7 +1954,7 @@ class PoliticianManager(models.Manager):
     def retrieve_politician_list(
             limit_to_this_state_code="",
             politician_we_vote_id_list=[],
-            read_only=False,
+            read_only=True,
     ):
         """
 

--- a/politician/models.py
+++ b/politician/models.py
@@ -1968,10 +1968,13 @@ class PoliticianManager(models.Manager):
         politician_list_found = False
 
         try:
-            if positive_value_exists(read_only):
-                politician_query = Politician.objects.using('readonly').all()
-            else:
-                politician_query = Politician.objects.all()
+            # WV-450: switch to using readonly DB, instead of conditional logic
+            # if positive_value_exists(read_only):
+            #     politician_query = Politician.objects.using('readonly').all()
+            # else:
+            #     politician_query = Politician.objects.all()
+
+            politician_query = Politician.objects.using('readonly').all()
             if len(politician_we_vote_id_list):
                 politician_query = politician_query.filter(we_vote_id__in=politician_we_vote_id_list)
             if positive_value_exists(limit_to_this_state_code):

--- a/politician/models.py
+++ b/politician/models.py
@@ -1358,7 +1358,7 @@ class PoliticianManager(models.Manager):
         politician_search_results_list = []
 
         try:
-            queryset = Politician.objects.all()
+            queryset = Politician.objects.using('readonly').all()
             if name_search_terms is not None:
                 name_search_words = name_search_terms.split()
             else:

--- a/politician/models.py
+++ b/politician/models.py
@@ -1969,12 +1969,13 @@ class PoliticianManager(models.Manager):
 
         try:
             # WV-450: switch to using readonly DB, instead of conditional logic
-            # if positive_value_exists(read_only):
-            #     politician_query = Politician.objects.using('readonly').all()
-            # else:
-            #     politician_query = Politician.objects.all()
+            # politician_query = Politician.objects.using('readonly').all()
 
-            politician_query = Politician.objects.using('readonly').all()
+            if positive_value_exists(read_only):
+                politician_query = Politician.objects.using('readonly').all()
+            else:
+                politician_query = Politician.objects.all()
+
             if len(politician_we_vote_id_list):
                 politician_query = politician_query.filter(we_vote_id__in=politician_we_vote_id_list)
             if positive_value_exists(limit_to_this_state_code):
@@ -2012,7 +2013,7 @@ class PoliticianManager(models.Manager):
             twitter_handle_list=[],
             politician_name='',
             ignore_politician_id_list=[],
-            read_only=False):
+            read_only=True):
         """
 
         :param state_code:


### PR DESCRIPTION
**search_politicians method**

-  Added .using('readonly').all() on a read_only 

> As our conversation on engineering-e slack, search_politicians is a read only method but has no read_only argument passed in the method. Would I need to pass that read_only == true argument in this method?

**retrieve_politician_list**

- Switched read_only argument to True
- Commented out conditional case to be discussed in Team Review

> Conditional statement already written in method, seems to only to be a read only method? 
Would we need conditional case if read_only = True? 
