### PR TITLE
WV-440 - Fix for Organization model to read-only database

### DIFF
--- a/admin_tools/views.py
+++ b/admin_tools/views.py
@@ -276,7 +276,7 @@ def data_cleanup_organization_analysis_view(request):
             for item in organization_filters:
                 final_organization_filters |= item
 
-            organization_list_with_duplicate_twitter = Organization.objects.all()
+            organization_list_with_duplicate_twitter = Organization.objects.using('readonly').all()
             organization_list_with_duplicate_twitter = organization_list_with_duplicate_twitter.filter(
                 final_organization_filters)
             organization_list_with_duplicate_twitter = organization_list_with_duplicate_twitter.exclude(
@@ -360,7 +360,7 @@ def data_cleanup_organization_list_analysis_view(request):
 
     create_twitter_link_to_organization = request.GET.get('create_twitter_link_to_organization', False)
 
-    organization_list = Organization.objects.all()
+    organization_list = Organization.objects.using('readonly').all()
 
     # Goal: Create TwitterLinkToOrganization
     # Goal: Look for opportunities to link Voters with Orgs

--- a/import_export_facebook/views_admin.py
+++ b/import_export_facebook/views_admin.py
@@ -379,7 +379,8 @@ def get_and_save_facebook_photo_view(request):
                                     )
 
     try:
-        query = CandidateCampaign.objects.all() if is_candidate else Organization.objects.all()
+        query = CandidateCampaign.objects.all() if is_candidate else Organization.objects.all()  # Cannot be
+        # 'readonly' because we save facebook URL and Profile image information below
 
         query = query.filter(we_vote_id__iexact=we_vote_id)
         entity_list = list(query)

--- a/import_export_twitter/controllers.py
+++ b/import_export_twitter/controllers.py
@@ -1796,7 +1796,7 @@ def retrieve_and_update_organizations_needing_twitter_update(batch_process_id=0)
         list(set(organization_we_vote_id_list_to_include) - set(organization_we_vote_id_list_to_exclude))
 
     try:
-        organization_queryset = Organization.objects.all()
+        organization_queryset = Organization.objects.using('readonly').all()
         organization_queryset = organization_queryset.filter(we_vote_id__in=organization_we_vote_id_list)
         organization_queryset = organization_queryset.exclude(organization_twitter_updates_failing=True)
         # Limit this search to non-individuals
@@ -2198,7 +2198,7 @@ def scrape_and_save_social_media_from_all_organizations(state_code='', force_ret
     twitter_handles_found = 0
 
     organization_manager = OrganizationManager()
-    organization_list_query = Organization.objects.order_by('organization_name')
+    organization_list_query = Organization.objects.order_by('organization_name')  # Cannot be readonly
     if positive_value_exists(state_code):
         organization_list_query = organization_list_query.filter(state_served_code=state_code)
 
@@ -2241,7 +2241,7 @@ def refresh_twitter_data_for_organizations(state_code='', google_civic_election_
     number_of_twitter_accounts_queried = 0
     number_of_organizations_updated = 0
 
-    organization_list_query = Organization.objects.order_by('organization_name')
+    organization_list_query = Organization.objects.using('readonly').order_by('organization_name')
     if positive_value_exists(state_code):
         organization_list_query = organization_list_query.filter(state_served_code=state_code)
 

--- a/import_export_wikipedia/controllers.py
+++ b/import_export_wikipedia/controllers.py
@@ -712,7 +712,7 @@ def retrieve_all_organizations_logos_from_wikipedia(state_code=''):
     logos_found = 0
     force_retrieve = False
 
-    organization_list_query = Organization.objects.order_by('organization_name')
+    organization_list_query = Organization.objects.order_by('organization_name')  # Cannot be 'readonly'
     if positive_value_exists(state_code):
         organization_list_query = organization_list_query.filter(state_served_code=state_code)
 

--- a/issue/controllers.py
+++ b/issue/controllers.py
@@ -523,7 +523,7 @@ def issue_organizations_retrieve_for_api(issue_we_vote_id=''):  # issueOrganizat
     organization_list_found = False
     from organization.models import Organization
     try:
-        organization_queryset = Organization.objects.all()
+        organization_queryset = Organization.objects.using('readonly').all()
         organization_queryset = organization_queryset.filter(we_vote_id__in=complete_organization_we_vote_id_list)
         organization_queryset = organization_queryset.order_by('-twitter_followers_count')
         organization_list = list(organization_queryset)

--- a/organization/models.py
+++ b/organization/models.py
@@ -2654,7 +2654,7 @@ class OrganizationListManager(models.Manager):
                 # - organization.twitter_user_id
                 # - organization.organization_twitter_handle
                 try:
-                    organization_queryset = Organization.objects.all()
+                    organization_queryset = Organization.objects.all()  # Cannot be Readonly
 
                     # We want to find organizations with *any* of these values
                     new_filter = Q(twitter_user_id=twitter_user_id)
@@ -2995,7 +2995,7 @@ class OrganizationListManager(models.Manager):
 
         if positive_value_exists(organization_name):
             try:
-                organization_queryset = Organization.objects.all()
+                organization_queryset = Organization.objects.using('readonly').all()
                 organization_queryset = organization_queryset.filter(
                     organization_name__iexact=organization_name)
 

--- a/organization/views_admin.py
+++ b/organization/views_admin.py
@@ -2463,7 +2463,7 @@ def organization_position_new_view(request, organization_id):
     organization_on_stage_found = False
     organization_on_stage = Organization()
     try:
-        organization_on_stage = Organization.objects.get(id=organization_id)
+        organization_on_stage = Organization.objects.using('readonly').get(id=organization_id)
         organization_on_stage_found = True
     except Organization.MultipleObjectsReturned as e:
         handle_record_found_more_than_one_exception(e, logger=logger)
@@ -2693,9 +2693,9 @@ def organization_position_edit_view(request, organization_id=0, organization_we_
     organization_on_stage_found = False
     try:
         if positive_value_exists(organization_id):
-            organization_on_stage = Organization.objects.get(id=organization_id)
+            organization_on_stage = Organization.objects.using('readonly').get(id=organization_id)
         else:
-            organization_on_stage = Organization.objects.get(we_vote_id=organization_we_vote_id)
+            organization_on_stage = Organization.objects.using('readonly').get(we_vote_id=organization_we_vote_id)
         organization_on_stage_found = True
     except Organization.MultipleObjectsReturned as e:
         handle_record_found_more_than_one_exception(e, logger=logger)

--- a/politician/controllers.py
+++ b/politician/controllers.py
@@ -823,7 +823,7 @@ def match_politician_to_organization(
     if use_name_match:
         organization_possible_match_by_name_found = False
         try:
-            queryset = Organization.objects.all()
+            queryset = Organization.objects.all()  # Cannot be 'readonly'
             queryset = queryset.filter(
                 Q(politician_we_vote_id__isnull=True) |
                 Q(politician_we_vote_id__iexact=''))

--- a/position/controllers.py
+++ b/position/controllers.py
@@ -220,7 +220,7 @@ def find_organizations_referenced_in_positions_for_this_voter(voter):
             final_organization_filters |= item
 
         # Finally, retrieve all of the organizations from any of these positions
-        organization_list_query = Organization.objects.all()
+        organization_list_query = Organization.objects.using('readonly').all()
         organization_list_query = organization_list_query.filter(final_organization_filters)
 
         for organization in organization_list_query:

--- a/voter/views_admin.py
+++ b/voter/views_admin.py
@@ -987,7 +987,7 @@ def voter_edit_view(request, voter_id=0, voter_we_vote_id=""):
                 for item in org_twitter_filters:
                     final_filters |= item
 
-            organization_list_with_duplicate_twitter = Organization.objects.all()
+            organization_list_with_duplicate_twitter = Organization.objects.using('readonly').all()
             organization_list_with_duplicate_twitter = organization_list_with_duplicate_twitter.filter(final_filters)
             organization_list_with_duplicate_twitter = organization_list_with_duplicate_twitter.exclude(
                 we_vote_id=voter_on_stage.linked_organization_we_vote_id)
@@ -1005,7 +1005,7 @@ def voter_edit_view(request, voter_id=0, voter_we_vote_id=""):
         # ####################################
         # Find the voter that has this organization as their linked_organization_we_vote_id
         linked_organization_we_vote_id_list_updated = []
-        linked_organization_we_vote_id_list = Organization.objects.all()
+        linked_organization_we_vote_id_list = Organization.objects.using('readonly').all()
         linked_organization_we_vote_id_list = linked_organization_we_vote_id_list.filter(
             we_vote_id__iexact=voter_on_stage.linked_organization_we_vote_id)
 


### PR DESCRIPTION
\admin_tools\views.py - Goes to Template values
\issue\controllers.py - data retrieved for Api

\import_export_twitter\controllers.py -  Data is passed on to the below functions
(refresh_twitter_organization_details  -> save_fresh_twitter_details  >save_fresh_twitter_details_to_organization(in this function another instance of Organization is created and the twitter details are updated to the organization table) 

\organization\views_admin.py  - Goes to template values
\organization\models.py - Goes to template values
\position\controllers.py - Organization information retrieved for the voter list template
\voter\views_admin.py - Goes to Template values

\import_export_wikipedia\controllers.py - Added Comment - Cannot be Read-only
\politician\controllers.py - Line - Added Comment - Cannot be Read-only
\import_export_facebook\views_admin.py - Added Comment - Cannot be Read-only
