### PR TITLE
Removing __iexact from "we_vote_id" queries. We have found that searches with __iexact are much slower and don't use indexes in the same way, so I am removing most of them. Also adding SMS_BYPASS_MOBILE_NUMBER as an environment_variables setting.

### DIFF
--- a/activity/models.py
+++ b/activity/models.py
@@ -369,13 +369,13 @@ class ActivityManager(models.Manager):
             if positive_value_exists(parent_comment_we_vote_id):
                 queryset = ActivityComment.objects.using('readonly').all()
                 queryset = queryset.filter(
-                    parent_comment_we_vote_id__iexact=parent_comment_we_vote_id,
+                    parent_comment_we_vote_id=parent_comment_we_vote_id,
                     deleted=False
                 )
             else:
-                queryset = ActivityComment.objects.all()
+                queryset = ActivityComment.objects.using('readonly').all()
                 queryset = queryset.filter(
-                    parent_we_vote_id__iexact=parent_we_vote_id,
+                    parent_we_vote_id=parent_we_vote_id,
                     deleted=False
                 )
                 # Don't retrieve entries where there is a value for parent_comment_we_vote_id
@@ -425,13 +425,13 @@ class ActivityManager(models.Manager):
             if positive_value_exists(parent_comment_we_vote_id):
                 queryset = ActivityComment.objects.all()
                 queryset = queryset.filter(
-                    parent_comment_we_vote_id__iexact=parent_comment_we_vote_id,
+                    parent_comment_we_vote_id=parent_comment_we_vote_id,
                     deleted=False
                 )
             else:
                 queryset = ActivityComment.objects.all()
                 queryset = queryset.filter(
-                    parent_we_vote_id__iexact=parent_we_vote_id,
+                    parent_we_vote_id=parent_we_vote_id,
                     deleted=False
                 )
                 # Don't retrieve entries where there is a value for parent_comment_we_vote_id
@@ -489,11 +489,11 @@ class ActivityManager(models.Manager):
                 campaignx_we_vote_id=campaignx_we_vote_id,
                 deleted=False,
                 kind_of_notice=kind_of_notice,
-                recipient_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
+                recipient_voter_we_vote_id=recipient_voter_we_vote_id,
             )
             if positive_value_exists(speaker_organization_we_vote_id):
                 query = query.filter(
-                    speaker_organization_we_vote_id__iexact=speaker_organization_we_vote_id,
+                    speaker_organization_we_vote_id=speaker_organization_we_vote_id,
                 )
                 activity_notice = query.get()
                 activity_notice_id = activity_notice.id
@@ -502,7 +502,7 @@ class ActivityManager(models.Manager):
                 status += "RETRIEVE_RECENT_ACTIVITY_NOTICE_FOUND_BY_ORG_WE_VOTE_ID "
             elif positive_value_exists(speaker_voter_we_vote_id):
                 query = query.filter(
-                    speaker_voter_we_vote_id__iexact=speaker_voter_we_vote_id,
+                    speaker_voter_we_vote_id=speaker_voter_we_vote_id,
                 )
                 activity_notice = query.get()
                 activity_notice_id = activity_notice.id
@@ -648,7 +648,7 @@ class ActivityManager(models.Manager):
                     date_of_notice__gte=earliest_date_of_notice,
                     deleted=False,
                     kind_of_seed=kind_of_seed,
-                    recipient_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
+                    recipient_voter_we_vote_id=recipient_voter_we_vote_id,
                 )
                 activity_notice_seed_id = activity_notice_seed.id
                 activity_notice_seed_found = True
@@ -699,8 +699,8 @@ class ActivityManager(models.Manager):
                     campaignx_we_vote_id=campaignx_we_vote_id,
                     deleted=False,
                     kind_of_notice=kind_of_notice,
-                    recipient_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
-                    speaker_organization_we_vote_id__iexact=speaker_organization_we_vote_id,
+                    recipient_voter_we_vote_id=recipient_voter_we_vote_id,
+                    speaker_organization_we_vote_id=speaker_organization_we_vote_id,
                 )
                 activity_notice_id = activity_notice.id
                 activity_notice_found = True
@@ -712,8 +712,8 @@ class ActivityManager(models.Manager):
                     campaignx_we_vote_id=campaignx_we_vote_id,
                     deleted=False,
                     kind_of_notice=kind_of_notice,
-                    recipient_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
-                    speaker_voter_we_vote_id__iexact=speaker_voter_we_vote_id,
+                    recipient_voter_we_vote_id=recipient_voter_we_vote_id,
+                    speaker_voter_we_vote_id=speaker_voter_we_vote_id,
                 )
                 activity_notice_id = activity_notice.id
                 activity_notice_found = True
@@ -831,7 +831,7 @@ class ActivityManager(models.Manager):
                     date_of_notice__gte=earliest_date_of_notice,
                     deleted=False,
                     kind_of_seed=kind_of_seed,
-                    speaker_organization_we_vote_id__iexact=speaker_organization_we_vote_id,
+                    speaker_organization_we_vote_id=speaker_organization_we_vote_id,
                 )
                 activity_notice_seed_id = activity_notice_seed.id
                 activity_notice_seed_found = True
@@ -843,7 +843,7 @@ class ActivityManager(models.Manager):
                     date_of_notice__gte=earliest_date_of_notice,
                     deleted=False,
                     kind_of_seed=kind_of_seed,
-                    speaker_voter_we_vote_id__iexact=speaker_voter_we_vote_id,
+                    speaker_voter_we_vote_id=speaker_voter_we_vote_id,
                 )
                 activity_notice_seed_id = activity_notice_seed.id
                 activity_notice_seed_found = True
@@ -896,7 +896,7 @@ class ActivityManager(models.Manager):
         try:
             queryset = ActivityNotice.objects.all()
             queryset = queryset.filter(
-                recipient_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
+                recipient_voter_we_vote_id=recipient_voter_we_vote_id,
                 deleted=False
             )
             queryset = queryset.exclude(
@@ -1257,7 +1257,7 @@ class ActivityManager(models.Manager):
             if activity_notice_clicked and activity_notice_seen:
                 ActivityNotice.objects.all().filter(
                     id__in=activity_notice_id_list,
-                    recipient_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
+                    recipient_voter_we_vote_id=recipient_voter_we_vote_id,
                     deleted=False
                 ).update(
                     activity_notice_seen=True,
@@ -1265,14 +1265,14 @@ class ActivityManager(models.Manager):
             elif activity_notice_clicked:
                 ActivityNotice.objects.all().filter(
                     id__in=activity_notice_id_list,
-                    recipient_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
+                    recipient_voter_we_vote_id=recipient_voter_we_vote_id,
                     deleted=False
                 ).update(
                     activity_notice_clicked=True)
             elif activity_notice_seen:
                 ActivityNotice.objects.all().filter(
                     id__in=activity_notice_id_list,
-                    recipient_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
+                    recipient_voter_we_vote_id=recipient_voter_we_vote_id,
                     deleted=False
                 ).update(
                     activity_notice_seen=True)
@@ -1550,7 +1550,7 @@ class ActivityManager(models.Manager):
 
         try:
             updated_count = ActivityComment.objects.all().filter(
-                commenter_voter_we_vote_id__iexact=speaker_voter_we_vote_id,
+                commenter_voter_we_vote_id=speaker_voter_we_vote_id,
                 deleted=False
             ).update(
                 commenter_name=speaker_name)
@@ -1564,7 +1564,7 @@ class ActivityManager(models.Manager):
 
         try:
             updated_count = ActivityNotice.objects.all().filter(
-                speaker_voter_we_vote_id__iexact=speaker_voter_we_vote_id,
+                speaker_voter_we_vote_id=speaker_voter_we_vote_id,
                 deleted=False
             ).update(
                 speaker_name=speaker_name)
@@ -1578,12 +1578,12 @@ class ActivityManager(models.Manager):
 
         try:
             updated_seed_count1 = ActivityNoticeSeed.objects.all().filter(
-                speaker_voter_we_vote_id__iexact=speaker_voter_we_vote_id,
+                speaker_voter_we_vote_id=speaker_voter_we_vote_id,
                 deleted=False
             ).update(
                 speaker_name=speaker_name)
             updated_seed_count2 = ActivityNoticeSeed.objects.all().filter(
-                recipient_voter_we_vote_id__iexact=speaker_voter_we_vote_id,
+                recipient_voter_we_vote_id=speaker_voter_we_vote_id,
                 deleted=False
             ).update(
                 recipient_name=speaker_name)
@@ -1598,7 +1598,7 @@ class ActivityManager(models.Manager):
 
         try:
             updated_count = ActivityPost.objects.all().filter(
-                speaker_voter_we_vote_id__iexact=speaker_voter_we_vote_id,
+                speaker_voter_we_vote_id=speaker_voter_we_vote_id,
                 deleted=False
             ).update(
                 speaker_name=speaker_name)

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -264,7 +264,7 @@ class AnalyticsCountManager(models.Manager):
             first_visit_query = AnalyticsAction.objects.using('readonly').all()  # 'analytics'
             first_visit_query = first_visit_query.filter(Q(action_constant=ACTION_VOTER_GUIDE_VISIT) |
                                                          Q(action_constant=ACTION_ORGANIZATION_AUTO_FOLLOW))
-            first_visit_query = first_visit_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+            first_visit_query = first_visit_query.filter(organization_we_vote_id=organization_we_vote_id)
             if positive_value_exists(google_civic_election_id):
                 first_visit_query = first_visit_query.filter(google_civic_election_id=google_civic_election_id)
             first_visit_query = first_visit_query.filter(first_visit_today=True)
@@ -390,7 +390,7 @@ class AnalyticsCountManager(models.Manager):
                 count_query = count_query.filter(google_civic_election_id=google_civic_election_id)
             if positive_value_exists(organization_we_vote_id):
                 count_query = count_query.filter(action_constant=ACTION_VOTER_GUIDE_VISIT)
-                count_query = count_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                count_query = count_query.filter(organization_we_vote_id=organization_we_vote_id)
             if positive_value_exists(limit_to_one_date_as_integer):
                 count_query = count_query.filter(date_as_integer=limit_to_one_date_as_integer)
             elif positive_value_exists(count_through_this_date_as_integer):
@@ -416,7 +416,7 @@ class AnalyticsCountManager(models.Manager):
             count_query = AnalyticsAction.objects.using('readonly').all()  # 'analytics'
             count_query = count_query.filter(Q(action_constant=ACTION_VOTER_GUIDE_VISIT) |
                                              Q(action_constant=ACTION_ORGANIZATION_AUTO_FOLLOW))
-            count_query = count_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+            count_query = count_query.filter(organization_we_vote_id=organization_we_vote_id)
             count_query = count_query.filter(google_civic_election_id=google_civic_election_id)
             count_query = count_query.filter(first_visit_today=True)
             count_query = count_query.values('voter_we_vote_id').distinct()
@@ -438,7 +438,7 @@ class AnalyticsCountManager(models.Manager):
             count_query = count_query.filter(Q(action_constant=ACTION_ORGANIZATION_FOLLOW) |
                                              Q(action_constant=ACTION_ORGANIZATION_AUTO_FOLLOW))
             if positive_value_exists(organization_we_vote_id):
-                count_query = count_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                count_query = count_query.filter(organization_we_vote_id=organization_we_vote_id)
             count_query = count_query.filter(google_civic_election_id=google_civic_election_id)
             count_query = count_query.values('voter_we_vote_id').distinct()
             count_result = count_query.count()
@@ -458,7 +458,7 @@ class AnalyticsCountManager(models.Manager):
             count_query = AnalyticsAction.objects.using('readonly').all()  # 'analytics'
             count_query = count_query.filter(action_constant=ACTION_ORGANIZATION_AUTO_FOLLOW)
             if positive_value_exists(organization_we_vote_id):
-                count_query = count_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                count_query = count_query.filter(organization_we_vote_id=organization_we_vote_id)
             count_query = count_query.filter(google_civic_election_id=google_civic_election_id)
             count_query = count_query.values('voter_we_vote_id').distinct()
             count_result = count_query.count()
@@ -471,7 +471,7 @@ class AnalyticsCountManager(models.Manager):
         count_result = None
         try:
             count_query = AnalyticsAction.objects.using('readonly').all()  # 'analytics'
-            count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            count_query = count_query.filter(voter_we_vote_id=voter_we_vote_id)
             count_result = count_query.count()
         except Exception as e:
             pass
@@ -482,12 +482,12 @@ class AnalyticsCountManager(models.Manager):
         count_result = None
         try:
             count_query = AnalyticsAction.objects.using('readonly').all()  # 'analytics'
-            count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            count_query = count_query.filter(voter_we_vote_id=voter_we_vote_id)
             count_query = count_query.filter(action_constant=ACTION_BALLOT_VISIT)
             if positive_value_exists(google_civic_election_id):
                 count_query = count_query.filter(google_civic_election_id=google_civic_election_id)
             if positive_value_exists(organization_we_vote_id):
-                count_query = count_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                count_query = count_query.filter(organization_we_vote_id=organization_we_vote_id)
             count_result = count_query.count()
         except Exception as e:
             pass
@@ -498,7 +498,7 @@ class AnalyticsCountManager(models.Manager):
         count_result = None
         try:
             count_query = AnalyticsAction.objects.using('readonly').all()  # 'analytics'
-            count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            count_query = count_query.filter(voter_we_vote_id=voter_we_vote_id)
             count_query = count_query.filter(action_constant=ACTION_WELCOME_VISIT)
             count_result = count_query.count()
         except Exception as e:
@@ -510,7 +510,7 @@ class AnalyticsCountManager(models.Manager):
         count_result = None
         try:
             count_query = AnalyticsAction.objects.using('readonly').all()  # 'analytics'
-            count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            count_query = count_query.filter(voter_we_vote_id=voter_we_vote_id)
             count_query = count_query.values('date_as_integer').distinct()
             count_result = count_query.count()
         except Exception as e:
@@ -522,7 +522,7 @@ class AnalyticsCountManager(models.Manager):
         last_action_date = None
         try:
             fetch_query = AnalyticsAction.objects.using('readonly').all()  # 'analytics'
-            fetch_query = fetch_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            fetch_query = fetch_query.filter(voter_we_vote_id=voter_we_vote_id)
             fetch_query = fetch_query.order_by('-id')
             fetch_query = fetch_query[:1]
             fetch_result = list(fetch_query)
@@ -537,7 +537,7 @@ class AnalyticsCountManager(models.Manager):
         count_result = 0
         try:
             count_query = AnalyticsAction.objects.using('readonly').all()  # 'analytics'
-            count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            count_query = count_query.filter(voter_we_vote_id=voter_we_vote_id)
             count_query = count_query.filter(action_constant=ACTION_VOTER_GUIDE_VISIT)
             count_query = count_query.values('organization_we_vote_id').distinct()
             count_result = count_query.count()
@@ -742,13 +742,13 @@ class AnalyticsManager(models.Manager):
             else:
                 list_query = AnalyticsAction.objects.using('analytics').all()
             if positive_value_exists(voter_we_vote_id):
-                list_query = list_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                list_query = list_query.filter(voter_we_vote_id=voter_we_vote_id)
             elif len(voter_we_vote_id_list):
                 list_query = list_query.filter(voter_we_vote_id__in=voter_we_vote_id_list)
             if positive_value_exists(google_civic_election_id):
                 list_query = list_query.filter(google_civic_election_id=google_civic_election_id)
             if positive_value_exists(organization_we_vote_id):
-                list_query = list_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                list_query = list_query.filter(organization_we_vote_id=organization_we_vote_id)
             if positive_value_exists(action_constant):
                 list_query = list_query.filter(action_constant=action_constant)
             if positive_value_exists(state_code):
@@ -802,13 +802,13 @@ class AnalyticsManager(models.Manager):
             elif positive_value_exists(analytics_date_as_integer):
                 list_query = list_query.filter(analytics_date_as_integer=analytics_date_as_integer)
             if positive_value_exists(voter_we_vote_id):
-                list_query = list_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                list_query = list_query.filter(voter_we_vote_id=voter_we_vote_id)
             elif len(voter_we_vote_id_list):
                 list_query = list_query.filter(voter_we_vote_id__in=voter_we_vote_id_list)
             if positive_value_exists(google_civic_election_id):
                 list_query = list_query.filter(google_civic_election_id=google_civic_election_id)
             if positive_value_exists(organization_we_vote_id):
-                list_query = list_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                list_query = list_query.filter(organization_we_vote_id=organization_we_vote_id)
             if positive_value_exists(kind_of_process):
                 list_query = list_query.filter(kind_of_process__iexact=kind_of_process)
 
@@ -854,13 +854,13 @@ class AnalyticsManager(models.Manager):
             list_query = AnalyticsProcessed.objects.using('analytics').filter(
                 analytics_date_as_integer=analytics_date_as_integer)
             if positive_value_exists(voter_we_vote_id):
-                list_query = list_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                list_query = list_query.filter(voter_we_vote_id=voter_we_vote_id)
             elif len(voter_we_vote_id_list):
                 list_query = list_query.filter(voter_we_vote_id__in=voter_we_vote_id_list)
             if positive_value_exists(google_civic_election_id):
                 list_query = list_query.filter(google_civic_election_id=google_civic_election_id)
             if positive_value_exists(organization_we_vote_id):
-                list_query = list_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                list_query = list_query.filter(organization_we_vote_id=organization_we_vote_id)
             if positive_value_exists(kind_of_process):
                 list_query = list_query.filter(kind_of_process__iexact=kind_of_process)
             list_query.delete()
@@ -1462,7 +1462,7 @@ class AnalyticsManager(models.Manager):
             try:
                 metrics_saved, created = OrganizationElectionMetrics.objects.using('analytics').update_or_create(
                     google_civic_election_id=google_civic_election_id,
-                    organization_we_vote_id__iexact=organization_we_vote_id,
+                    organization_we_vote_id=organization_we_vote_id,
                     defaults=organization_election_metrics_values
                 )
             except Exception as e:
@@ -1546,7 +1546,7 @@ class AnalyticsManager(models.Manager):
 
             try:
                 metrics_saved, created = SitewideVoterMetrics.objects.using('analytics').update_or_create(
-                    voter_we_vote_id__iexact=voter_we_vote_id,
+                    voter_we_vote_id=voter_we_vote_id,
                     defaults=sitewide_voter_metrics_values
                 )
                 success = True
@@ -1573,7 +1573,7 @@ class AnalyticsManager(models.Manager):
     @staticmethod
     def sitewide_voter_metrics_for_this_voter_updated_this_date(voter_we_vote_id, updated_date_integer):
         updated_on_date_query = SitewideVoterMetrics.objects.using('readonly').filter(  # 'analytics'
-            voter_we_vote_id__iexact=voter_we_vote_id,
+            voter_we_vote_id=voter_we_vote_id,
             last_calculated_date_as_integer=updated_date_integer
         )
         return positive_value_exists(updated_on_date_query.count())
@@ -1641,7 +1641,7 @@ class AnalyticsManager(models.Manager):
                     first_visit_query = AnalyticsAction.objects.using('analytics').all()
                     first_visit_query = first_visit_query.order_by("id")  # order by oldest first
                     first_visit_query = first_visit_query.filter(date_as_integer=one_date_as_integer)
-                    first_visit_query = first_visit_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                    first_visit_query = first_visit_query.filter(voter_we_vote_id=voter_we_vote_id)
                     analytics_action = first_visit_query.first()
 
                     if not analytics_action.first_visit_today:
@@ -1672,7 +1672,7 @@ class AnalyticsManager(models.Manager):
         # Get distinct days
         try:
             distinct_days_query = AnalyticsAction.objects.using('readonly').all()  # 'analytics'
-            distinct_days_query = distinct_days_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            distinct_days_query = distinct_days_query.filter(voter_we_vote_id=voter_we_vote_id)
             distinct_days_query = distinct_days_query.values('date_as_integer').distinct()
             distinct_days_list = list(distinct_days_query)
         except Exception as e:
@@ -1689,7 +1689,7 @@ class AnalyticsManager(models.Manager):
                 first_visit_query = AnalyticsAction.objects.using('analytics').all()
                 first_visit_query = first_visit_query.order_by("id")  # order by oldest first
                 first_visit_query = first_visit_query.filter(date_as_integer=one_date_as_integer)
-                first_visit_query = first_visit_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                first_visit_query = first_visit_query.filter(voter_we_vote_id=voter_we_vote_id)
                 analytics_action = first_visit_query.first()
 
                 analytics_action.first_visit_today = True

--- a/analytics/views_admin.py
+++ b/analytics/views_admin.py
@@ -801,7 +801,7 @@ def organization_analytics_index_view(request):
         organization_election_metrics_query = OrganizationElectionMetrics.objects.using('readonly').all()  # 'analytics'
         organization_election_metrics_query = organization_election_metrics_query.order_by('-election_day_text')
         organization_election_metrics_query = \
-            organization_election_metrics_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+            organization_election_metrics_query.filter(organization_we_vote_id=organization_we_vote_id)
         organization_election_metrics_query = organization_election_metrics_query[:3]
         organization_election_metrics_list = list(organization_election_metrics_query)
     except OrganizationElectionMetrics.DoesNotExist:
@@ -813,7 +813,7 @@ def organization_analytics_index_view(request):
         organization_daily_metrics_query = OrganizationDailyMetrics.objects.using('readonly').all()  # 'analytics'
         organization_daily_metrics_query = organization_daily_metrics_query.order_by('-date_as_integer')
         organization_daily_metrics_query = \
-            organization_daily_metrics_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+            organization_daily_metrics_query.filter(organization_we_vote_id=organization_we_vote_id)
         organization_daily_metrics_query = organization_daily_metrics_query[:3]
         organization_daily_metrics_list = list(organization_daily_metrics_query)
     except OrganizationDailyMetrics.DoesNotExist:
@@ -911,12 +911,12 @@ def analytics_action_list_view(request, voter_we_vote_id=False, organization_we_
             analytics_action_query = analytics_action_query.filter(
                 date_as_integer__lte=through_date_as_integer)
         if positive_value_exists(voter_we_vote_id):
-            analytics_action_query = analytics_action_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            analytics_action_query = analytics_action_query.filter(voter_we_vote_id=voter_we_vote_id)
         if positive_value_exists(google_civic_election_id):
             analytics_action_query = analytics_action_query.filter(google_civic_election_id=google_civic_election_id)
         if positive_value_exists(organization_we_vote_id):
             analytics_action_query = analytics_action_query.filter(
-                organization_we_vote_id__iexact=organization_we_vote_id)
+                organization_we_vote_id=organization_we_vote_id)
 
         if positive_value_exists(analytics_action_search):
             search_words = analytics_action_search.split()
@@ -930,7 +930,7 @@ def analytics_action_list_view(request, voter_we_vote_id=False, organization_we_
                     new_filter = Q(action_constant=action_constant_integer)
                     filters.append(new_filter)
 
-                new_filter = Q(ballot_item_we_vote_id__iexact=one_word)
+                new_filter = Q(ballot_item_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 if positive_value_exists(one_word_integer):
@@ -945,13 +945,13 @@ def analytics_action_list_view(request, voter_we_vote_id=False, organization_we_
                     new_filter = Q(id=one_word_integer)
                     filters.append(new_filter)
 
-                new_filter = Q(organization_we_vote_id__iexact=one_word)
+                new_filter = Q(organization_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = Q(state_code__iexact=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(voter_we_vote_id__iexact=one_word)
+                new_filter = Q(voter_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 # Add the first query
@@ -1106,7 +1106,7 @@ def organization_daily_metrics_view(request):
         organization_daily_metrics_query = OrganizationDailyMetrics.objects.using('analytics').\
             order_by('-date_as_integer')
         organization_daily_metrics_query = organization_daily_metrics_query.filter(
-            organization_we_vote_id__iexact=organization_we_vote_id)
+            organization_we_vote_id=organization_we_vote_id)
         organization_daily_metrics_list = list(organization_daily_metrics_query)
     except OrganizationDailyMetrics.DoesNotExist:
         # This is fine
@@ -1184,7 +1184,7 @@ def organization_election_metrics_view(request):
                 organization_election_metrics_query.filter(google_civic_election_id=google_civic_election_id)
         if positive_value_exists(organization_we_vote_id):
             organization_election_metrics_query = \
-                organization_election_metrics_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                organization_election_metrics_query.filter(organization_we_vote_id=organization_we_vote_id)
         organization_election_metrics_list = list(organization_election_metrics_query)
     except OrganizationElectionMetrics.DoesNotExist:
         # This is fine

--- a/apple/controllers.py
+++ b/apple/controllers.py
@@ -141,7 +141,7 @@ def delete_apple_user_entries_for_voter(voter_to_delete_we_vote_id):
         return results
 
     apple_users_query = AppleUser.objects.all()
-    apple_users_query = apple_users_query.filter(voter_we_vote_id__iexact=voter_to_delete_we_vote_id)
+    apple_users_query = apple_users_query.filter(voter_we_vote_id=voter_to_delete_we_vote_id)
     apple_users_list = list(apple_users_query)
     for apple_user_link in apple_users_list:
         try:
@@ -199,7 +199,7 @@ def move_apple_user_entries_to_another_voter(from_voter_we_vote_id, to_voter_we_
 
     apple_users_query = AppleUser.objects.all()
     apple_users_query = apple_users_query.filter(
-        voter_we_vote_id__iexact=from_voter_we_vote_id)
+        voter_we_vote_id=from_voter_we_vote_id)
     apple_users_list = list(apple_users_query)
     for apple_user_link in apple_users_list:
         try:

--- a/ballot/models.py
+++ b/ballot/models.py
@@ -570,7 +570,7 @@ class BallotItemManager(models.Manager):
                     contest_measure_id__exact=contest_measure_id,
                     contest_office_id__exact=contest_office_id,
                     google_civic_election_id__exact=google_civic_election_id,
-                    polling_location_we_vote_id__iexact=polling_location_we_vote_id,
+                    polling_location_we_vote_id=polling_location_we_vote_id,
                     defaults=create_values)
                 ballot_item_found = True
             except BallotItem.MultipleObjectsReturned as e:
@@ -1282,7 +1282,7 @@ class BallotItemListManager(models.Manager):
                 ballot_item_queryset = ballot_item_queryset.filter(voter_id=voter_id)
             if positive_value_exists(polling_location_we_vote_id):
                 ballot_item_queryset = ballot_item_queryset.filter(
-                    polling_location_we_vote_id__iexact=polling_location_we_vote_id)
+                    polling_location_we_vote_id=polling_location_we_vote_id)
 
             ballot_item_list = list(ballot_item_queryset)
             ballot_item_list_count = len(ballot_item_list)
@@ -1491,7 +1491,7 @@ class BallotItemListManager(models.Manager):
                     voter_id=voter_id)
             elif positive_value_exists(polling_location_we_vote_id):
                 ballot_item_queryset = ballot_item_queryset.filter(
-                    polling_location_we_vote_id__iexact=polling_location_we_vote_id)
+                    polling_location_we_vote_id=polling_location_we_vote_id)
             ballot_item_queryset = ballot_item_queryset.filter(google_civic_election_id=google_civic_election_id)
             return ballot_item_queryset.count()
         except BallotItem.DoesNotExist:
@@ -1732,7 +1732,7 @@ class BallotItemListManager(models.Manager):
             ballot_item_queryset = ballot_item_queryset.filter(google_civic_election_id=google_civic_election_id)
             if positive_value_exists(polling_location_we_vote_id):
                 ballot_item_queryset = ballot_item_queryset.filter(
-                    polling_location_we_vote_id__iexact=polling_location_we_vote_id)
+                    polling_location_we_vote_id=polling_location_we_vote_id)
             else:
                 ballot_item_queryset = ballot_item_queryset.filter(
                     voter_id=voter_id)
@@ -1746,17 +1746,17 @@ class BallotItemListManager(models.Manager):
                 if positive_value_exists(contest_office_we_vote_id):
                     # Ignore entries with contest_office_we_vote_id coming in from master server
                     ballot_item_queryset = ballot_item_queryset.filter(~Q(
-                        contest_office_we_vote_id__iexact=contest_office_we_vote_id))
+                        contest_office_we_vote_id=contest_office_we_vote_id))
                 elif positive_value_exists(contest_measure_we_vote_id):
                     # Ignore entries with contest_measure_we_vote_id coming in from master server
                     ballot_item_queryset = ballot_item_queryset.filter(~Q(
-                        contest_measure_we_vote_id__iexact=contest_measure_we_vote_id))
+                        contest_measure_we_vote_id=contest_measure_we_vote_id))
             elif positive_value_exists(contest_office_we_vote_id):
                 ballot_item_queryset = ballot_item_queryset.filter(
-                    contest_office_we_vote_id__iexact=contest_office_we_vote_id)
+                    contest_office_we_vote_id=contest_office_we_vote_id)
             elif positive_value_exists(contest_measure_we_vote_id):
                 ballot_item_queryset = ballot_item_queryset.filter(
-                    contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+                    contest_measure_we_vote_id=contest_measure_we_vote_id)
 
             ballot_item_list_objects = list(ballot_item_queryset)
             ballot_item_list_count = len(ballot_item_list_objects)
@@ -2165,7 +2165,7 @@ class BallotReturnedManager(models.Manager):
                 status += "BALLOT_RETURNED_FOUND_FROM_VOTER_ID "
             elif positive_value_exists(ballot_returned_we_vote_id):
                 ballot_deleted_count, details = BallotReturned.objects.get(
-                    we_vote_id__iexact=ballot_returned_we_vote_id).delete()
+                    we_vote_id=ballot_returned_we_vote_id).delete()
                 ballot_deleted = positive_value_exists(ballot_deleted_count)
                 status += "BALLOT_RETURNED_FOUND_FROM_BALLOT_RETURNED_WE_VOTE_ID "
             elif positive_value_exists(ballot_location_shortcut):
@@ -3295,7 +3295,7 @@ class BallotReturnedListManager(models.Manager):
             ballot_returned_queryset = \
                 ballot_returned_queryset.filter(google_civic_election_id=google_civic_election_id)
             ballot_returned_queryset = \
-                ballot_returned_queryset.filter(polling_location_we_vote_id__iexact=polling_location_we_vote_id)
+                ballot_returned_queryset.filter(polling_location_we_vote_id=polling_location_we_vote_id)
             ballot_returned_queryset = ballot_returned_queryset.filter(voter_id=voter_id)
 
             ballot_returned_list = list(ballot_returned_queryset)
@@ -3441,13 +3441,13 @@ class BallotReturnedListManager(models.Manager):
                 new_filter = Q(normalized_state__icontains=ballot_returned_search_str)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=ballot_returned_search_str)
+                new_filter = Q(we_vote_id=ballot_returned_search_str)
                 filters.append(new_filter)
 
                 new_filter = Q(voter_id__iexact=ballot_returned_search_str)
                 filters.append(new_filter)
 
-                new_filter = Q(polling_location_we_vote_id__iexact=ballot_returned_search_str)
+                new_filter = Q(polling_location_we_vote_id=ballot_returned_search_str)
                 filters.append(new_filter)
 
                 # Add the first query
@@ -3671,11 +3671,11 @@ class BallotReturnedListManager(models.Manager):
                         and ballot_returned_we_vote_id != to_ballot_returned_we_vote_id:
                     # Find Voter Ballot Saved entries that are copied from this polling_location
                     # number_query = VoterBallotSaved.objects.filter(
-                    #     ballot_returned_we_vote_id__iexact=ballot_returned_we_vote_id)
+                    #     ballot_returned_we_vote_id=ballot_returned_we_vote_id)
                     # number_updated = number_query.count()
 
                     number_updated = VoterBallotSaved.objects.filter(
-                        ballot_returned_we_vote_id__iexact=ballot_returned_we_vote_id)\
+                        ballot_returned_we_vote_id=ballot_returned_we_vote_id)\
                         .update(ballot_returned_we_vote_id=to_ballot_returned_we_vote_id)
                     total_updated += number_updated
                     # If still here, delete the ballot_returned we are looking at
@@ -3718,7 +3718,7 @@ class BallotReturnedListManager(models.Manager):
 
             # Ignore entries with polling_location_we_vote_id coming in from master server
             ballot_returned_queryset = ballot_returned_queryset.filter(~Q(
-                polling_location_we_vote_id__iexact=polling_location_we_vote_id))
+                polling_location_we_vote_id=polling_location_we_vote_id))
 
             ballot_returned_list_objects = ballot_returned_queryset
 
@@ -4010,7 +4010,7 @@ class VoterBallotSavedManager(models.Manager):
                 status += "VOTER_BALLOT_SAVED_FOUND_FROM_VOTER_ID_AND_GOOGLE_CIVIC "
             elif positive_value_exists(voter_id) and positive_value_exists(ballot_returned_we_vote_id):
                 voter_ballot_saved = VoterBallotSaved.objects.get(
-                    voter_id=voter_id, ballot_returned_we_vote_id__iexact=ballot_returned_we_vote_id)
+                    voter_id=voter_id, ballot_returned_we_vote_id=ballot_returned_we_vote_id)
                 # If still here, we found an existing voter_ballot_saved
                 voter_ballot_saved_id = voter_ballot_saved.id
                 voter_ballot_saved_found = True if positive_value_exists(voter_ballot_saved_id) else False

--- a/bookmark/models.py
+++ b/bookmark/models.py
@@ -337,10 +337,10 @@ class BookmarkItemList(models.Model):
                     candidate_we_vote_id=candidate_we_vote_id)
             if positive_value_exists(contest_measure_we_vote_id):
                 bookmark_item_list = bookmark_item_list.filter(
-                    contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+                    contest_measure_we_vote_id=contest_measure_we_vote_id)
             if positive_value_exists(contest_office_we_vote_id):
                 bookmark_item_list = bookmark_item_list.filter(
-                    contest_office_we_vote_id__iexact=contest_office_we_vote_id)
+                    contest_office_we_vote_id=contest_office_we_vote_id)
             if len(bookmark_item_list):
                 bookmark_item_list_found = True
         except Exception as e:

--- a/campaign/controllers.py
+++ b/campaign/controllers.py
@@ -2114,7 +2114,7 @@ def merge_these_two_campaignx_entries(
     campaignx1_organization_we_vote_id_list = []
     campaignx2_listed_by_organization_to_delete_list = []
     queryset = CampaignXListedByOrganization.objects.all()
-    queryset = queryset.filter(campaignx_we_vote_id__iexact=campaignx1_we_vote_id)
+    queryset = queryset.filter(campaignx_we_vote_id=campaignx1_we_vote_id)
     campaignx1_listed_by_organization_list = list(queryset)
     for campaignx1_listed_by_organization in campaignx1_listed_by_organization_list:
         if positive_value_exists(campaignx1_listed_by_organization.site_owner_organization_we_vote_id) and \
@@ -2124,7 +2124,7 @@ def merge_these_two_campaignx_entries(
                 .append(campaignx1_listed_by_organization.site_owner_organization_we_vote_id)
 
     queryset = CampaignXListedByOrganization.objects.all()
-    queryset = queryset.filter(campaignx_we_vote_id__iexact=campaignx2_we_vote_id)
+    queryset = queryset.filter(campaignx_we_vote_id=campaignx2_we_vote_id)
     campaignx2_listed_by_organization_list = list(queryset)
     for campaignx2_listed_by_organization in campaignx2_listed_by_organization_list:
         # Is this listed_by_organization already in CampaignX 1?
@@ -2144,7 +2144,7 @@ def merge_these_two_campaignx_entries(
     # #####################################
     # Merge CampaignXNewsItems
     campaignx_news_items_moved = CampaignXNewsItem.objects \
-        .filter(campaignx_we_vote_id__iexact=campaignx2_we_vote_id) \
+        .filter(campaignx_we_vote_id=campaignx2_we_vote_id) \
         .update(campaignx_we_vote_id=campaignx1_we_vote_id)
 
     # ##################################
@@ -2152,7 +2152,7 @@ def merge_these_two_campaignx_entries(
     #  so we don't need to check for duplicates.
     from campaign.models import CampaignXSEOFriendlyPath
     campaignx_seo_friendly_path_moved = CampaignXSEOFriendlyPath.objects \
-        .filter(campaignx_we_vote_id__iexact=campaignx2_we_vote_id) \
+        .filter(campaignx_we_vote_id=campaignx2_we_vote_id) \
         .update(campaignx_we_vote_id=campaignx1_we_vote_id)
 
     # ##################################
@@ -2160,7 +2160,7 @@ def merge_these_two_campaignx_entries(
     try:
         from politician.models import Politician
         linked_campaignx_we_vote_id_updated = Politician.objects \
-            .filter(linked_campaignx_we_vote_id__iexact=campaignx2_we_vote_id) \
+            .filter(linked_campaignx_we_vote_id=campaignx2_we_vote_id) \
             .update(linked_campaignx_we_vote_id=campaignx1_we_vote_id)
     except Exception as e:
         status += "POLITICIAN_LINKED_CAMPAIGNX_WE_VOTE_ID_NOT_UPDATED: " + str(e) + " "
@@ -2238,7 +2238,7 @@ def merge_these_two_campaignx_entries(
     campaignx1_voter_we_vote_id_list = []
     campaignx2_supporters_to_delete_list = []
     queryset = CampaignXSupporter.objects.all()
-    queryset = queryset.filter(campaignx_we_vote_id__iexact=campaignx1_we_vote_id)
+    queryset = queryset.filter(campaignx_we_vote_id=campaignx1_we_vote_id)
     campaignx1_supporters_list = list(queryset)
     for campaignx1_supporter in campaignx1_supporters_list:
         if positive_value_exists(campaignx1_supporter.organization_we_vote_id) and \
@@ -2249,7 +2249,7 @@ def merge_these_two_campaignx_entries(
             campaignx1_voter_we_vote_id_list.append(campaignx1_supporter.voter_we_vote_id)
 
     queryset = CampaignXSupporter.objects.all()
-    queryset = queryset.filter(campaignx_we_vote_id__iexact=campaignx2_we_vote_id)
+    queryset = queryset.filter(campaignx_we_vote_id=campaignx2_we_vote_id)
     campaignx2_supporters_list = list(queryset)
     for campaignx2_supporter in campaignx2_supporters_list:
         # Is this campaign politician already in CampaignX 1?
@@ -2345,21 +2345,21 @@ def move_campaignx_to_another_organization(
     if positive_value_exists(to_organization_name):
         try:
             campaignx_owner_entries_moved += CampaignXOwner.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CAMPAIGNX_TO_ORG_OWNER_UPDATE-FROM_ORG_WE_VOTE_ID-WITH_NAME: " + str(e) + " "
         try:
             campaignx_supporter_entries_moved += CampaignXSupporter.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(supporter_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CAMPAIGNX_TO_ORG_SUPPORTER_UPDATE-FROM_ORG_WE_VOTE_ID-WITH_NAME: " + str(e) + " "
         try:
             campaignx_news_item_entries_moved += CampaignXNewsItem.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(speaker_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
@@ -2367,26 +2367,26 @@ def move_campaignx_to_another_organization(
     else:
         try:
             campaignx_owner_entries_moved += CampaignXOwner.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CAMPAIGNX_TO_ORG_OWNER_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
         try:
             campaignx_supporter_entries_moved += CampaignXSupporter.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CAMPAIGNX_TO_ORG_SUPPORTER_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
         try:
             campaignx_news_item_entries_moved += CampaignXNewsItem.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CAMPAIGNX_NEWS_ITEM_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
 
     try:
         campaignx_listed_entries_moved += CampaignXListedByOrganization.objects \
-            .filter(site_owner_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+            .filter(site_owner_organization_we_vote_id=from_organization_we_vote_id) \
             .update(site_owner_organization_we_vote_id=to_organization_we_vote_id)
     except Exception as e:
         status += "FAILED-CAMPAIGNX_LISTED_BY_ORG_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
@@ -2418,7 +2418,7 @@ def move_campaignx_to_another_politician(
     if positive_value_exists(from_politician_we_vote_id):
         try:
             campaignx_entries_moved += CampaignXPolitician.objects \
-                .filter(politician_we_vote_id__iexact=from_politician_we_vote_id) \
+                .filter(politician_we_vote_id=from_politician_we_vote_id) \
                 .update(politician_we_vote_id=to_politician_we_vote_id)
         except Exception as e:
             status += "FAILED_MOVE_CAMPAIGNX_BY_POLITICIAN_WE_VOTE_ID: " + str(e) + " "
@@ -2473,7 +2473,7 @@ def move_campaignx_to_another_voter(
     # Move based on started_by_voter_we_vote_id
     try:
         campaignx_entries_moved += CampaignX.objects\
-            .filter(started_by_voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(started_by_voter_we_vote_id=from_voter_we_vote_id)\
             .update(started_by_voter_we_vote_id=to_voter_we_vote_id)
     except Exception as e:
         status += "FAILED-CAMPAIGNX_UPDATE: " + str(e) + " "
@@ -2483,7 +2483,7 @@ def move_campaignx_to_another_voter(
     # Move News Item based on voter_we_vote_id
     try:
         campaignx_news_item_entries_moved += CampaignXNewsItem.objects\
-            .filter(voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(voter_we_vote_id=from_voter_we_vote_id)\
             .update(voter_we_vote_id=to_voter_we_vote_id)
     except Exception as e:
         status += "FAILED-CAMPAIGNX_NEWS_ITEM_UPDATE-FROM_VOTER_WE_VOTE_ID: " + str(e) + " "
@@ -2493,7 +2493,7 @@ def move_campaignx_to_another_voter(
     # Move owners based on voter_we_vote_id
     try:
         campaignx_owner_entries_moved += CampaignXOwner.objects\
-            .filter(voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(voter_we_vote_id=from_voter_we_vote_id)\
             .update(voter_we_vote_id=to_voter_we_vote_id)
     except Exception as e:
         status += "FAILED-CAMPAIGNX_OWNER_UPDATE-FROM_VOTER_WE_VOTE_ID: " + str(e) + " "
@@ -2503,7 +2503,7 @@ def move_campaignx_to_another_voter(
     # Move supporters based on voter_we_vote_id
     try:
         campaignx_supporter_entries_moved += CampaignXSupporter.objects\
-            .filter(voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(voter_we_vote_id=from_voter_we_vote_id)\
             .update(voter_we_vote_id=to_voter_we_vote_id)
     except Exception as e:
         status += "FAILED-CAMPAIGNX_SUPPORTER_UPDATE-FROM_VOTER_WE_VOTE_ID: " + str(e) + " "
@@ -2514,7 +2514,7 @@ def move_campaignx_to_another_voter(
     if positive_value_exists(to_organization_name):
         try:
             campaignx_owner_entries_moved += CampaignXOwner.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
@@ -2522,7 +2522,7 @@ def move_campaignx_to_another_voter(
             success = False
         try:
             campaignx_supporter_entries_moved += CampaignXSupporter.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(supporter_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
@@ -2530,7 +2530,7 @@ def move_campaignx_to_another_voter(
             success = False
         try:
             campaignx_news_item_entries_moved += CampaignXNewsItem.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(speaker_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
@@ -2539,21 +2539,21 @@ def move_campaignx_to_another_voter(
     else:
         try:
             campaignx_owner_entries_moved += CampaignXOwner.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CAMPAIGNX_OWNER_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
             success = False
         try:
             campaignx_supporter_entries_moved += CampaignXSupporter.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CAMPAIGNX_SUPPORTER_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
             success = False
         try:
             campaignx_news_item_entries_moved += CampaignXNewsItem.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CAMPAIGNX_NEWS_ITEM_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
@@ -2561,7 +2561,7 @@ def move_campaignx_to_another_voter(
 
     try:
         campaignx_listed_entries_moved += CampaignXListedByOrganization.objects \
-            .filter(site_owner_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+            .filter(site_owner_organization_we_vote_id=from_organization_we_vote_id) \
             .update(site_owner_organization_we_vote_id=to_organization_we_vote_id)
     except Exception as e:
         status += "FAILED-CAMPAIGNX_LISTED_BY_ORG_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
@@ -2931,7 +2931,7 @@ def delete_campaign_supporter(voter_to_delete=None):
     
     try:
         number_deleted, details = CampaignXSupporter.objects\
-            .filter(voter_we_vote_id__iexact=voter_to_delete_id, )\
+            .filter(voter_we_vote_id=voter_to_delete_id, )\
             .delete()
         campaign_supporter_deleted += number_deleted
     except Exception as e:

--- a/campaign/models.py
+++ b/campaign/models.py
@@ -443,8 +443,8 @@ class CampaignXManager(models.Manager):
 
         try:
             campaignx_owner_query = CampaignXOwner.objects.using('readonly').filter(
-                campaignx_we_vote_id__iexact=campaignx_we_vote_id,
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                campaignx_we_vote_id=campaignx_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id)
             voter_is_campaignx_owner = positive_value_exists(campaignx_owner_query.count())
             status += 'VOTER_IS_CAMPAIGNX_OWNER '
         except CampaignXOwner as e:
@@ -456,7 +456,7 @@ class CampaignXManager(models.Manager):
             try:
                 # Which teams does this voter belong to, with campaignX rights?
                 team_member_queryset = OrganizationTeamMember.objects.using('readonly').filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id)
+                    voter_we_vote_id=voter_we_vote_id)
                 team_member_queryset = team_member_queryset.filter(
                     Q(can_edit_campaignx_owned_by_organization=True) |
                     Q(can_moderate_campaignx_owned_by_organization=True) |
@@ -469,7 +469,7 @@ class CampaignXManager(models.Manager):
             if len(teams_voter_is_on_organization_we_vote_id_list) > 0:
                 try:
                     owner_queryset = CampaignXOwner.objects.using('readonly').filter(
-                        campaignx_we_vote_id__iexact=campaignx_we_vote_id,
+                        campaignx_we_vote_id=campaignx_we_vote_id,
                         organization_we_vote_id__in=teams_voter_is_on_organization_we_vote_id_list)
                     voter_is_campaignx_owner = positive_value_exists(owner_queryset.count())
                     status += 'VOTER_IS_CAMPAIGNX_OWNER_AS_TEAM_MEMBER '
@@ -491,8 +491,8 @@ class CampaignXManager(models.Manager):
 
         try:
             queryset = CampaignXSupporter.objects.using('readonly').filter(
-                campaignx_we_vote_id__iexact=campaignx_we_vote_id,
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                campaignx_we_vote_id=campaignx_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id)
             voter_is_campaignx_owner = positive_value_exists(queryset.count())
             status += 'VOTER_IS_CAMPAIGNX_SUPPORTER '
         except CampaignXSupporter as e:
@@ -863,11 +863,11 @@ class CampaignXManager(models.Manager):
             if positive_value_exists(read_only):
                 campaignx_entries_are_not_duplicates_list_query = \
                     CampaignXEntriesAreNotDuplicates.objects.using('readonly').filter(
-                        campaignx1_we_vote_id__iexact=campaignx_we_vote_id,
+                        campaignx1_we_vote_id=campaignx_we_vote_id,
                     )
             else:
                 campaignx_entries_are_not_duplicates_list_query = CampaignXEntriesAreNotDuplicates.objects.filter(
-                    campaignx1_we_vote_id__iexact=campaignx_we_vote_id,
+                    campaignx1_we_vote_id=campaignx_we_vote_id,
                 )
             campaignx_entries_are_not_duplicates_list1 = list(campaignx_entries_are_not_duplicates_list_query)
             success = True
@@ -885,12 +885,12 @@ class CampaignXManager(models.Manager):
                 if positive_value_exists(read_only):
                     campaignx_entries_are_not_duplicates_list_query = \
                         CampaignXEntriesAreNotDuplicates.objects.using('readonly').filter(
-                            campaignx2_we_vote_id__iexact=campaignx_we_vote_id,
+                            campaignx2_we_vote_id=campaignx_we_vote_id,
                         )
                 else:
                     campaignx_entries_are_not_duplicates_list_query = \
                         CampaignXEntriesAreNotDuplicates.objects.filter(
-                            campaignx2_we_vote_id__iexact=campaignx_we_vote_id,
+                            campaignx2_we_vote_id=campaignx_we_vote_id,
                         )
                 campaignx_entries_are_not_duplicates_list2 = list(campaignx_entries_are_not_duplicates_list_query)
                 success = True
@@ -1160,7 +1160,7 @@ class CampaignXManager(models.Manager):
             else:
                 if positive_value_exists(including_started_by_voter_we_vote_id):
                     # started_by this voter
-                    new_filter = Q(started_by_voter_we_vote_id__iexact=including_started_by_voter_we_vote_id)
+                    new_filter = Q(started_by_voter_we_vote_id=including_started_by_voter_we_vote_id)
                     filters.append(new_filter)
                     # Voter is owner of the campaign, or on team that owns it
                     voter_owned_campaignx_we_vote_ids = campaignx_manager.retrieve_voter_owned_campaignx_we_vote_ids(
@@ -1263,7 +1263,7 @@ class CampaignXManager(models.Manager):
             if positive_value_exists(including_started_by_voter_we_vote_id):
                 # started_by this voter
                 new_filter = \
-                    Q(started_by_voter_we_vote_id__iexact=including_started_by_voter_we_vote_id)
+                    Q(started_by_voter_we_vote_id=including_started_by_voter_we_vote_id)
                 filters.append(new_filter)
                 # Voter is owner of the campaign, or on team that owns it
                 voter_owned_campaignx_we_vote_ids = campaignx_manager.retrieve_voter_owned_campaignx_we_vote_ids(
@@ -2036,9 +2036,9 @@ class CampaignXManager(models.Manager):
             return ''
         try:
             if positive_value_exists(read_only):
-                campaignx = CampaignX.objects.using('readonly').get(we_vote_id__iexact=campaignx_we_vote_id)
+                campaignx = CampaignX.objects.using('readonly').get(we_vote_id=campaignx_we_vote_id)
             else:
-                campaignx = CampaignX.objects.get(we_vote_id__iexact=campaignx_we_vote_id)
+                campaignx = CampaignX.objects.get(we_vote_id=campaignx_we_vote_id)
             return campaignx.campaign_title
         except CampaignX.DoesNotExist as e:
             # Some test data will throw this, no worries
@@ -2084,7 +2084,7 @@ class CampaignXManager(models.Manager):
 
         try:
             campaignx_owner_query = CampaignXOwner.objects.using('readonly').filter(
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                voter_we_vote_id=voter_we_vote_id)
             campaignx_owner_query = campaignx_owner_query.values_list('campaignx_we_vote_id', flat=True).distinct()
             campaignx_owner_campaignx_we_vote_ids = list(campaignx_owner_query)
         except CampaignXOwner as e:
@@ -2094,7 +2094,7 @@ class CampaignXManager(models.Manager):
         try:
             # Which teams does this voter belong to, with can_send_updates_for_campaignx_owned_by_organization rights?
             team_member_queryset = OrganizationTeamMember.objects.using('readonly').filter(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
                 can_send_updates_for_campaignx_owned_by_organization=True
             )
             team_member_queryset = team_member_queryset.values_list('organization_we_vote_id', flat=True).distinct()
@@ -2130,7 +2130,7 @@ class CampaignXManager(models.Manager):
 
         try:
             campaignx_owner_query = CampaignXOwner.objects.using('readonly').filter(
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                voter_we_vote_id=voter_we_vote_id)
             campaignx_owner_query = campaignx_owner_query.values_list('campaignx_we_vote_id', flat=True).distinct()
             campaignx_owner_campaignx_we_vote_ids = list(campaignx_owner_query)
         except CampaignXOwner as e:
@@ -2140,7 +2140,7 @@ class CampaignXManager(models.Manager):
         try:
             # Which teams does this voter belong to, with campaignX rights?
             team_member_queryset = OrganizationTeamMember.objects.using('readonly').filter(
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                voter_we_vote_id=voter_we_vote_id)
             team_member_queryset = team_member_queryset.filter(
                 Q(can_edit_campaignx_owned_by_organization=True) |
                 Q(can_moderate_campaignx_owned_by_organization=True) |
@@ -2178,7 +2178,7 @@ class CampaignXManager(models.Manager):
 
         try:
             campaignx_owner_entries_updated = CampaignXOwner.objects \
-                .filter(organization_we_vote_id__iexact=organization_we_vote_id) \
+                .filter(organization_we_vote_id=organization_we_vote_id) \
                 .update(organization_name=organization_name,
                         we_vote_hosted_profile_image_url_medium=we_vote_hosted_profile_image_url_medium,
                         we_vote_hosted_profile_image_url_tiny=we_vote_hosted_profile_image_url_tiny)
@@ -2205,7 +2205,7 @@ class CampaignXManager(models.Manager):
 
         try:
             campaignx_supporter_entries_updated = CampaignXSupporter.objects \
-                .filter(organization_we_vote_id__iexact=organization_we_vote_id) \
+                .filter(organization_we_vote_id=organization_we_vote_id) \
                 .update(supporter_name=supporter_name,
                         we_vote_hosted_profile_image_url_medium=we_vote_hosted_profile_image_url_medium,
                         we_vote_hosted_profile_image_url_tiny=we_vote_hosted_profile_image_url_tiny)
@@ -2234,7 +2234,7 @@ class CampaignXManager(models.Manager):
             if not positive_value_exists(campaignx_we_vote_id):
                 try:
                     queryset = CampaignX.objects.using('readonly').all()
-                    queryset = queryset.filter(linked_politician_we_vote_id__iexact=politician_we_vote_id)
+                    queryset = queryset.filter(linked_politician_we_vote_id=politician_we_vote_id)
                     temp_list = queryset.values_list('we_vote_id', flat=True).distinct()
                     campaignx_we_vote_id = temp_list[0]
                 except Exception as e:
@@ -2243,7 +2243,7 @@ class CampaignXManager(models.Manager):
                     return error_results
             try:
                 queryset = Organization.objects.using('readonly').all()
-                queryset = queryset.filter(politician_we_vote_id__iexact=politician_we_vote_id)
+                queryset = queryset.filter(politician_we_vote_id=politician_we_vote_id)
                 temp_list = queryset.values_list('we_vote_id', flat=True).distinct()
                 organization_we_vote_id = temp_list[0]
             except Exception as e:
@@ -2253,7 +2253,7 @@ class CampaignXManager(models.Manager):
             try:
                 from follow.models import FOLLOWING, FOLLOW_DISLIKE, FollowOrganization
                 queryset = FollowOrganization.objects.using('readonly').all()
-                queryset = queryset.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                queryset = queryset.filter(organization_we_vote_id=organization_we_vote_id)
                 following_queryset = queryset.filter(following_status=FOLLOWING)
                 supporters_count = following_queryset.count()
                 disliking_queryset = queryset.filter(following_status=FOLLOW_DISLIKE)
@@ -2265,7 +2265,7 @@ class CampaignXManager(models.Manager):
         else:
             try:
                 count_query = CampaignXSupporter.objects.using('readonly').all()
-                count_query = count_query.filter(campaignx_we_vote_id__iexact=campaignx_we_vote_id)
+                count_query = count_query.filter(campaignx_we_vote_id=campaignx_we_vote_id)
                 count_query = count_query.filter(campaign_supported=True)
                 supporters_count = count_query.count()
             except Exception as e:
@@ -2564,8 +2564,8 @@ class CampaignXManager(models.Manager):
                 }
                 campaignx_entries_are_not_duplicates, new_campaignx_entries_are_not_duplicates_created = \
                     CampaignXEntriesAreNotDuplicates.objects.update_or_create(
-                        campaignx1_we_vote_id__iexact=campaignx1_we_vote_id,
-                        campaignx2_we_vote_id__iexact=campaignx2_we_vote_id,
+                        campaignx1_we_vote_id=campaignx1_we_vote_id,
+                        campaignx2_we_vote_id=campaignx2_we_vote_id,
                         defaults=updated_values)
                 success = True
                 status += "CAMPAIGNX_ENTRIES_ARE_NOT_DUPLICATES_UPDATED_OR_CREATED "

--- a/campaign/views_admin.py
+++ b/campaign/views_admin.py
@@ -1176,19 +1176,19 @@ def campaign_list_view(request):
             new_filter = Q(campaign_description__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(linked_politician_we_vote_id__iexact=one_word)
+            new_filter = Q(linked_politician_we_vote_id=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(organization_we_vote_id__iexact=one_word)
+            new_filter = Q(organization_we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(seo_friendly_path__iexact=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(started_by_voter_we_vote_id__iexact=one_word)
+            new_filter = Q(started_by_voter_we_vote_id=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(we_vote_id__iexact=one_word)
+            new_filter = Q(we_vote_id=one_word)
             filters.append(new_filter)
 
             # Add the first query
@@ -1347,7 +1347,7 @@ def campaign_summary_view(request, campaignx_we_vote_id=""):
         from campaign.models import CampaignXSEOFriendlyPath
         try:
             path_query = CampaignXSEOFriendlyPath.objects.all()
-            path_query = path_query.filter(campaignx_we_vote_id__iexact=campaignx_we_vote_id)
+            path_query = path_query.filter(campaignx_we_vote_id=campaignx_we_vote_id)
             path_count = path_query.count()
             path_list = list(path_query[:4])
         except Exception as e:
@@ -1384,7 +1384,7 @@ def campaign_summary_view(request, campaignx_we_vote_id=""):
     if positive_value_exists(campaignx.linked_politician_we_vote_id):
         from position.models import PositionEntered
         position_query = PositionEntered.objects.using('readonly').all()
-        position_query = position_query.filter(politician_we_vote_id__iexact=campaignx.linked_politician_we_vote_id)
+        position_query = position_query.filter(politician_we_vote_id=campaignx.linked_politician_we_vote_id)
         # position_query = position_query.exclude(
         #     Q(statement_text__isnull=True) |
         #     Q(statement_text__exact='')
@@ -1392,7 +1392,7 @@ def campaign_summary_view(request, campaignx_we_vote_id=""):
         position_list = list(position_query[:4])
     else:
         supporters_query = CampaignXSupporter.objects.using('readonly').all()
-        supporters_query = supporters_query.filter(campaignx_we_vote_id__iexact=campaignx_we_vote_id)
+        supporters_query = supporters_query.filter(campaignx_we_vote_id=campaignx_we_vote_id)
         supporters_query = supporters_query.exclude(
             Q(supporter_endorsement__isnull=True) |
             Q(supporter_endorsement__exact='')
@@ -1461,11 +1461,11 @@ def campaign_supporters_list_view(request, campaignx_we_vote_id=""):
 
     messages_on_stage = get_messages(request)
 
-    campaignx = CampaignX.objects.get(we_vote_id__iexact=campaignx_we_vote_id)
+    campaignx = CampaignX.objects.get(we_vote_id=campaignx_we_vote_id)
     campaignx_title = campaignx.campaign_title
 
     supporters_query = CampaignXSupporter.objects.all()
-    supporters_query = supporters_query.filter(campaignx_we_vote_id__iexact=campaignx_we_vote_id)
+    supporters_query = supporters_query.filter(campaignx_we_vote_id=campaignx_we_vote_id)
 
     if positive_value_exists(only_show_supporters_with_endorsements):
         supporters_query = supporters_query.exclude(
@@ -1508,10 +1508,10 @@ def campaign_supporters_list_view(request, campaignx_we_vote_id=""):
             new_filter = Q(supporter_endorsement__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(voter_we_vote_id__iexact=one_word)
+            new_filter = Q(voter_we_vote_id=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(organization_we_vote_id__iexact=one_word)
+            new_filter = Q(organization_we_vote_id=one_word)
             filters.append(new_filter)
 
             # Add the first query
@@ -1679,7 +1679,7 @@ def campaign_supporters_list_process_view(request):
                                     )
 
     supporters_query = CampaignXSupporter.objects.all()
-    supporters_query = supporters_query.filter(campaignx_we_vote_id__iexact=campaignx_we_vote_id)
+    supporters_query = supporters_query.filter(campaignx_we_vote_id=campaignx_we_vote_id)
 
     if positive_value_exists(only_show_supporters_with_endorsements):
         supporters_query = supporters_query.exclude(
@@ -1705,10 +1705,10 @@ def campaign_supporters_list_process_view(request):
             new_filter = Q(supporter_endorsement__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(voter_we_vote_id__iexact=one_word)
+            new_filter = Q(voter_we_vote_id=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(organization_we_vote_id__iexact=one_word)
+            new_filter = Q(organization_we_vote_id=one_word)
             filters.append(new_filter)
 
             # Add the first query
@@ -2285,8 +2285,8 @@ def campaignx_not_duplicates_view(request):
         campaignx1_we_vote_id, campaignx2_we_vote_id)
     if results['success']:
         queryset = CampaignXEntriesArePossibleDuplicates.objects.filter(
-            campaignx1_we_vote_id__iexact=campaignx1_we_vote_id,
-            campaignx2_we_vote_id__iexact=campaignx2_we_vote_id,
+            campaignx1_we_vote_id=campaignx1_we_vote_id,
+            campaignx2_we_vote_id=campaignx2_we_vote_id,
         )
         queryset.delete()
         if positive_value_exists(voter_we_vote_id):

--- a/candidate/controllers.py
+++ b/candidate/controllers.py
@@ -983,7 +983,7 @@ def move_candidates_to_another_politician(
     if positive_value_exists(from_politician_we_vote_id):
         try:
             candidate_entries_moved += CandidateCampaign.objects \
-                .filter(politician_we_vote_id__iexact=from_politician_we_vote_id) \
+                .filter(politician_we_vote_id=from_politician_we_vote_id) \
                 .update(politician_id=to_politician_id,
                         politician_we_vote_id=to_politician_we_vote_id)
         except Exception as e:

--- a/candidate/models.py
+++ b/candidate/models.py
@@ -1084,7 +1084,7 @@ class CandidateListManager(models.Manager):
             candidate_query = candidate_query.filter(we_vote_id__in=candidate_we_vote_id_list)
             # Ignore entries with we_vote_id coming in from master server
             if positive_value_exists(we_vote_id_from_master):
-                candidate_query = candidate_query.filter(~Q(we_vote_id__iexact=we_vote_id_from_master))
+                candidate_query = candidate_query.filter(~Q(we_vote_id=we_vote_id_from_master))
 
             # We want to find candidates with *any* of these values
             if positive_value_exists(google_civic_candidate_name):
@@ -1277,7 +1277,7 @@ class CandidateListManager(models.Manager):
                     filters.append(new_filter)
 
             if positive_value_exists(politician_we_vote_id):
-                new_filter = Q(politician_we_vote_id__iexact=politician_we_vote_id)
+                new_filter = Q(politician_we_vote_id=politician_we_vote_id)
                 filters.append(new_filter)
 
             if positive_value_exists(candidate_twitter_handle):
@@ -1734,14 +1734,14 @@ class CandidateListManager(models.Manager):
         try:
             if positive_value_exists(politician_id) and positive_value_exists(politician_we_vote_id):
                 candidate_query = candidate_query.filter(
-                    Q(politician_we_vote_id__iexact=politician_we_vote_id) |
+                    Q(politician_we_vote_id=politician_we_vote_id) |
                     Q(politician_id=politician_id)
                 )
             elif positive_value_exists(politician_id):
                 candidate_query = candidate_query.filter(politician_id=politician_id)
             else:
                 candidate_query = candidate_query.filter(
-                    politician_we_vote_id__iexact=politician_we_vote_id)
+                    politician_we_vote_id=politician_we_vote_id)
 
             position_count = candidate_query.count()
         except Exception as e:
@@ -2417,7 +2417,7 @@ class CandidateListManager(models.Manager):
             elif positive_value_exists(politician_id):
                 candidate_query = candidate_query.filter(politician_id=politician_id)
             else:
-                candidate_query = candidate_query.filter(politician_we_vote_id__iexact=politician_we_vote_id)
+                candidate_query = candidate_query.filter(politician_we_vote_id=politician_we_vote_id)
             candidate_list = list(candidate_query)
             candidate_list_found = len(candidate_list) > 0
         except Exception as e:
@@ -3361,13 +3361,13 @@ class CandidateManager(models.Manager):
         try:
             if positive_value_exists(read_only):
                 candidates_are_not_duplicates = CandidatesAreNotDuplicates.objects.using('readonly').get(
-                    candidate1_we_vote_id__iexact=candidate1_we_vote_id,
-                    candidate2_we_vote_id__iexact=candidate2_we_vote_id,
+                    candidate1_we_vote_id=candidate1_we_vote_id,
+                    candidate2_we_vote_id=candidate2_we_vote_id,
                 )
             else:
                 candidates_are_not_duplicates = CandidatesAreNotDuplicates.objects.get(
-                    candidate1_we_vote_id__iexact=candidate1_we_vote_id,
-                    candidate2_we_vote_id__iexact=candidate2_we_vote_id,
+                    candidate1_we_vote_id=candidate1_we_vote_id,
+                    candidate2_we_vote_id=candidate2_we_vote_id,
                 )
             candidates_are_not_duplicates_found = True
             success = True
@@ -3387,13 +3387,13 @@ class CandidateManager(models.Manager):
             try:
                 if positive_value_exists(read_only):
                     candidates_are_not_duplicates = CandidatesAreNotDuplicates.objects.using('readonly').get(
-                        candidate1_we_vote_id__iexact=candidate2_we_vote_id,
-                        candidate2_we_vote_id__iexact=candidate1_we_vote_id,
+                        candidate1_we_vote_id=candidate2_we_vote_id,
+                        candidate2_we_vote_id=candidate1_we_vote_id,
                     )
                 else:
                     candidates_are_not_duplicates = CandidatesAreNotDuplicates.objects.get(
-                        candidate1_we_vote_id__iexact=candidate2_we_vote_id,
-                        candidate2_we_vote_id__iexact=candidate1_we_vote_id,
+                        candidate1_we_vote_id=candidate2_we_vote_id,
+                        candidate2_we_vote_id=candidate1_we_vote_id,
                     )
                 candidates_are_not_duplicates_found = True
                 success = True
@@ -3432,11 +3432,11 @@ class CandidateManager(models.Manager):
         try:
             if positive_value_exists(read_only):
                 candidates_are_not_duplicates_list_query = CandidatesAreNotDuplicates.objects.using('readonly').filter(
-                    candidate1_we_vote_id__iexact=candidate_we_vote_id,
+                    candidate1_we_vote_id=candidate_we_vote_id,
                 )
             else:
                 candidates_are_not_duplicates_list_query = CandidatesAreNotDuplicates.objects.filter(
-                    candidate1_we_vote_id__iexact=candidate_we_vote_id,
+                    candidate1_we_vote_id=candidate_we_vote_id,
                 )
             candidates_are_not_duplicates_list1 = list(candidates_are_not_duplicates_list_query)
             success = True
@@ -3454,12 +3454,12 @@ class CandidateManager(models.Manager):
                 if positive_value_exists(read_only):
                     candidates_are_not_duplicates_list_query = \
                         CandidatesAreNotDuplicates.objects.using('readonly').filter(
-                            candidate2_we_vote_id__iexact=candidate_we_vote_id,
+                            candidate2_we_vote_id=candidate_we_vote_id,
                         )
                 else:
                     candidates_are_not_duplicates_list_query = \
                         CandidatesAreNotDuplicates.objects.filter(
-                            candidate2_we_vote_id__iexact=candidate_we_vote_id,
+                            candidate2_we_vote_id=candidate_we_vote_id,
                         )
                 candidates_are_not_duplicates_list2 = list(candidates_are_not_duplicates_list_query)
                 success = True
@@ -3618,8 +3618,8 @@ class CandidateManager(models.Manager):
                 candidate_on_stage, new_candidate_created = \
                     CandidateCampaign.objects.update_or_create(
                         # google_civic_election_id__exact=google_civic_election_id,
-                        we_vote_id__iexact=candidate_we_vote_id,
-                        # contest_office_we_vote_id__iexact=contest_office_we_vote_id,
+                        we_vote_id=candidate_we_vote_id,
+                        # contest_office_we_vote_id=contest_office_we_vote_id,
                         defaults=updated_candidate_values)
                 candidate_found = True
                 success = True
@@ -3951,7 +3951,7 @@ class CandidateManager(models.Manager):
                 candidates_are_not_duplicates, new_candidates_are_not_duplicates_created = \
                     CandidatesAreNotDuplicates.objects.update_or_create(
                         candidate1_we_vote_id__exact=candidate1_we_vote_id,
-                        candidate2_we_vote_id__iexact=candidate2_we_vote_id,
+                        candidate2_we_vote_id=candidate2_we_vote_id,
                         defaults=updated_values)
                 success = True
                 status += "CANDIDATES_ARE_NOT_DUPLICATES_UPDATED_OR_CREATED "
@@ -4829,7 +4829,7 @@ class CandidateManager(models.Manager):
         existing_candidate_entry = ''
 
         try:
-            existing_candidate_entry = CandidateCampaign.objects.get(we_vote_id__iexact=candidate_we_vote_id)
+            existing_candidate_entry = CandidateCampaign.objects.get(we_vote_id=candidate_we_vote_id)
             values_changed = False
 
             if existing_candidate_entry:

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -150,7 +150,7 @@ def candidates_sync_out_view(request):  # candidatesSyncOut
             new_filter = Q(party__icontains=candidate_search)
             filters.append(new_filter)
 
-            new_filter = Q(we_vote_id__iexact=candidate_search)
+            new_filter = Q(we_vote_id=candidate_search)
             filters.append(new_filter)
 
             # Add the first query
@@ -387,8 +387,8 @@ def candidates_not_duplicates_view(request):
         candidate1_we_vote_id, candidate2_we_vote_id)
     if results['success']:
         queryset = CandidatesArePossibleDuplicates.objects.filter(
-            candidate1_we_vote_id__iexact=candidate1_we_vote_id,
-            candidate2_we_vote_id__iexact=candidate2_we_vote_id,
+            candidate1_we_vote_id=candidate1_we_vote_id,
+            candidate2_we_vote_id=candidate2_we_vote_id,
         )
         queryset.delete()
         messages.add_message(request, messages.INFO, 'Two candidates marked as not duplicates.')
@@ -1099,10 +1099,10 @@ def candidate_list_view(request):
                 new_filter = Q(google_civic_candidate_name3__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(linked_campaignx_we_vote_id__iexact=one_word)
+                new_filter = Q(linked_campaignx_we_vote_id=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(politician_we_vote_id__iexact=one_word)
+                new_filter = Q(politician_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = Q(party__icontains=one_word)
@@ -1120,7 +1120,7 @@ def candidate_list_view(request):
                 new_filter = Q(vote_usa_politician_id__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = Q(wikipedia_url__icontains=one_word)
@@ -1457,7 +1457,7 @@ def candidate_list_view(request):
                     candidate.candidate_merge_possibility = twitter_possibility_list[0]
                 else:
                     request_history_query = RemoteRequestHistory.objects.using('readonly').filter(
-                        candidate_campaign_we_vote_id__iexact=candidate.we_vote_id,
+                        candidate_campaign_we_vote_id=candidate.we_vote_id,
                         kind_of_action=RETRIEVE_POSSIBLE_TWITTER_HANDLES)
                     request_history_list = list(request_history_query)
                     if request_history_list and positive_value_exists(len(request_history_list)):
@@ -1478,7 +1478,7 @@ def candidate_list_view(request):
                     candidate.google_search_merge_possibility = google_search_possibility_query[0]
                 else:
                     request_history_query = RemoteRequestHistory.objects.using('readonly').filter(
-                        candidate_campaign_we_vote_id__iexact=candidate.we_vote_id,
+                        candidate_campaign_we_vote_id=candidate.we_vote_id,
                         kind_of_action=RETRIEVE_POSSIBLE_GOOGLE_LINKS)
                     request_history_list = list(request_history_query)
                     if request_history_list and positive_value_exists(len(request_history_list)):
@@ -2292,7 +2292,7 @@ def candidate_edit_view(request, candidate_id=0, candidate_we_vote_id=""):
             from politician.models import PoliticianSEOFriendlyPath
             try:
                 path_query = PoliticianSEOFriendlyPath.objects.using('readonly').all()
-                path_query = path_query.filter(politician_we_vote_id__iexact=politician_we_vote_id)
+                path_query = path_query.filter(politician_we_vote_id=politician_we_vote_id)
                 path_count = path_query.count()
                 path_list = list(path_query[:3])
             except Exception as e:
@@ -2381,7 +2381,7 @@ def candidate_edit_view(request, candidate_id=0, candidate_we_vote_id=""):
             find_possible_duplicate_candidates_to_merge_with_this_candidate(candidate=candidate_on_stage)
 
         queryset = CandidateChangeLog.objects.using('readonly').all()
-        queryset = queryset.filter(candidate_we_vote_id__iexact=candidate_we_vote_id)
+        queryset = queryset.filter(candidate_we_vote_id=candidate_we_vote_id)
         queryset = queryset.order_by('-log_datetime')
         change_log_list = list(queryset)
 
@@ -5244,8 +5244,8 @@ def update_candidate_from_politician_view(request):
     politician_we_vote_id = politician.we_vote_id
 
     queryset = CandidateCampaign.objects.using('readonly').all()
-    queryset = queryset.filter(politician_we_vote_id__iexact=politician_we_vote_id)
-    queryset = queryset.filter(we_vote_id__iexact=candidate_we_vote_id)
+    queryset = queryset.filter(politician_we_vote_id=politician_we_vote_id)
+    queryset = queryset.filter(we_vote_id=candidate_we_vote_id)
     queryset = queryset.order_by('-candidate_year', '-candidate_ultimate_election_date')
     candidate_list = list(queryset)
     candidate_list_by_politician_we_vote_id = {}

--- a/challenge/controllers.py
+++ b/challenge/controllers.py
@@ -2110,7 +2110,7 @@ def merge_these_two_challenges(
     challenge1_organization_we_vote_id_list = []
     challenge2_listed_by_organization_to_delete_list = []
     queryset = ChallengeListedByOrganization.objects.all()
-    queryset = queryset.filter(challenge_we_vote_id__iexact=challenge1_we_vote_id)
+    queryset = queryset.filter(challenge_we_vote_id=challenge1_we_vote_id)
     challenge1_listed_by_organization_list = list(queryset)
     for challenge1_listed_by_organization in challenge1_listed_by_organization_list:
         if positive_value_exists(challenge1_listed_by_organization.site_owner_organization_we_vote_id) and \
@@ -2120,7 +2120,7 @@ def merge_these_two_challenges(
                 .append(challenge1_listed_by_organization.site_owner_organization_we_vote_id)
 
     queryset = ChallengeListedByOrganization.objects.all()
-    queryset = queryset.filter(challenge_we_vote_id__iexact=challenge2_we_vote_id)
+    queryset = queryset.filter(challenge_we_vote_id=challenge2_we_vote_id)
     challenge2_listed_by_organization_list = list(queryset)
     for challenge2_listed_by_organization in challenge2_listed_by_organization_list:
         # Is this listed_by_organization already in Challenge 1?
@@ -2140,7 +2140,7 @@ def merge_these_two_challenges(
     # #####################################
     # Merge ChallengeNewsItems
     challenge_news_items_moved = ChallengeNewsItem.objects \
-        .filter(challenge_we_vote_id__iexact=challenge2_we_vote_id) \
+        .filter(challenge_we_vote_id=challenge2_we_vote_id) \
         .update(challenge_we_vote_id=challenge1_we_vote_id)
 
     # ##################################
@@ -2148,7 +2148,7 @@ def merge_these_two_challenges(
     #  so we don't need to check for duplicates.
     from challenge.models import ChallengeSEOFriendlyPath
     challenge_seo_friendly_path_moved = ChallengeSEOFriendlyPath.objects \
-        .filter(challenge_we_vote_id__iexact=challenge2_we_vote_id) \
+        .filter(challenge_we_vote_id=challenge2_we_vote_id) \
         .update(challenge_we_vote_id=challenge1_we_vote_id)
 
     # ##################################
@@ -2156,7 +2156,7 @@ def merge_these_two_challenges(
     try:
         from politician.models import Politician
         linked_challenge_we_vote_id_updated = Politician.objects \
-            .filter(linked_challenge_we_vote_id__iexact=challenge2_we_vote_id) \
+            .filter(linked_challenge_we_vote_id=challenge2_we_vote_id) \
             .update(linked_challenge_we_vote_id=challenge1_we_vote_id)
     except Exception as e:
         status += "POLITICIAN_LINKED_CHALLENGE_WE_VOTE_ID_NOT_UPDATED: " + str(e) + " "
@@ -2234,7 +2234,7 @@ def merge_these_two_challenges(
     challenge1_voter_we_vote_id_list = []
     challenge2_supporters_to_delete_list = []
     queryset = ChallengeSupporter.objects.all()
-    queryset = queryset.filter(challenge_we_vote_id__iexact=challenge1_we_vote_id)
+    queryset = queryset.filter(challenge_we_vote_id=challenge1_we_vote_id)
     challenge1_supporters_list = list(queryset)
     for challenge1_supporter in challenge1_supporters_list:
         if positive_value_exists(challenge1_supporter.organization_we_vote_id) and \
@@ -2245,7 +2245,7 @@ def merge_these_two_challenges(
             challenge1_voter_we_vote_id_list.append(challenge1_supporter.voter_we_vote_id)
 
     queryset = ChallengeSupporter.objects.all()
-    queryset = queryset.filter(challenge_we_vote_id__iexact=challenge2_we_vote_id)
+    queryset = queryset.filter(challenge_we_vote_id=challenge2_we_vote_id)
     challenge2_supporters_list = list(queryset)
     for challenge2_supporter in challenge2_supporters_list:
         # Is this challenge politician already in Challenge 1?
@@ -2341,21 +2341,21 @@ def move_challenge_to_another_organization(
     if positive_value_exists(to_organization_name):
         try:
             challenge_owner_entries_moved += ChallengeOwner.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CHALLENGE_TO_ORG_OWNER_UPDATE-FROM_ORG_WE_VOTE_ID-WITH_NAME: " + str(e) + " "
         try:
             challenge_supporter_entries_moved += ChallengeSupporter.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(supporter_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CHALLENGE_TO_ORG_SUPPORTER_UPDATE-FROM_ORG_WE_VOTE_ID-WITH_NAME: " + str(e) + " "
         try:
             challenge_news_item_entries_moved += ChallengeNewsItem.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(speaker_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
@@ -2363,26 +2363,26 @@ def move_challenge_to_another_organization(
     else:
         try:
             challenge_owner_entries_moved += ChallengeOwner.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CHALLENGE_TO_ORG_OWNER_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
         try:
             challenge_supporter_entries_moved += ChallengeSupporter.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CHALLENGE_TO_ORG_SUPPORTER_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
         try:
             challenge_news_item_entries_moved += ChallengeNewsItem.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CHALLENGE_NEWS_ITEM_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
 
     try:
         challenge_listed_entries_moved += ChallengeListedByOrganization.objects \
-            .filter(site_owner_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+            .filter(site_owner_organization_we_vote_id=from_organization_we_vote_id) \
             .update(site_owner_organization_we_vote_id=to_organization_we_vote_id)
     except Exception as e:
         status += "FAILED-CHALLENGE_LISTED_BY_ORG_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
@@ -2414,7 +2414,7 @@ def move_challenge_to_another_politician(
     if positive_value_exists(from_politician_we_vote_id):
         try:
             challenges_moved += ChallengePolitician.objects \
-                .filter(politician_we_vote_id__iexact=from_politician_we_vote_id) \
+                .filter(politician_we_vote_id=from_politician_we_vote_id) \
                 .update(politician_we_vote_id=to_politician_we_vote_id)
         except Exception as e:
             status += "FAILED_MOVE_CHALLENGE_BY_POLITICIAN_WE_VOTE_ID: " + str(e) + " "
@@ -2469,7 +2469,7 @@ def move_challenge_to_another_voter(
     # Move based on started_by_voter_we_vote_id
     try:
         challenges_moved += Challenge.objects\
-            .filter(started_by_voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(started_by_voter_we_vote_id=from_voter_we_vote_id)\
             .update(started_by_voter_we_vote_id=to_voter_we_vote_id)
     except Exception as e:
         status += "FAILED-CHALLENGE_UPDATE: " + str(e) + " "
@@ -2479,7 +2479,7 @@ def move_challenge_to_another_voter(
     # Move News Item based on voter_we_vote_id
     try:
         challenge_news_item_entries_moved += ChallengeNewsItem.objects\
-            .filter(voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(voter_we_vote_id=from_voter_we_vote_id)\
             .update(voter_we_vote_id=to_voter_we_vote_id)
     except Exception as e:
         status += "FAILED-CHALLENGE_NEWS_ITEM_UPDATE-FROM_VOTER_WE_VOTE_ID: " + str(e) + " "
@@ -2489,7 +2489,7 @@ def move_challenge_to_another_voter(
     # Move owners based on voter_we_vote_id
     try:
         challenge_owner_entries_moved += ChallengeOwner.objects\
-            .filter(voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(voter_we_vote_id=from_voter_we_vote_id)\
             .update(voter_we_vote_id=to_voter_we_vote_id)
     except Exception as e:
         status += "FAILED-CHALLENGE_OWNER_UPDATE-FROM_VOTER_WE_VOTE_ID: " + str(e) + " "
@@ -2499,7 +2499,7 @@ def move_challenge_to_another_voter(
     # Move supporters based on voter_we_vote_id
     try:
         challenge_supporter_entries_moved += ChallengeSupporter.objects\
-            .filter(voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(voter_we_vote_id=from_voter_we_vote_id)\
             .update(voter_we_vote_id=to_voter_we_vote_id)
     except Exception as e:
         status += "FAILED-CHALLENGE_SUPPORTER_UPDATE-FROM_VOTER_WE_VOTE_ID: " + str(e) + " "
@@ -2510,7 +2510,7 @@ def move_challenge_to_another_voter(
     if positive_value_exists(to_organization_name):
         try:
             challenge_owner_entries_moved += ChallengeOwner.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
@@ -2518,7 +2518,7 @@ def move_challenge_to_another_voter(
             success = False
         try:
             challenge_supporter_entries_moved += ChallengeSupporter.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(supporter_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
@@ -2526,7 +2526,7 @@ def move_challenge_to_another_voter(
             success = False
         try:
             challenge_news_item_entries_moved += ChallengeNewsItem.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(speaker_name=to_organization_name,
                         organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
@@ -2535,21 +2535,21 @@ def move_challenge_to_another_voter(
     else:
         try:
             challenge_owner_entries_moved += ChallengeOwner.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CHALLENGE_OWNER_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
             success = False
         try:
             challenge_supporter_entries_moved += ChallengeSupporter.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CHALLENGE_SUPPORTER_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
             success = False
         try:
             challenge_news_item_entries_moved += ChallengeNewsItem.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-CHALLENGE_NEWS_ITEM_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
@@ -2557,7 +2557,7 @@ def move_challenge_to_another_voter(
 
     try:
         challenge_listed_entries_moved += ChallengeListedByOrganization.objects \
-            .filter(site_owner_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+            .filter(site_owner_organization_we_vote_id=from_organization_we_vote_id) \
             .update(site_owner_organization_we_vote_id=to_organization_we_vote_id)
     except Exception as e:
         status += "FAILED-CHALLENGE_LISTED_BY_ORG_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
@@ -2927,7 +2927,7 @@ def delete_challenge_supporter(voter_to_delete=None):
     
     try:
         number_deleted, details = ChallengeSupporter.objects\
-            .filter(voter_we_vote_id__iexact=voter_to_delete_id, )\
+            .filter(voter_we_vote_id=voter_to_delete_id, )\
             .delete()
         challenge_supporter_deleted += number_deleted
     except Exception as e:

--- a/challenge/models.py
+++ b/challenge/models.py
@@ -429,8 +429,8 @@ class ChallengeManager(models.Manager):
 
         try:
             challenge_owner_query = ChallengeOwner.objects.using('readonly').filter(
-                challenge_we_vote_id__iexact=challenge_we_vote_id,
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                challenge_we_vote_id=challenge_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id)
             voter_is_challenge_owner = positive_value_exists(challenge_owner_query.count())
             status += 'VOTER_IS_CHALLENGE_OWNER '
         except ChallengeOwner as e:
@@ -442,7 +442,7 @@ class ChallengeManager(models.Manager):
             try:
                 # Which teams does this voter belong to, with challenge rights?
                 team_member_queryset = OrganizationTeamMember.objects.using('readonly').filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id)
+                    voter_we_vote_id=voter_we_vote_id)
                 team_member_queryset = team_member_queryset.filter(
                     Q(can_edit_challenge_owned_by_organization=True) |
                     Q(can_moderate_challenge_owned_by_organization=True) |
@@ -455,7 +455,7 @@ class ChallengeManager(models.Manager):
             if len(teams_voter_is_on_organization_we_vote_id_list) > 0:
                 try:
                     owner_queryset = ChallengeOwner.objects.using('readonly').filter(
-                        challenge_we_vote_id__iexact=challenge_we_vote_id,
+                        challenge_we_vote_id=challenge_we_vote_id,
                         organization_we_vote_id__in=teams_voter_is_on_organization_we_vote_id_list)
                     voter_is_challenge_owner = positive_value_exists(owner_queryset.count())
                     status += 'VOTER_IS_CHALLENGE_OWNER_AS_TEAM_MEMBER '
@@ -477,8 +477,8 @@ class ChallengeManager(models.Manager):
 
         try:
             queryset = ChallengeSupporter.objects.using('readonly').filter(
-                challenge_we_vote_id__iexact=challenge_we_vote_id,
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                challenge_we_vote_id=challenge_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id)
             voter_is_challenge_owner = positive_value_exists(queryset.count())
             status += 'VOTER_IS_CHALLENGE_SUPPORTER '
         except ChallengeSupporter as e:
@@ -850,11 +850,11 @@ class ChallengeManager(models.Manager):
             if positive_value_exists(read_only):
                 challenges_are_not_duplicates_list_query = \
                     ChallengesAreNotDuplicates.objects.using('readonly').filter(
-                        challenge1_we_vote_id__iexact=challenge_we_vote_id,
+                        challenge1_we_vote_id=challenge_we_vote_id,
                     )
             else:
                 challenges_are_not_duplicates_list_query = ChallengesAreNotDuplicates.objects.filter(
-                    challenge1_we_vote_id__iexact=challenge_we_vote_id,
+                    challenge1_we_vote_id=challenge_we_vote_id,
                 )
             challenges_are_not_duplicates_list1 = list(challenges_are_not_duplicates_list_query)
             success = True
@@ -872,12 +872,12 @@ class ChallengeManager(models.Manager):
                 if positive_value_exists(read_only):
                     challenges_are_not_duplicates_list_query = \
                         ChallengesAreNotDuplicates.objects.using('readonly').filter(
-                            challenge2_we_vote_id__iexact=challenge_we_vote_id,
+                            challenge2_we_vote_id=challenge_we_vote_id,
                         )
                 else:
                     challenges_are_not_duplicates_list_query = \
                         ChallengesAreNotDuplicates.objects.filter(
-                            challenge2_we_vote_id__iexact=challenge_we_vote_id,
+                            challenge2_we_vote_id=challenge_we_vote_id,
                         )
                 challenges_are_not_duplicates_list2 = list(challenges_are_not_duplicates_list_query)
                 success = True
@@ -1147,7 +1147,7 @@ class ChallengeManager(models.Manager):
             else:
                 if positive_value_exists(including_started_by_voter_we_vote_id):
                     # started_by this voter
-                    new_filter = Q(started_by_voter_we_vote_id__iexact=including_started_by_voter_we_vote_id)
+                    new_filter = Q(started_by_voter_we_vote_id=including_started_by_voter_we_vote_id)
                     filters.append(new_filter)
                     # Voter is owner of the challenge, or on team that owns it
                     voter_owned_challenge_we_vote_ids = challenge_manager.retrieve_voter_owned_challenge_we_vote_ids(
@@ -1250,7 +1250,7 @@ class ChallengeManager(models.Manager):
             if positive_value_exists(including_started_by_voter_we_vote_id):
                 # started_by this voter
                 new_filter = \
-                    Q(started_by_voter_we_vote_id__iexact=including_started_by_voter_we_vote_id)
+                    Q(started_by_voter_we_vote_id=including_started_by_voter_we_vote_id)
                 filters.append(new_filter)
                 # Voter is owner of the challenge, or on team that owns it
                 voter_owned_challenge_we_vote_ids = challenge_manager.retrieve_voter_owned_challenge_we_vote_ids(
@@ -2023,9 +2023,9 @@ class ChallengeManager(models.Manager):
             return ''
         try:
             if positive_value_exists(read_only):
-                challenge = Challenge.objects.using('readonly').get(we_vote_id__iexact=challenge_we_vote_id)
+                challenge = Challenge.objects.using('readonly').get(we_vote_id=challenge_we_vote_id)
             else:
-                challenge = Challenge.objects.get(we_vote_id__iexact=challenge_we_vote_id)
+                challenge = Challenge.objects.get(we_vote_id=challenge_we_vote_id)
             return challenge.challenge_title
         except Challenge.DoesNotExist as e:
             # Some test data will throw this, no worries
@@ -2071,7 +2071,7 @@ class ChallengeManager(models.Manager):
 
         try:
             challenge_owner_query = ChallengeOwner.objects.using('readonly').filter(
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                voter_we_vote_id=voter_we_vote_id)
             challenge_owner_query = challenge_owner_query.values_list('challenge_we_vote_id', flat=True).distinct()
             challenge_owner_challenge_we_vote_ids = list(challenge_owner_query)
         except ChallengeOwner as e:
@@ -2081,7 +2081,7 @@ class ChallengeManager(models.Manager):
         try:
             # Which teams does this voter belong to, with can_send_updates_for_challenge_owned_by_organization rights?
             team_member_queryset = OrganizationTeamMember.objects.using('readonly').filter(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
                 can_send_updates_for_challenge_owned_by_organization=True
             )
             team_member_queryset = team_member_queryset.values_list('organization_we_vote_id', flat=True).distinct()
@@ -2117,7 +2117,7 @@ class ChallengeManager(models.Manager):
 
         try:
             challenge_owner_query = ChallengeOwner.objects.using('readonly').filter(
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                voter_we_vote_id=voter_we_vote_id)
             challenge_owner_query = challenge_owner_query.values_list('challenge_we_vote_id', flat=True).distinct()
             challenge_owner_challenge_we_vote_ids = list(challenge_owner_query)
         except ChallengeOwner as e:
@@ -2127,7 +2127,7 @@ class ChallengeManager(models.Manager):
         try:
             # Which teams does this voter belong to, with challenge rights?
             team_member_queryset = OrganizationTeamMember.objects.using('readonly').filter(
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                voter_we_vote_id=voter_we_vote_id)
             team_member_queryset = team_member_queryset.filter(
                 Q(can_edit_challenge_owned_by_organization=True) |
                 Q(can_moderate_challenge_owned_by_organization=True) |
@@ -2165,7 +2165,7 @@ class ChallengeManager(models.Manager):
 
         try:
             challenge_owner_entries_updated = ChallengeOwner.objects \
-                .filter(organization_we_vote_id__iexact=organization_we_vote_id) \
+                .filter(organization_we_vote_id=organization_we_vote_id) \
                 .update(organization_name=organization_name,
                         we_vote_hosted_profile_image_url_medium=we_vote_hosted_profile_image_url_medium,
                         we_vote_hosted_profile_image_url_tiny=we_vote_hosted_profile_image_url_tiny)
@@ -2192,7 +2192,7 @@ class ChallengeManager(models.Manager):
 
         try:
             challenge_supporter_entries_updated = ChallengeSupporter.objects \
-                .filter(organization_we_vote_id__iexact=organization_we_vote_id) \
+                .filter(organization_we_vote_id=organization_we_vote_id) \
                 .update(supporter_name=supporter_name,
                         we_vote_hosted_profile_image_url_medium=we_vote_hosted_profile_image_url_medium,
                         we_vote_hosted_profile_image_url_tiny=we_vote_hosted_profile_image_url_tiny)
@@ -2221,7 +2221,7 @@ class ChallengeManager(models.Manager):
             if not positive_value_exists(challenge_we_vote_id):
                 try:
                     queryset = Challenge.objects.using('readonly').all()
-                    queryset = queryset.filter(politician_we_vote_id__iexact=politician_we_vote_id)
+                    queryset = queryset.filter(politician_we_vote_id=politician_we_vote_id)
                     temp_list = queryset.values_list('we_vote_id', flat=True).distinct()
                     challenge_we_vote_id = temp_list[0]
                 except Exception as e:
@@ -2230,7 +2230,7 @@ class ChallengeManager(models.Manager):
                     return error_results
             try:
                 queryset = Organization.objects.using('readonly').all()
-                queryset = queryset.filter(politician_we_vote_id__iexact=politician_we_vote_id)
+                queryset = queryset.filter(politician_we_vote_id=politician_we_vote_id)
                 temp_list = queryset.values_list('we_vote_id', flat=True).distinct()
                 organization_we_vote_id = temp_list[0]
             except Exception as e:
@@ -2240,7 +2240,7 @@ class ChallengeManager(models.Manager):
             try:
                 from follow.models import FOLLOWING, FOLLOW_DISLIKE, FollowOrganization
                 queryset = FollowOrganization.objects.using('readonly').all()
-                queryset = queryset.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                queryset = queryset.filter(organization_we_vote_id=organization_we_vote_id)
                 following_queryset = queryset.filter(following_status=FOLLOWING)
                 supporters_count = following_queryset.count()
                 disliking_queryset = queryset.filter(following_status=FOLLOW_DISLIKE)
@@ -2252,7 +2252,7 @@ class ChallengeManager(models.Manager):
         else:
             try:
                 count_query = ChallengeSupporter.objects.using('readonly').all()
-                count_query = count_query.filter(challenge_we_vote_id__iexact=challenge_we_vote_id)
+                count_query = count_query.filter(challenge_we_vote_id=challenge_we_vote_id)
                 count_query = count_query.filter(challenge_supported=True)
                 supporters_count = count_query.count()
             except Exception as e:
@@ -2551,8 +2551,8 @@ class ChallengeManager(models.Manager):
                 }
                 challenges_are_not_duplicates, new_challenges_are_not_duplicates_created = \
                     ChallengesAreNotDuplicates.objects.update_or_create(
-                        challenge1_we_vote_id__iexact=challenge1_we_vote_id,
-                        challenge2_we_vote_id__iexact=challenge2_we_vote_id,
+                        challenge1_we_vote_id=challenge1_we_vote_id,
+                        challenge2_we_vote_id=challenge2_we_vote_id,
                         defaults=updated_values)
                 success = True
                 status += "CHALLENGES_ARE_NOT_DUPLICATES_UPDATED_OR_CREATED "

--- a/challenge/views_admin.py
+++ b/challenge/views_admin.py
@@ -1189,19 +1189,19 @@ def challenge_list_view(request):
             new_filter = Q(challenge_description__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(politician_we_vote_id__iexact=one_word)
+            new_filter = Q(politician_we_vote_id=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(organization_we_vote_id__iexact=one_word)
+            new_filter = Q(organization_we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(seo_friendly_path__iexact=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(started_by_voter_we_vote_id__iexact=one_word)
+            new_filter = Q(started_by_voter_we_vote_id=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(we_vote_id__iexact=one_word)
+            new_filter = Q(we_vote_id=one_word)
             filters.append(new_filter)
 
             # Add the first query
@@ -1359,7 +1359,7 @@ def challenge_summary_view(request, challenge_we_vote_id=""):
         from challenge.models import ChallengeSEOFriendlyPath
         try:
             path_query = ChallengeSEOFriendlyPath.objects.all()
-            path_query = path_query.filter(challenge_we_vote_id__iexact=challenge_we_vote_id)
+            path_query = path_query.filter(challenge_we_vote_id=challenge_we_vote_id)
             path_count = path_query.count()
             path_list = list(path_query[:4])
         except Exception as e:
@@ -1396,7 +1396,7 @@ def challenge_summary_view(request, challenge_we_vote_id=""):
     if positive_value_exists(challenge.politician_we_vote_id):
         from position.models import PositionEntered
         position_query = PositionEntered.objects.using('readonly').all()
-        position_query = position_query.filter(politician_we_vote_id__iexact=challenge.politician_we_vote_id)
+        position_query = position_query.filter(politician_we_vote_id=challenge.politician_we_vote_id)
         # position_query = position_query.exclude(
         #     Q(statement_text__isnull=True) |
         #     Q(statement_text__exact='')
@@ -1404,7 +1404,7 @@ def challenge_summary_view(request, challenge_we_vote_id=""):
         position_list = list(position_query[:4])
     else:
         supporters_query = ChallengeSupporter.objects.using('readonly').all()
-        supporters_query = supporters_query.filter(challenge_we_vote_id__iexact=challenge_we_vote_id)
+        supporters_query = supporters_query.filter(challenge_we_vote_id=challenge_we_vote_id)
         supporters_query = supporters_query.exclude(
             Q(supporter_endorsement__isnull=True) |
             Q(supporter_endorsement__exact='')
@@ -1473,11 +1473,11 @@ def challenge_supporters_list_view(request, challenge_we_vote_id=""):
 
     messages_on_stage = get_messages(request)
 
-    challenge = Challenge.objects.get(we_vote_id__iexact=challenge_we_vote_id)
+    challenge = Challenge.objects.get(we_vote_id=challenge_we_vote_id)
     challenge_title = challenge.challenge_title
 
     supporters_query = ChallengeSupporter.objects.all()
-    supporters_query = supporters_query.filter(challenge_we_vote_id__iexact=challenge_we_vote_id)
+    supporters_query = supporters_query.filter(challenge_we_vote_id=challenge_we_vote_id)
 
     if positive_value_exists(only_show_supporters_with_endorsements):
         supporters_query = supporters_query.exclude(
@@ -1520,10 +1520,10 @@ def challenge_supporters_list_view(request, challenge_we_vote_id=""):
             new_filter = Q(supporter_endorsement__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(voter_we_vote_id__iexact=one_word)
+            new_filter = Q(voter_we_vote_id=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(organization_we_vote_id__iexact=one_word)
+            new_filter = Q(organization_we_vote_id=one_word)
             filters.append(new_filter)
 
             # Add the first query
@@ -1691,7 +1691,7 @@ def challenge_supporters_list_process_view(request):
                                     )
 
     supporters_query = ChallengeSupporter.objects.all()
-    supporters_query = supporters_query.filter(challenge_we_vote_id__iexact=challenge_we_vote_id)
+    supporters_query = supporters_query.filter(challenge_we_vote_id=challenge_we_vote_id)
 
     if positive_value_exists(only_show_supporters_with_endorsements):
         supporters_query = supporters_query.exclude(
@@ -1717,10 +1717,10 @@ def challenge_supporters_list_process_view(request):
             new_filter = Q(supporter_endorsement__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(voter_we_vote_id__iexact=one_word)
+            new_filter = Q(voter_we_vote_id=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(organization_we_vote_id__iexact=one_word)
+            new_filter = Q(organization_we_vote_id=one_word)
             filters.append(new_filter)
 
             # Add the first query
@@ -2297,8 +2297,8 @@ def challenge_not_duplicates_view(request):
         challenge1_we_vote_id, challenge2_we_vote_id)
     if results['success']:
         queryset = ChallengesArePossibleDuplicates.objects.filter(
-            challenge1_we_vote_id__iexact=challenge1_we_vote_id,
-            challenge2_we_vote_id__iexact=challenge2_we_vote_id,
+            challenge1_we_vote_id=challenge1_we_vote_id,
+            challenge2_we_vote_id=challenge2_we_vote_id,
         )
         queryset.delete()
         if positive_value_exists(voter_we_vote_id):

--- a/config/environment_variables-template.json
+++ b/config/environment_variables-template.json
@@ -157,6 +157,8 @@
   "_comment-Search_Google_Drive_for_TWITTER_CONSUMER_KEY_for_more_details": "",
   "_comment-SOCIAL_AUTH_TWITTER_KEY == TWITTER_CONSUMER_KEY": "",
   "_comment-SOCIAL_AUTH_TWITTER_SECRET == TWITTER_CONSUMER_SECRET": "",
+  "_comment-MOBILE_PHONE_BYPASS":   "Use this test phone number and code when creating automated tests",
+  "SMS_BYPASS_MOBILE_NUMBER":       "+1 808-935-8555",
   "SOCIAL_AUTH_SMS_BYPASS":         "123456",
   "SOCIAL_AUTH_TWITTER_KEY":        "<This is Twitter's `Consumer Key`>",
   "SOCIAL_AUTH_TWITTER_SECRET":     "<This is Twitter's `Consumer Secret`>",

--- a/donate/models.py
+++ b/donate/models.py
@@ -317,7 +317,7 @@ class DonationManager(models.Manager):
         if positive_value_exists(voter_we_vote_id):
             try:
                 stripe_customer_id_queryset = DonateLinkToVoter.objects.filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id).values()
+                    voter_we_vote_id=voter_we_vote_id).values()
                 stripe_customer_id = stripe_customer_id_queryset[0]['stripe_customer_id']
                 if positive_value_exists(stripe_customer_id):
                     success = True
@@ -884,7 +884,7 @@ class DonationManager(models.Manager):
 
         try:
             donation_queryset = DonationJournal.objects.all().order_by('-created')
-            donation_queryset = donation_queryset.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            donation_queryset = donation_queryset.filter(voter_we_vote_id=voter_we_vote_id)
             donation_journal_list = list(donation_queryset)
 
             if len(donation_journal_list):
@@ -927,9 +927,9 @@ class DonationManager(models.Manager):
         try:
             donation_queryset = DonationPlanDefinition.objects.all().order_by('-id')
             if positive_value_exists(voter_we_vote_id):
-                donation_queryset = donation_queryset.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                donation_queryset = donation_queryset.filter(voter_we_vote_id=voter_we_vote_id)
             elif positive_value_exists(organization_we_vote_id):
-                donation_queryset = donation_queryset.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                donation_queryset = donation_queryset.filter(organization_we_vote_id=organization_we_vote_id)
             donation_queryset = donation_queryset.filter(is_organization_plan=is_organization_plan)
             if positive_value_exists(plan_type_enum):
                 donation_queryset = donation_queryset.filter(plan_type_enum__iexact=plan_type_enum)
@@ -977,9 +977,9 @@ class DonationManager(models.Manager):
         try:
             donation_queryset = DonationPlanDefinition.objects.all().order_by('-id')
             if positive_value_exists(voter_we_vote_id):
-                donation_queryset = donation_queryset.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                donation_queryset = donation_queryset.filter(voter_we_vote_id=voter_we_vote_id)
             if positive_value_exists(organization_we_vote_id):
-                donation_queryset = donation_queryset.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                donation_queryset = donation_queryset.filter(organization_we_vote_id=organization_we_vote_id)
             donation_plan_definition_list = list(donation_queryset)
 
             if len(donation_plan_definition_list):
@@ -1222,7 +1222,7 @@ class DonationManager(models.Manager):
             voter_manager = VoterManager()
             org_we_vote_id = voter_manager.fetch_linked_organization_we_vote_id_by_voter_we_vote_id(voter_we_vote_id)
 
-            rows = DonationPlanDefinition.objects.get(organization_we_vote_id__iexact=org_we_vote_id,
+            rows = DonationPlanDefinition.objects.get(organization_we_vote_id=org_we_vote_id,
                                                       is_organization_plan=True,
                                                       donation_plan_is_active=True)
             if len(rows):
@@ -1255,7 +1255,7 @@ class DonationManager(models.Manager):
 
         try:
             donate_link_query = DonateLinkToVoter.objects.all()
-            donate_link_query = donate_link_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            donate_link_query = donate_link_query.filter(voter_we_vote_id=voter_we_vote_id)
             donate_link_list = list(donate_link_query)
             status += "move_donate_link_to_voter_from_voter_to_voter LIST_RETRIEVED-" + \
                       voter_we_vote_id + "-TO-" + to_voter_we_vote_id + " LENGTH: " + str(len(donate_link_list)) + " "
@@ -1304,7 +1304,7 @@ class DonationManager(models.Manager):
 
         try:
             donation_journal_query = DonationJournal.objects.all()
-            donation_journal_query = donation_journal_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            donation_journal_query = donation_journal_query.filter(voter_we_vote_id=voter_we_vote_id)
             donation_journal_list = list(donation_journal_query)
             status += "move_donation_journal_entries_from_voter_to_voter LIST_RETRIEVED-" + \
                       voter_we_vote_id + "-TO-" + to_voter_we_vote_id + \
@@ -1355,7 +1355,7 @@ class DonationManager(models.Manager):
         try:
             donation_plan_definition_query = DonationPlanDefinition.objects.all()
             donation_plan_definition_query = donation_plan_definition_query.filter(
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                voter_we_vote_id=voter_we_vote_id)
             donation_plan_definition_list = list(donation_plan_definition_query)
             status += "move_donation_plan_definition_entries_from_voter_to_voter LIST_RETRIEVED-" + \
                       voter_we_vote_id + "-TO-" + to_voter_we_vote_id + \
@@ -1406,7 +1406,7 @@ class DonationManager(models.Manager):
         try:
             donation_journal_query = DonationJournal.objects.all()
             donation_journal_query = donation_journal_query.filter(
-                organization_we_vote_id__iexact=from_organization_we_vote_id)
+                organization_we_vote_id=from_organization_we_vote_id)
             donation_journal_list = list(donation_journal_query)
             status += "move_donation_journal_entries_from_organization_to_organization LIST_RETRIEVED-" + \
                       from_organization_we_vote_id + "-TO-" + to_organization_we_vote_id +  \
@@ -1457,7 +1457,7 @@ class DonationManager(models.Manager):
         try:
             donation_plan_definition_query = DonationPlanDefinition.objects.all()
             donation_plan_definition_query = donation_plan_definition_query.filter(
-                organization_we_vote_id__iexact=from_organization_we_vote_id)
+                organization_we_vote_id=from_organization_we_vote_id)
             donation_plan_definition_list = list(donation_plan_definition_query)
             status += "move_donation_plan_definition_entries_from_organization_to_organization LIST_RETRIEVED-" + \
                       from_organization_we_vote_id + "-TO-" + to_organization_we_vote_id + \
@@ -1562,7 +1562,7 @@ class DonationManager(models.Manager):
     @staticmethod
     def update_journal_entry_for_refund(charge, voter_we_vote_id, refund):
         if refund and refund['amount'] > 0 and refund['status'] == "succeeded":
-            row = DonationJournal.objects.get(charge_id__iexact=charge, voter_we_vote_id__iexact=voter_we_vote_id)
+            row = DonationJournal.objects.get(charge_id__iexact=charge, voter_we_vote_id=voter_we_vote_id)
             row.status = textwrap.shorten(row.status + " CHARGE_REFUND_REQUESTED" + "_" + str(refund['created']) +
                                           "_" + refund['currency'] + "_" + str(refund['amount']) + "_REFUND_ID" +
                                           refund['id'] + " ", width=255, placeholder="...")
@@ -1579,7 +1579,7 @@ class DonationManager(models.Manager):
 
     @staticmethod
     def update_journal_entry_for_already_refunded(charge, voter_we_vote_id):
-        row = DonationJournal.objects.get(charge_id__iexact=charge, voter_we_vote_id__iexact=voter_we_vote_id)
+        row = DonationJournal.objects.get(charge_id__iexact=charge, voter_we_vote_id=voter_we_vote_id)
         row.status = textwrap.shorten(row.status + "CHARGE_WAS_ALREADY_REFUNDED_" + str(datetime.utcnow()) + " ",
                                       width=255, placeholder="...")
         row.amount_refunded = row.amount
@@ -1690,8 +1690,8 @@ class DonationManager(models.Manager):
         try:
             # Then find the SUBSCRIPTION_SETUP_AND_INITIAL in the DonationJournal row that matches this charge.succeeded
             queryset = DonationJournal.objects.all().order_by('-id')
-            journal_rows = queryset.filter(voter_we_vote_id__iexact=voter_we_vote_id,
-                                   organization_we_vote_id__iexact=organization_we_vote_id,
+            journal_rows = queryset.filter(voter_we_vote_id=voter_we_vote_id,
+                                   organization_we_vote_id=organization_we_vote_id,
                                    amount=amount,
                                    record_enum__iexact="SUBSCRIPTION_SETUP_AND_INITIAL")
 

--- a/election/views_admin.py
+++ b/election/views_admin.py
@@ -394,7 +394,7 @@ def election_one_ballot_retrieve_view(request, election_local_id=0):
     if positive_value_exists(polling_location_we_vote_id):
         try:
             polling_location = PollingLocation.objects.get(
-                we_vote_id__iexact=polling_location_we_vote_id)
+                we_vote_id=polling_location_we_vote_id)
         except PollingLocation.DoesNotExist:
             messages.add_message(request, messages.INFO,
                                  'Could not retrieve ballot data for this map point for {election_name}, '

--- a/electoral_district/models.py
+++ b/electoral_district/models.py
@@ -201,7 +201,7 @@ class ElectoralDistrictManager(models.Manager):
         try:
             if positive_value_exists(polling_location_we_vote_id):
                 electoral_district_query = ElectoralDistrictLinkToPollingLocation.objects.filter(
-                    polling_location_we_vote_id__iexact=polling_location_we_vote_id)
+                    polling_location_we_vote_id=polling_location_we_vote_id)
                 electoral_district_list = list(electoral_district_query)
                 for one_electoral_district in electoral_district_list:
                     one_electoral_district.delete()
@@ -210,8 +210,8 @@ class ElectoralDistrictManager(models.Manager):
                 status += 'ELECTORAL_DISTRICT_LINKS_DELETED_BY_POLLING_LOCATION_WE_VOTE_ID '
             # elif positive_value_exists(voter_we_vote_id) and positive_value_exists(issue_we_vote_id):
             #     electoral_district_query = ElectoralDistrictLinkToPollingLocation.objects.filter(
-            #         voter_we_vote_id__iexact=voter_we_vote_id,
-            #         issue_we_vote_id__iexact=issue_we_vote_id)
+            #         voter_we_vote_id=voter_we_vote_id,
+            #         issue_we_vote_id=issue_we_vote_id)
             #     electoral_district_list = list(electoral_district_query)
             #     for one_electoral_district in electoral_district_list:
             #         one_electoral_district.delete()
@@ -328,11 +328,11 @@ class ElectoralDistrictManager(models.Manager):
 
                 if positive_value_exists(polling_location_we_vote_id):
                     electoral_district_query = \
-                        electoral_district_query.filter(polling_location_we_vote_id__iexact=polling_location_we_vote_id)
+                        electoral_district_query.filter(polling_location_we_vote_id=polling_location_we_vote_id)
                 if positive_value_exists(electoral_district_we_vote_id):
                     electoral_district_query = \
                         electoral_district_query.filter(
-                            electoral_district_we_vote_id__iexact=electoral_district_we_vote_id)
+                            electoral_district_we_vote_id=electoral_district_we_vote_id)
                 if positive_value_exists(ballotpedia_district_id):
                     electoral_district_query = \
                         electoral_district_query.filter(ballotpedia_district_id=ballotpedia_district_id)
@@ -434,14 +434,14 @@ class ElectoralDistrictManager(models.Manager):
 
             if positive_value_exists(ballotpedia_district_id):
                 ElectoralDistrictLinkToPollingLocation.objects.update_or_create(
-                    polling_location_we_vote_id__iexact=polling_location_we_vote_id,
+                    polling_location_we_vote_id=polling_location_we_vote_id,
                     ballotpedia_district_id=ballotpedia_district_id,
                     defaults=defaults,
                     )
             elif positive_value_exists(electoral_district_we_vote_id):
                 ElectoralDistrictLinkToPollingLocation.objects.update_or_create(
-                    polling_location_we_vote_id__iexact=polling_location_we_vote_id,
-                    electoral_district_we_vote_id__iexact=electoral_district_we_vote_id,
+                    polling_location_we_vote_id=polling_location_we_vote_id,
+                    electoral_district_we_vote_id=electoral_district_we_vote_id,
                     defaults=defaults,
                     )
             status = "POLLING_LOCATION_LINK_TO_ELECTORAL_DISTRICT_CREATED_OR_UPDATED "

--- a/electoral_district/views_admin.py
+++ b/electoral_district/views_admin.py
@@ -121,7 +121,7 @@ def electoral_district_list_view(request):
         # Find the electoral_districts this map point is in
         electoral_district_link_query = ElectoralDistrictLinkToPollingLocation.objects.all()
         electoral_district_link_query = electoral_district_link_query.filter(
-            polling_location_we_vote_id__iexact=polling_location_we_vote_id)
+            polling_location_we_vote_id=polling_location_we_vote_id)
 
         electoral_district_link_list = list(electoral_district_link_query)
 
@@ -131,7 +131,7 @@ def electoral_district_list_view(request):
         electoral_district_count = 0
         filters = []
         for one_link in electoral_district_link_list:
-            new_filter = Q(we_vote_id__iexact=one_link.electoral_district_we_vote_id)
+            new_filter = Q(we_vote_id=one_link.electoral_district_we_vote_id)
             filters.append(new_filter)
 
         # Add the first query
@@ -181,7 +181,7 @@ def electoral_district_list_view(request):
                 new_filter = Q(state_code__iexact=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
                 # Add the first query
@@ -241,7 +241,7 @@ def electoral_district_summary_view(request):
     electoral_district_on_stage_found = False
     electoral_district_on_stage = ElectoralDistrict()
     try:
-        electoral_district_on_stage = ElectoralDistrict.objects.get(we_vote_id__iexact=electoral_district_we_vote_id)
+        electoral_district_on_stage = ElectoralDistrict.objects.get(we_vote_id=electoral_district_we_vote_id)
         electoral_district_on_stage_found = True
     except ElectoralDistrict.MultipleObjectsReturned as e:
         handle_record_found_more_than_one_exception(e, logger=logger)

--- a/email_outbound/models.py
+++ b/email_outbound/models.py
@@ -522,25 +522,25 @@ class EmailManager(models.Manager):
                 if positive_value_exists(voter_we_vote_id):
                     if positive_value_exists(read_only):
                         email_address_object = EmailAddress.objects.using('readonly').get(
-                            we_vote_id__iexact=email_address_object_we_vote_id,
-                            voter_we_vote_id__iexact=voter_we_vote_id,
+                            we_vote_id=email_address_object_we_vote_id,
+                            voter_we_vote_id=voter_we_vote_id,
                             deleted=False
                         )
                     else:
                         email_address_object = EmailAddress.objects.get(
-                            we_vote_id__iexact=email_address_object_we_vote_id,
-                            voter_we_vote_id__iexact=voter_we_vote_id,
+                            we_vote_id=email_address_object_we_vote_id,
+                            voter_we_vote_id=voter_we_vote_id,
                             deleted=False
                         )
                 else:
                     if positive_value_exists(read_only):
                         email_address_object = EmailAddress.objects.using('readonly').get(
-                            we_vote_id__iexact=email_address_object_we_vote_id,
+                            we_vote_id=email_address_object_we_vote_id,
                             deleted=False
                         )
                     else:
                         email_address_object = EmailAddress.objects.get(
-                            we_vote_id__iexact=email_address_object_we_vote_id,
+                            we_vote_id=email_address_object_we_vote_id,
                             deleted=False
                         )
                 email_address_object_id = email_address_object.id
@@ -556,7 +556,7 @@ class EmailManager(models.Manager):
                 if positive_value_exists(voter_we_vote_id):
                     email_address_queryset = email_address_queryset.filter(
                         normalized_email_address__iexact=normalized_email_address,
-                        voter_we_vote_id__iexact=voter_we_vote_id,
+                        voter_we_vote_id=voter_we_vote_id,
                         deleted=False
                     )
                 else:
@@ -759,7 +759,7 @@ class EmailManager(models.Manager):
             else:
                 email_address_queryset = EmailAddress.objects.all()
             email_address_queryset = email_address_queryset.filter(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
                 deleted=False
             )
             email_address_queryset = email_address_queryset.order_by('-id')  # Put most recent email at top of list
@@ -811,7 +811,7 @@ class EmailManager(models.Manager):
                 else:
                     email_address_queryset = EmailAddress.objects.all()
                 email_address_queryset = email_address_queryset.filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id,
+                    voter_we_vote_id=voter_we_vote_id,
                     email_ownership_is_verified=True,
                     deleted=False
                 )

--- a/follow/models.py
+++ b/follow/models.py
@@ -173,15 +173,15 @@ class FollowCampaignXManager(models.Manager):
                 status = 'FOLLOW_ISSUE_FOUND_WITH_ID'
             elif positive_value_exists(voter_we_vote_id) and positive_value_exists(issue_id):
                 follow_campaignx_on_stage = FollowIssue.objects.get(
-                    voter_we_vote_id__iexact=voter_we_vote_id,
+                    voter_we_vote_id=voter_we_vote_id,
                     issue_id=issue_id)
                 follow_campaignx_on_stage_id = follow_campaignx_on_stage.id
                 success = True
                 status = 'FOLLOW_ISSUE_FOUND_WITH_VOTER_WE_VOTE_ID_AND_ISSUE_ID'
             elif positive_value_exists(voter_we_vote_id) and positive_value_exists(issue_we_vote_id):
                 follow_campaignx_on_stage = FollowIssue.objects.get(
-                    voter_we_vote_id__iexact=voter_we_vote_id,
-                    issue_we_vote_id__iexact=issue_we_vote_id)
+                    voter_we_vote_id=voter_we_vote_id,
+                    issue_we_vote_id=issue_we_vote_id)
                 follow_campaignx_on_stage_id = follow_campaignx_on_stage.id
                 success = True
                 status = 'FOLLOW_ISSUE_FOUND_WITH_VOTER_WE_VOTE_ID_AND_ISSUE_WE_VOTE_ID'
@@ -242,7 +242,7 @@ class FollowCampaignXManager(models.Manager):
                 status += 'FOLLOW_ISSUE_DELETED_BY_ID '
             elif positive_value_exists(voter_we_vote_id) and positive_value_exists(issue_id):
                 follow_campaignx_query = FollowIssue.objects.filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id,
+                    voter_we_vote_id=voter_we_vote_id,
                     issue_id=issue_id)
                 follow_campaignx_list = list(follow_campaignx_query)
                 for one_follow_campaignx in follow_campaignx_list:
@@ -252,8 +252,8 @@ class FollowCampaignXManager(models.Manager):
                 status += 'FOLLOW_ISSUE_DELETED_BY_VOTER_WE_VOTE_ID_AND_ISSUE_ID '
             elif positive_value_exists(voter_we_vote_id) and positive_value_exists(issue_we_vote_id):
                 follow_campaignx_query = FollowIssue.objects.filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id,
-                    issue_we_vote_id__iexact=issue_we_vote_id)
+                    voter_we_vote_id=voter_we_vote_id,
+                    issue_we_vote_id=issue_we_vote_id)
                 follow_campaignx_list = list(follow_campaignx_query)
                 for one_follow_campaignx in follow_campaignx_list:
                     one_follow_campaignx.delete()
@@ -453,15 +453,15 @@ class FollowIssueManager(models.Manager):
                 status = 'FOLLOW_ISSUE_FOUND_WITH_ID'
             elif positive_value_exists(voter_we_vote_id) and positive_value_exists(issue_id):
                 follow_issue_on_stage = FollowIssue.objects.get(
-                    voter_we_vote_id__iexact=voter_we_vote_id,
+                    voter_we_vote_id=voter_we_vote_id,
                     issue_id=issue_id)
                 follow_issue_on_stage_id = follow_issue_on_stage.id
                 success = True
                 status = 'FOLLOW_ISSUE_FOUND_WITH_VOTER_WE_VOTE_ID_AND_ISSUE_ID'
             elif positive_value_exists(voter_we_vote_id) and positive_value_exists(issue_we_vote_id):
                 follow_issue_on_stage = FollowIssue.objects.get(
-                    voter_we_vote_id__iexact=voter_we_vote_id,
-                    issue_we_vote_id__iexact=issue_we_vote_id)
+                    voter_we_vote_id=voter_we_vote_id,
+                    issue_we_vote_id=issue_we_vote_id)
                 follow_issue_on_stage_id = follow_issue_on_stage.id
                 success = True
                 status = 'FOLLOW_ISSUE_FOUND_WITH_VOTER_WE_VOTE_ID_AND_ISSUE_WE_VOTE_ID'
@@ -522,7 +522,7 @@ class FollowIssueManager(models.Manager):
                 status += 'FOLLOW_ISSUE_DELETED_BY_ID '
             elif positive_value_exists(voter_we_vote_id) and positive_value_exists(issue_id):
                 follow_issue_query = FollowIssue.objects.filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id,
+                    voter_we_vote_id=voter_we_vote_id,
                     issue_id=issue_id)
                 follow_issue_list = list(follow_issue_query)
                 for one_follow_issue in follow_issue_list:
@@ -532,8 +532,8 @@ class FollowIssueManager(models.Manager):
                 status += 'FOLLOW_ISSUE_DELETED_BY_VOTER_WE_VOTE_ID_AND_ISSUE_ID '
             elif positive_value_exists(voter_we_vote_id) and positive_value_exists(issue_we_vote_id):
                 follow_issue_query = FollowIssue.objects.filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id,
-                    issue_we_vote_id__iexact=issue_we_vote_id)
+                    voter_we_vote_id=voter_we_vote_id,
+                    issue_we_vote_id=issue_we_vote_id)
                 follow_issue_list = list(follow_issue_query)
                 for one_follow_issue in follow_issue_list:
                     one_follow_issue.delete()
@@ -607,7 +607,7 @@ class FollowIssueManager(models.Manager):
         try:
             suggested_issue_to_follow_queryset = SuggestedIssueToFollow.objects.all()
             suggested_issue_to_follow_list = suggested_issue_to_follow_queryset.filter(
-                viewer_voter_we_vote_id__iexact=viewer_voter_we_vote_id,
+                viewer_voter_we_vote_id=viewer_voter_we_vote_id,
                 from_twitter=from_twitter)
             if len(suggested_issue_to_follow_list):
                 success = True
@@ -646,7 +646,7 @@ class FollowMetricsManager(models.Manager):
         count_result = None
         try:
             count_query = FollowOrganization.objects.using('readonly').all()
-            count_query = count_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+            count_query = count_query.filter(organization_we_vote_id=organization_we_vote_id)
             count_query = count_query.filter(following_status=FOLLOWING)
             # count_query = count_query.values("voter_id").distinct()
             count_query = count_query.values("organization_we_vote_id_that_is_following").distinct()
@@ -685,7 +685,7 @@ class FollowMetricsManager(models.Manager):
         try:
             count_query = FollowIssue.objects.using('readonly').all()
             if positive_value_exists(voter_we_vote_id):
-                count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                count_query = count_query.filter(voter_we_vote_id=voter_we_vote_id)
             count_query = count_query.filter(following_status=FOLLOWING)
             if positive_value_exists(limit_to_one_date_as_integer):
                 date_as_string = "{date}".format(date=limit_to_one_date_as_integer)
@@ -727,7 +727,7 @@ class FollowIssueList(models.Model):
         follow_issue_list_length = 0
         try:
             follow_issue_list_query = FollowIssue.objects.using('readonly').all()
-            follow_issue_list_query = follow_issue_list_query.filter(issue_we_vote_id__iexact=issue_we_vote_id)
+            follow_issue_list_query = follow_issue_list_query.filter(issue_we_vote_id=issue_we_vote_id)
             follow_issue_list_query = follow_issue_list_query.filter(following_status=FOLLOWING)
             follow_issue_list_length = follow_issue_list_query.count()
 
@@ -743,7 +743,7 @@ class FollowIssueList(models.Model):
         follow_issue_list_length = 0
         try:
             follow_issue_list_query = FollowIssue.objects.using('readonly').all()
-            follow_issue_list_query = follow_issue_list_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            follow_issue_list_query = follow_issue_list_query.filter(voter_we_vote_id=voter_we_vote_id)
             follow_issue_list_query = follow_issue_list_query.filter(following_status=following_status)
             follow_issue_list_length = follow_issue_list_query.count()
 
@@ -773,7 +773,7 @@ class FollowIssueList(models.Model):
                 follow_issue_list_query = FollowIssue.objects.using('readonly').all()
             else:
                 follow_issue_list_query = FollowIssue.objects.all()
-            follow_issue_list_query = follow_issue_list_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            follow_issue_list_query = follow_issue_list_query.filter(voter_we_vote_id=voter_we_vote_id)
             if positive_value_exists(following_status):
                 follow_issue_list = follow_issue_list_query.filter(following_status=following_status)
             if len(follow_issue_list):
@@ -798,7 +798,7 @@ class FollowIssueList(models.Model):
 
         try:
             follow_issue_list_query = FollowIssue.objects.using('readonly').all()
-            follow_issue_list_query = follow_issue_list_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            follow_issue_list_query = follow_issue_list_query.filter(voter_we_vote_id=voter_we_vote_id)
             if positive_value_exists(following_status):
                 follow_issue_list_query = follow_issue_list_query.filter(following_status=following_status)
             follow_issue_list_query = follow_issue_list_query.values("issue_we_vote_id").distinct()
@@ -851,7 +851,7 @@ class FollowIssueList(models.Model):
             if positive_value_exists(issue_id):
                 follow_issue_list = follow_issue_list.filter(issue_id=issue_id)
             else:
-                follow_issue_list = follow_issue_list.filter(issue_we_vote_id__iexact=issue_we_vote_id)
+                follow_issue_list = follow_issue_list.filter(issue_we_vote_id=issue_we_vote_id)
             if positive_value_exists(following_status):
                 follow_issue_list = follow_issue_list.filter(following_status=following_status)
             if len(follow_issue_list):
@@ -1328,7 +1328,7 @@ class FollowOrganizationManager(models.Manager):
         try:
             suggested_organization_to_follow_queryset = SuggestedOrganizationToFollow.objects.all()
             suggested_organization_to_follow_list = suggested_organization_to_follow_queryset.filter(
-                viewer_voter_we_vote_id__iexact=viewer_voter_we_vote_id,
+                viewer_voter_we_vote_id=viewer_voter_we_vote_id,
                 from_twitter=from_twitter)
             if len(suggested_organization_to_follow_list):
                 success = True

--- a/friend/controllers.py
+++ b/friend/controllers.py
@@ -55,7 +55,7 @@ def delete_friend_invitations_for_voter(voter_to_delete_we_vote_id):
     # FROM SENDER: Invitations sent BY the voter_to_delete to others
     try:
         number_deleted, details = FriendInvitationEmailLink.objects\
-            .filter(sender_voter_we_vote_id__iexact=voter_to_delete_we_vote_id, )\
+            .filter(sender_voter_we_vote_id=voter_to_delete_we_vote_id, )\
             .delete()
         friend_invitation_entries_deleted += number_deleted
     except Exception as e:
@@ -67,7 +67,7 @@ def delete_friend_invitations_for_voter(voter_to_delete_we_vote_id):
     # FROM SENDER: Invitations sent BY the voter_to_delete to others
     try:
         number_deleted, details = FriendInvitationVoterLink.objects\
-            .filter(sender_voter_we_vote_id__iexact=voter_to_delete_we_vote_id, )\
+            .filter(sender_voter_we_vote_id=voter_to_delete_we_vote_id, )\
             .delete()
         friend_invitation_entries_deleted += number_deleted
     except Exception as e:
@@ -78,7 +78,7 @@ def delete_friend_invitations_for_voter(voter_to_delete_we_vote_id):
     # FROM RECIPIENT: Invitations sent TO the voter_to_delete from others            
     try:
         number_deleted, details = FriendInvitationVoterLink.objects\
-            .filter(recipient_voter_we_vote_id__iexact=voter_to_delete_we_vote_id, )\
+            .filter(recipient_voter_we_vote_id=voter_to_delete_we_vote_id, )\
             .delete()
         friend_invitation_entries_deleted += number_deleted
     except Exception as e:
@@ -133,7 +133,7 @@ def delete_friends_for_voter(voter_to_delete_we_vote_id):
     
     try:
         number_deleted, details = CurrentFriend.objects\
-            .filter(viewer_voter_we_vote_id__iexact=voter_to_delete_we_vote_id, )\
+            .filter(viewer_voter_we_vote_id=voter_to_delete_we_vote_id, )\
             .delete()
         friend_entries_deleted += number_deleted
     except Exception as e:
@@ -186,7 +186,7 @@ def delete_suggested_friends_for_voter(voter_to_delete_we_vote_id):
             
     try:
         number_deleted, details = SuggestedFriend.objects\
-            .filter(viewer_voter_we_vote_id__iexact=voter_to_delete_we_vote_id, )\
+            .filter(viewer_voter_we_vote_id=voter_to_delete_we_vote_id, )\
             .delete()
         suggested_friend_entries_deleted += number_deleted
     except Exception as e:
@@ -3203,11 +3203,11 @@ def generate_mutual_friend_preview_list_serialized_for_two_voters(
     #  for both person A and person B, regardless of which one is looking
     queryset = MutualFriend.objects.using('readonly').all()
     queryset = queryset.filter(
-        Q(viewer_voter_we_vote_id__iexact=first_friend_voter_we_vote_id) |
-        Q(viewee_voter_we_vote_id__iexact=first_friend_voter_we_vote_id))
+        Q(viewer_voter_we_vote_id=first_friend_voter_we_vote_id) |
+        Q(viewee_voter_we_vote_id=first_friend_voter_we_vote_id))
     queryset = queryset.filter(
-        Q(viewer_voter_we_vote_id__iexact=second_friend_voter_we_vote_id) |
-        Q(viewee_voter_we_vote_id__iexact=second_friend_voter_we_vote_id))
+        Q(viewer_voter_we_vote_id=second_friend_voter_we_vote_id) |
+        Q(viewee_voter_we_vote_id=second_friend_voter_we_vote_id))
     queryset = queryset.filter(
         Q(mutual_friend_display_name_exists=True) |
         Q(mutual_friend_profile_image_exists=True))
@@ -4213,7 +4213,7 @@ def move_friends_to_another_voter(
 
     try:
         number_deleted, details = CurrentFriend.objects\
-            .filter(viewer_voter_we_vote_id__iexact=from_voter_we_vote_id, )\
+            .filter(viewer_voter_we_vote_id=from_voter_we_vote_id, )\
             .delete()
         from_voter_we_vote_id += number_deleted
     except Exception as e:
@@ -4305,7 +4305,7 @@ def move_suggested_friends_to_another_voter(
     
     try:
         number_deleted, details = SuggestedFriend.objects\
-            .filter(viewer_voter_we_vote_id__iexact=from_voter_we_vote_id, )\
+            .filter(viewer_voter_we_vote_id=from_voter_we_vote_id, )\
             .delete()
         from_voter_we_vote_id += number_deleted
     except Exception as e:

--- a/friend/models.py
+++ b/friend/models.py
@@ -234,11 +234,11 @@ class FriendManager(models.Manager):
 
         try:
             friend_invitation, created = FriendInvitationEmailLink.objects.update_or_create(
-                sender_voter_we_vote_id__iexact=sender_voter_we_vote_id,
+                sender_voter_we_vote_id=sender_voter_we_vote_id,
                 recipient_voter_email__iexact=recipient_voter_email,
                 defaults=defaults,
             )
-            # recipient_email_we_vote_id__iexact = recipient_email_we_vote_id,
+            # recipient_email_we_vote_id = recipient_email_we_vote_id,
             friend_invitation_saved = True
             success = True
             status += "FRIEND_INVITATION_EMAIL_LINK_UPDATED_OR_CREATED "
@@ -283,8 +283,8 @@ class FriendManager(models.Manager):
 
         try:
             friend_invitation, created = FriendInvitationVoterLink.objects.update_or_create(
-                sender_voter_we_vote_id__iexact=sender_voter_we_vote_id,
-                recipient_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
+                sender_voter_we_vote_id=sender_voter_we_vote_id,
+                recipient_voter_we_vote_id=recipient_voter_we_vote_id,
                 defaults=defaults,
             )
             friend_invitation_saved = True
@@ -353,13 +353,13 @@ class FriendManager(models.Manager):
         try:
             if positive_value_exists(read_only):
                 current_friend = CurrentFriend.objects.using('readonly').get(
-                    viewer_voter_we_vote_id__iexact=sender_voter_we_vote_id,
-                    viewee_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
+                    viewer_voter_we_vote_id=sender_voter_we_vote_id,
+                    viewee_voter_we_vote_id=recipient_voter_we_vote_id,
                 )
             else:
                 current_friend = CurrentFriend.objects.get(
-                    viewer_voter_we_vote_id__iexact=sender_voter_we_vote_id,
-                    viewee_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
+                    viewer_voter_we_vote_id=sender_voter_we_vote_id,
+                    viewee_voter_we_vote_id=recipient_voter_we_vote_id,
                 )
             current_friend_found = True
             success = True
@@ -379,13 +379,13 @@ class FriendManager(models.Manager):
             try:
                 if positive_value_exists(read_only):
                     current_friend = CurrentFriend.objects.using('readonly').get(
-                        viewer_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
-                        viewee_voter_we_vote_id__iexact=sender_voter_we_vote_id,
+                        viewer_voter_we_vote_id=recipient_voter_we_vote_id,
+                        viewee_voter_we_vote_id=sender_voter_we_vote_id,
                     )
                 else:
                     current_friend = CurrentFriend.objects.get(
-                        viewer_voter_we_vote_id__iexact=recipient_voter_we_vote_id,
-                        viewee_voter_we_vote_id__iexact=sender_voter_we_vote_id,
+                        viewer_voter_we_vote_id=recipient_voter_we_vote_id,
+                        viewee_voter_we_vote_id=sender_voter_we_vote_id,
                     )
                 current_friend_found = True
                 success = True
@@ -417,13 +417,13 @@ class FriendManager(models.Manager):
         try:
             if positive_value_exists(read_only):
                 suggested_friend = SuggestedFriend.objects.using('readonly').get(
-                    viewer_voter_we_vote_id__iexact=voter_we_vote_id_one,
-                    viewee_voter_we_vote_id__iexact=voter_we_vote_id_two,
+                    viewer_voter_we_vote_id=voter_we_vote_id_one,
+                    viewee_voter_we_vote_id=voter_we_vote_id_two,
                 )
             else:
                 suggested_friend = SuggestedFriend.objects.get(
-                    viewer_voter_we_vote_id__iexact=voter_we_vote_id_one,
-                    viewee_voter_we_vote_id__iexact=voter_we_vote_id_two,
+                    viewer_voter_we_vote_id=voter_we_vote_id_one,
+                    viewee_voter_we_vote_id=voter_we_vote_id_two,
                 )
             suggested_friend_found = True
             success = True
@@ -443,13 +443,13 @@ class FriendManager(models.Manager):
             try:
                 if positive_value_exists(read_only):
                     suggested_friend = SuggestedFriend.objects.using('readonly').get(
-                        viewer_voter_we_vote_id__iexact=voter_we_vote_id_two,
-                        viewee_voter_we_vote_id__iexact=voter_we_vote_id_one,
+                        viewer_voter_we_vote_id=voter_we_vote_id_two,
+                        viewee_voter_we_vote_id=voter_we_vote_id_one,
                     )
                 else:
                     suggested_friend = SuggestedFriend.objects.get(
-                        viewer_voter_we_vote_id__iexact=voter_we_vote_id_two,
-                        viewee_voter_we_vote_id__iexact=voter_we_vote_id_one,
+                        viewer_voter_we_vote_id=voter_we_vote_id_two,
+                        viewee_voter_we_vote_id=voter_we_vote_id_one,
                     )
                 suggested_friend_found = True
                 success = True
@@ -628,8 +628,8 @@ class FriendManager(models.Manager):
         friend_invitation_voter_link = FriendInvitationVoterLink()
         try:
             friend_invitation_voter_link = FriendInvitationVoterLink.objects.get(
-                sender_voter_we_vote_id__iexact=sender_voter.we_vote_id,
-                recipient_voter_we_vote_id__iexact=recipient_voter.we_vote_id,
+                sender_voter_we_vote_id=sender_voter.we_vote_id,
+                recipient_voter_we_vote_id=recipient_voter.we_vote_id,
             )
             success = True
             friend_invitation_found = True
@@ -754,7 +754,7 @@ class FriendManager(models.Manager):
         friend_invitation_email_link = FriendInvitationEmailLink()
         try:
             friend_invitation_email_link = FriendInvitationEmailLink.objects.get(
-                sender_voter_we_vote_id__iexact=sender_voter.we_vote_id,
+                sender_voter_we_vote_id=sender_voter.we_vote_id,
                 recipient_voter_email__iexact=recipient_voter_email,
             )
             success = True
@@ -809,8 +809,8 @@ class FriendManager(models.Manager):
         try:
             current_friend_queryset = CurrentFriend.objects.using('readonly').all()
             current_friend_queryset = current_friend_queryset.filter(
-                Q(viewer_voter_we_vote_id__iexact=voter_we_vote_id) |
-                Q(viewee_voter_we_vote_id__iexact=voter_we_vote_id))
+                Q(viewer_voter_we_vote_id=voter_we_vote_id) |
+                Q(viewee_voter_we_vote_id=voter_we_vote_id))
             current_friends_count = current_friend_queryset.count()
         except Exception as e:
             current_friends_count = 0
@@ -837,8 +837,8 @@ class FriendManager(models.Manager):
         try:
             voter_friends_queryset = CurrentFriend.objects.using('readonly').all()
             voter_friends_queryset = voter_friends_queryset.filter(
-                Q(viewer_voter_we_vote_id__iexact=voter_we_vote_id) |
-                Q(viewee_voter_we_vote_id__iexact=voter_we_vote_id))
+                Q(viewer_voter_we_vote_id=voter_we_vote_id) |
+                Q(viewee_voter_we_vote_id=voter_we_vote_id))
             voter_friends_list = list(voter_friends_queryset)
             for one_friend in voter_friends_list:
                 voter_friends_we_vote_id_list.append(one_friend.fetch_other_voter_we_vote_id(voter_we_vote_id))
@@ -849,8 +849,8 @@ class FriendManager(models.Manager):
         try:
             friend_friends_queryset = CurrentFriend.objects.using('readonly').all()
             friend_friends_queryset = friend_friends_queryset.filter(
-                Q(viewer_voter_we_vote_id__iexact=friend_voter_we_vote_id) |
-                Q(viewee_voter_we_vote_id__iexact=friend_voter_we_vote_id))
+                Q(viewer_voter_we_vote_id=friend_voter_we_vote_id) |
+                Q(viewee_voter_we_vote_id=friend_voter_we_vote_id))
             friend_friends_list = list(friend_friends_queryset)
             for one_friend in friend_friends_list:
                 friend_friends_we_vote_id_list.append(one_friend.fetch_other_voter_we_vote_id(friend_voter_we_vote_id))
@@ -885,8 +885,8 @@ class FriendManager(models.Manager):
         try:
             suggested_friend_queryset = SuggestedFriend.objects.using('readonly').all()
             suggested_friend_queryset = suggested_friend_queryset.filter(
-                Q(viewer_voter_we_vote_id__iexact=voter_we_vote_id) |
-                Q(viewee_voter_we_vote_id__iexact=voter_we_vote_id))
+                Q(viewer_voter_we_vote_id=voter_we_vote_id) |
+                Q(viewee_voter_we_vote_id=voter_we_vote_id))
             suggested_friends_count = suggested_friend_queryset.count()
         except Exception as e:
             suggested_friends_count = 0
@@ -917,8 +917,8 @@ class FriendManager(models.Manager):
             else:
                 current_friend_queryset = CurrentFriend.objects.all()
             current_friend_queryset = current_friend_queryset.filter(
-                Q(viewer_voter_we_vote_id__iexact=voter_we_vote_id) |
-                Q(viewee_voter_we_vote_id__iexact=voter_we_vote_id))
+                Q(viewer_voter_we_vote_id=voter_we_vote_id) |
+                Q(viewee_voter_we_vote_id=voter_we_vote_id))
             current_friend_queryset = current_friend_queryset.order_by('-date_last_changed')
             current_friend_list = list(current_friend_queryset)
 
@@ -978,8 +978,8 @@ class FriendManager(models.Manager):
             # editable CurrentFriend objects.
             current_friend_queryset = CurrentFriend.objects.using('readonly').all()
             current_friend_queryset = current_friend_queryset.filter(
-                Q(viewer_voter_we_vote_id__iexact=voter_we_vote_id) |
-                Q(viewee_voter_we_vote_id__iexact=voter_we_vote_id))
+                Q(viewer_voter_we_vote_id=voter_we_vote_id) |
+                Q(viewee_voter_we_vote_id=voter_we_vote_id))
             # We can sort on the client
             # current_friend_queryset = current_friend_queryset.order_by('-date_last_changed')
             current_friend_list = list(current_friend_queryset)
@@ -1068,8 +1068,8 @@ class FriendManager(models.Manager):
         try:
             current_friend_queryset = CurrentFriend.objects.using('readonly').all()
             current_friend_queryset = current_friend_queryset.filter(
-                Q(viewer_voter_we_vote_id__iexact=voter_we_vote_id) |
-                Q(viewee_voter_we_vote_id__iexact=voter_we_vote_id))
+                Q(viewer_voter_we_vote_id=voter_we_vote_id) |
+                Q(viewee_voter_we_vote_id=voter_we_vote_id))
             current_friend_queryset = current_friend_queryset.order_by('-date_last_changed')
             current_friend_list = current_friend_queryset
 
@@ -1133,7 +1133,7 @@ class FriendManager(models.Manager):
             # Find invitations that I sent.
             friend_invitation_email_queryset = FriendInvitationEmailLink.objects.all()
             friend_invitation_email_queryset = friend_invitation_email_queryset.filter(
-                sender_voter_we_vote_id__iexact=sender_voter_we_vote_id)
+                sender_voter_we_vote_id=sender_voter_we_vote_id)
             friend_invitation_email_link_list = friend_invitation_email_queryset
 
             if len(friend_invitation_email_link_list):
@@ -1187,10 +1187,10 @@ class FriendManager(models.Manager):
             friend_invitation_voter_queryset = FriendInvitationVoterLink.objects.all()
             if positive_value_exists(sender_voter_we_vote_id):
                 friend_invitation_voter_queryset = friend_invitation_voter_queryset.filter(
-                    sender_voter_we_vote_id__iexact=sender_voter_we_vote_id)
+                    sender_voter_we_vote_id=sender_voter_we_vote_id)
             if positive_value_exists(recipient_voter_we_vote_id):
                 friend_invitation_voter_queryset = friend_invitation_voter_queryset.filter(
-                    recipient_voter_we_vote_id__iexact=recipient_voter_we_vote_id)
+                    recipient_voter_we_vote_id=recipient_voter_we_vote_id)
             friend_invitation_from_voter_list = friend_invitation_voter_queryset
 
             if len(friend_invitation_from_voter_list):
@@ -1295,10 +1295,10 @@ class FriendManager(models.Manager):
             # Find invitations that I sent that were accepted. Do NOT show invitations that were ignored.
             friend_invitation_voter_queryset = FriendInvitationVoterLink.objects.using('readonly').all()
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.filter(
-                sender_voter_we_vote_id__iexact=viewer_voter_we_vote_id)
+                sender_voter_we_vote_id=viewer_voter_we_vote_id)
             # It is possible through account merging to have an invitation to yourself. We want to exclude these.
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.exclude(
-                recipient_voter_we_vote_id__iexact=viewer_voter_we_vote_id)
+                recipient_voter_we_vote_id=viewer_voter_we_vote_id)
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.filter(invitation_status=ACCEPTED)
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.filter(deleted=False)
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.order_by('-date_last_changed')
@@ -1328,7 +1328,7 @@ class FriendManager(models.Manager):
             # Find invitations that I sent that were accepted. Do NOT show invitations that were ignored.
             friend_invitation_email_queryset = FriendInvitationEmailLink.objects.using('readonly').all()
             friend_invitation_email_queryset = friend_invitation_email_queryset.filter(
-                sender_voter_we_vote_id__iexact=viewer_voter_we_vote_id)
+                sender_voter_we_vote_id=viewer_voter_we_vote_id)
             friend_invitation_email_queryset = friend_invitation_email_queryset.filter(invitation_status=ACCEPTED)
             friend_invitation_email_queryset = friend_invitation_email_queryset.filter(deleted=False)
             friend_invitation_email_queryset = friend_invitation_email_queryset.order_by('-date_last_changed')
@@ -1373,10 +1373,10 @@ class FriendManager(models.Manager):
             # Find invitations that I received, including ones that I have ignored.
             friend_invitation_voter_queryset = FriendInvitationVoterLink.objects.using('readonly').all()
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.filter(
-                recipient_voter_we_vote_id__iexact=viewer_voter_we_vote_id)
+                recipient_voter_we_vote_id=viewer_voter_we_vote_id)
             # It is possible through account merging to have an invitation to yourself. We want to exclude these.
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.exclude(
-                sender_voter_we_vote_id__iexact=viewer_voter_we_vote_id)
+                sender_voter_we_vote_id=viewer_voter_we_vote_id)
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.filter(
                 Q(invitation_status=ACCEPTED) |
                 Q(invitation_status=IGNORED))
@@ -1537,10 +1537,10 @@ class FriendManager(models.Manager):
         try:
             friend_invitation_voter_queryset = FriendInvitationVoterLink.objects.all()
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.filter(
-                sender_voter_we_vote_id__iexact=sender_voter_we_vote_id)
+                sender_voter_we_vote_id=sender_voter_we_vote_id)
             # It is possible through account merging to have an invitation to yourself. We want to exclude these.
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.exclude(
-                recipient_voter_we_vote_id__iexact=sender_voter_we_vote_id)
+                recipient_voter_we_vote_id=sender_voter_we_vote_id)
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.filter(deleted=False)
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.exclude(
                 invitation_status__iexact=ACCEPTED)
@@ -1573,7 +1573,7 @@ class FriendManager(models.Manager):
         try:
             friend_invitation_email_queryset = FriendInvitationEmailLink.objects.all()
             friend_invitation_email_queryset = friend_invitation_email_queryset.filter(
-                sender_voter_we_vote_id__iexact=sender_voter_we_vote_id)
+                sender_voter_we_vote_id=sender_voter_we_vote_id)
             friend_invitation_email_queryset = friend_invitation_email_queryset.filter(deleted=False)
             friend_invitation_email_queryset = friend_invitation_email_queryset.exclude(
                 invitation_status__iexact=ACCEPTED)
@@ -1905,10 +1905,10 @@ class FriendManager(models.Manager):
             else:
                 friend_invitation_voter_queryset = FriendInvitationVoterLink.objects.all()
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.filter(
-                recipient_voter_we_vote_id__iexact=recipient_voter_we_vote_id)
+                recipient_voter_we_vote_id=recipient_voter_we_vote_id)
             # It is possible through account merging to have an invitation to yourself. We want to exclude these.
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.exclude(
-                sender_voter_we_vote_id__iexact=recipient_voter_we_vote_id)
+                sender_voter_we_vote_id=recipient_voter_we_vote_id)
             # Exclude accepted invitations, ignored and deleted invitations
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.filter(deleted=False)
             friend_invitation_voter_queryset = friend_invitation_voter_queryset.exclude(
@@ -2146,12 +2146,12 @@ class FriendManager(models.Manager):
                 queryset = MutualFriend.objects.all()
             if positive_value_exists(first_friend_voter_we_vote_id):
                 queryset = queryset.filter(
-                    Q(viewer_voter_we_vote_id__iexact=first_friend_voter_we_vote_id) |
-                    Q(viewee_voter_we_vote_id__iexact=first_friend_voter_we_vote_id))
+                    Q(viewer_voter_we_vote_id=first_friend_voter_we_vote_id) |
+                    Q(viewee_voter_we_vote_id=first_friend_voter_we_vote_id))
             if positive_value_exists(second_friend_voter_we_vote_id):
                 queryset = queryset.filter(
-                    Q(viewer_voter_we_vote_id__iexact=second_friend_voter_we_vote_id) |
-                    Q(viewee_voter_we_vote_id__iexact=second_friend_voter_we_vote_id))
+                    Q(viewer_voter_we_vote_id=second_friend_voter_we_vote_id) |
+                    Q(viewee_voter_we_vote_id=second_friend_voter_we_vote_id))
             if positive_value_exists(mutual_friend_voter_we_vote_id):
                 queryset = queryset.filter(
                     mutual_friend_voter_we_vote_id=mutual_friend_voter_we_vote_id,
@@ -2254,8 +2254,8 @@ class FriendManager(models.Manager):
             else:
                 suggested_friend_queryset = SuggestedFriend.objects.all()
             suggested_friend_queryset = suggested_friend_queryset.filter(
-                Q(viewer_voter_we_vote_id__iexact=voter_we_vote_id) |
-                Q(viewee_voter_we_vote_id__iexact=voter_we_vote_id))
+                Q(viewer_voter_we_vote_id=voter_we_vote_id) |
+                Q(viewee_voter_we_vote_id=voter_we_vote_id))
             if positive_value_exists(hide_deleted):
                 suggested_friend_queryset = suggested_friend_queryset.exclude(
                     Q(voter_we_vote_id_deleted_first__iexact=voter_we_vote_id) |
@@ -2321,8 +2321,8 @@ class FriendManager(models.Manager):
         try:
             suggested_friend_queryset = SuggestedFriend.objects.using('readonly').all()
             suggested_friend_queryset = suggested_friend_queryset.filter(
-                Q(viewer_voter_we_vote_id__iexact=voter_we_vote_id) |
-                Q(viewee_voter_we_vote_id__iexact=voter_we_vote_id))
+                Q(viewer_voter_we_vote_id=voter_we_vote_id) |
+                Q(viewee_voter_we_vote_id=voter_we_vote_id))
             suggested_friend_queryset = suggested_friend_queryset.exclude(
                 Q(voter_we_vote_id_deleted_first__iexact=voter_we_vote_id) |
                 Q(voter_we_vote_id_deleted_second__iexact=voter_we_vote_id))

--- a/friend/views_admin.py
+++ b/friend/views_admin.py
@@ -45,15 +45,15 @@ def current_friends_data_healing_view(request):
                 voter_we_vote_id=voter_we_vote_id)
             if positive_value_exists(linked_organization_we_vote_id):
                 viewer_updated = CurrentFriend.objects \
-                    .filter(viewer_voter_we_vote_id__iexact=voter_we_vote_id) \
-                    .exclude(viewer_organization_we_vote_id__iexact=linked_organization_we_vote_id) \
+                    .filter(viewer_voter_we_vote_id=voter_we_vote_id) \
+                    .exclude(viewer_organization_we_vote_id=linked_organization_we_vote_id) \
                     .update(viewer_organization_we_vote_id=linked_organization_we_vote_id)
                 if positive_value_exists(viewer_updated):
                     number_of_linked_org_updates += viewer_updated
 
                 viewee_updated = CurrentFriend.objects \
-                    .filter(viewee_voter_we_vote_id__iexact=voter_we_vote_id) \
-                    .exclude(viewee_organization_we_vote_id__iexact=linked_organization_we_vote_id) \
+                    .filter(viewee_voter_we_vote_id=voter_we_vote_id) \
+                    .exclude(viewee_organization_we_vote_id=linked_organization_we_vote_id) \
                     .update(viewee_organization_we_vote_id=linked_organization_we_vote_id)
                 if positive_value_exists(viewee_updated):
                     number_of_linked_org_updates += viewee_updated

--- a/google_custom_search/views_admin.py
+++ b/google_custom_search/views_admin.py
@@ -156,7 +156,7 @@ def bulk_retrieve_possible_google_search_users_view(request):
                 # Check to see if we have already tried to find their information from Twitter. We don't want to
                 #  search Twitter more than once.
                 request_history_query = RemoteRequestHistory.objects.filter(
-                    candidate_campaign_we_vote_id__iexact=one_candidate.we_vote_id,
+                    candidate_campaign_we_vote_id=one_candidate.we_vote_id,
                     kind_of_action=RETRIEVE_POSSIBLE_GOOGLE_LINKS)
                 request_history_list = list(request_history_query)
 

--- a/import_export_ballotpedia/controllers_bulk_retrieve.py
+++ b/import_export_ballotpedia/controllers_bulk_retrieve.py
@@ -135,7 +135,7 @@ def retrieve_ballotpedia_photos_in_bulk(
             # Check to see if we have already tried to find their photo link from Ballotpedia. We don't want to
             #  search Ballotpedia more than once.
             # request_history_query = RemoteRequestHistory.objects.using('readonly').filter(
-            #     candidate_campaign_we_vote_id__iexact=one_candidate.we_vote_id,
+            #     candidate_campaign_we_vote_id=one_candidate.we_vote_id,
             #     kind_of_action=RETRIEVE_POSSIBLE_BALLOTPEDIA_PHOTOS)
             # request_history_list = list(request_history_query)
             request_history_list = []

--- a/import_export_batches/views_admin.py
+++ b/import_export_batches/views_admin.py
@@ -1725,7 +1725,7 @@ def batch_process_list_view(request):
                 new_filter = Q(office_name__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = Q(wikipedia_id__icontains=one_word)
@@ -2297,7 +2297,7 @@ def batch_process_log_entry_list_view(request):
                 new_filter = Q(google_civic_election_id__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(polling_location_we_vote_id__iexact=one_word)
+                new_filter = Q(polling_location_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = Q(state_code__iexact=one_word)

--- a/import_export_facebook/models.py
+++ b/import_export_facebook/models.py
@@ -252,7 +252,7 @@ class FacebookManager(models.Manager):
 
         try:
             facebook_link_to_voter = FacebookLinkToVoter.objects.get(
-                voter_we_vote_id__iexact=voter_we_vote_id)
+                voter_we_vote_id=voter_we_vote_id)
             facebook_user_id = facebook_link_to_voter.facebook_user_id
             facebook_link_to_voter.delete()
             success = positive_value_exists(facebook_user_id)
@@ -791,11 +791,11 @@ class FacebookManager(models.Manager):
             elif positive_value_exists(voter_we_vote_id):
                 if positive_value_exists(read_only):
                     facebook_link_to_voter = FacebookLinkToVoter.objects.using('readonly').get(
-                        voter_we_vote_id__iexact=voter_we_vote_id,
+                        voter_we_vote_id=voter_we_vote_id,
                     )
                 else:
                     facebook_link_to_voter = FacebookLinkToVoter.objects.get(
-                        voter_we_vote_id__iexact=voter_we_vote_id,
+                        voter_we_vote_id=voter_we_vote_id,
                     )
                 facebook_link_to_voter_id = facebook_link_to_voter.id
                 facebook_link_to_voter_found = True

--- a/import_export_facebook/views_admin.py
+++ b/import_export_facebook/views_admin.py
@@ -307,7 +307,7 @@ def bulk_retrieve_facebook_photos_view(request):
             # Check to see if we have already tried to find their photo link from Facebook. We don't want to
             #  search Facebook more than once.
             # request_history_query = RemoteRequestHistory.objects.filter(
-            #     candidate_campaign_we_vote_id__iexact=one_candidate.we_vote_id,
+            #     candidate_campaign_we_vote_id=one_candidate.we_vote_id,
             #     kind_of_action=RETRIEVE_POSSIBLE_FACEBOOK_PHOTOS)
             # request_history_list = list(request_history_query)
             request_history_list = []
@@ -382,7 +382,7 @@ def get_and_save_facebook_photo_view(request):
         query = CandidateCampaign.objects.all() if is_candidate else Organization.objects.all()  # Cannot be
         # 'readonly' because we save facebook URL and Profile image information below
 
-        query = query.filter(we_vote_id__iexact=we_vote_id)
+        query = query.filter(we_vote_id=we_vote_id)
         entity_list = list(query)
         one_entity = entity_list[0]
 

--- a/import_export_google_civic/views_admin.py
+++ b/import_export_google_civic/views_admin.py
@@ -235,7 +235,7 @@ def retrieve_representatives_for_one_address_view(request):
     one_ballot_json_found = False
     if positive_value_exists(polling_location_we_vote_id):
         try:
-            polling_location = PollingLocation.objects.get(we_vote_id__iexact=polling_location_we_vote_id)
+            polling_location = PollingLocation.objects.get(we_vote_id=polling_location_we_vote_id)
         except PollingLocation.DoesNotExist:
             messages.add_message(request, messages.INFO,
                                  'Polling location not found. ')

--- a/import_export_wikipedia/views_admin.py
+++ b/import_export_wikipedia/views_admin.py
@@ -104,7 +104,7 @@ def bulk_retrieve_wikipedia_photos_view(request):
             # Check to see if we have already tried to find their photo link from Wikipedia. We don't want to
             #  search Wikipedia more than once.
             # request_history_query = RemoteRequestHistory.objects.using('readonly').filter(
-            #     candidate_campaign_we_vote_id__iexact=one_candidate.we_vote_id,
+            #     candidate_campaign_we_vote_id=one_candidate.we_vote_id,
             #     kind_of_action=RETRIEVE_POSSIBLE_WIKIPEDIA_PHOTOS)
             # request_history_list = list(request_history_query)
             request_history_list = []

--- a/issue/controllers.py
+++ b/issue/controllers.py
@@ -284,7 +284,7 @@ def issues_import_from_structured_json(structured_json):
         issue_on_stage_found = False
         try:
             if positive_value_exists(we_vote_id):
-                issue_query = Issue.objects.filter(we_vote_id__iexact=we_vote_id)
+                issue_query = Issue.objects.filter(we_vote_id=we_vote_id)
                 if len(issue_query):
                     issue_on_stage = issue_query[0]
                     issue_on_stage_found = True
@@ -1252,8 +1252,8 @@ def organization_link_to_issue_import_from_structured_json(structured_json):
         organization_link_found = False
         try:
             organization_link_query = OrganizationLinkToIssue.objects.filter(
-                organization_we_vote_id__iexact=organization_we_vote_id)
-            organization_link_query = organization_link_query.filter(issue_we_vote_id__iexact=issue_we_vote_id)
+                organization_we_vote_id=organization_we_vote_id)
+            organization_link_query = organization_link_query.filter(issue_we_vote_id=issue_we_vote_id)
             if len(organization_link_query):
                 organization_link = organization_link_query[0]
                 organization_link_found = True

--- a/issue/models.py
+++ b/issue/models.py
@@ -553,7 +553,7 @@ class IssueManager(models.Manager):
             issue_found = False
             try:
                 issue_on_stage = Issue.objects.get(
-                    we_vote_id__iexact=issue_we_vote_id,
+                    we_vote_id=issue_we_vote_id,
                 )
                 issue_found = True
                 success = True

--- a/issue/views_admin.py
+++ b/issue/views_admin.py
@@ -49,7 +49,7 @@ def issues_sync_out_view(request):  # issuesSyncOut
             new_filter = Q(issue_description__icontains=issue_search)
             filters.append(new_filter)
 
-            new_filter = Q(we_vote_id__iexact=issue_search)
+            new_filter = Q(we_vote_id=issue_search)
             filters.append(new_filter)
 
             # Add the first query
@@ -255,7 +255,7 @@ def issue_list_view(request):
                 new_filter = Q(issue_description__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
                 # Add the first query
@@ -408,7 +408,7 @@ def issue_edit_view(request, issue_we_vote_id):
     organization_list = []
 
     try:
-        issue_on_stage = Issue.objects.using('readonly').get(we_vote_id__iexact=issue_we_vote_id)
+        issue_on_stage = Issue.objects.using('readonly').get(we_vote_id=issue_we_vote_id)
         issue_on_stage_found = True
     except Issue.MultipleObjectsReturned as e:
         handle_record_found_more_than_one_exception(e, logger=logger)
@@ -560,7 +560,7 @@ def issue_edit_process_view(request):
     issue_on_stage = Issue()
     if positive_value_exists(issue_we_vote_id):
         try:
-            issue_on_stage = Issue.objects.get(we_vote_id__iexact=issue_we_vote_id)
+            issue_on_stage = Issue.objects.get(we_vote_id=issue_we_vote_id)
             issue_on_stage_found = True
         except Issue.MultipleObjectsReturned as e:
             handle_record_found_more_than_one_exception(e, logger=logger)
@@ -739,7 +739,7 @@ def issue_delete_process_view(request):
     issue_on_stage = Issue()
     if positive_value_exists(issue_we_vote_id):
         try:
-            issue_query = Issue.objects.filter(we_vote_id__iexact=issue_we_vote_id)
+            issue_query = Issue.objects.filter(we_vote_id=issue_we_vote_id)
             if len(issue_query):
                 issue_on_stage = issue_query[0]
                 issue_on_stage_found = True
@@ -818,7 +818,7 @@ def organization_link_to_issue_sync_out_view(request):  # organizationLinkToIssu
         #     new_filter = Q(issue_description__icontains=issue_search)
         #     filters.append(new_filter)
         #
-        #     new_filter = Q(we_vote_id__iexact=issue_search)
+        #     new_filter = Q(we_vote_id=issue_search)
         #     filters.append(new_filter)
         #
         #     # Add the first query

--- a/measure/models.py
+++ b/measure/models.py
@@ -406,7 +406,7 @@ class ContestMeasureManager(models.Manager):
                 try:
                     contest_measure_on_stage, new_measure_created = ContestMeasure.objects.update_or_create(
                         google_civic_election_id__exact=google_civic_election_id,
-                        we_vote_id__iexact=we_vote_id,
+                        we_vote_id=we_vote_id,
                         defaults=updated_contest_measure_values)
                     success = True
                     status += 'CONTEST_UPDATE_OR_CREATE_SUCCEEDED '
@@ -834,12 +834,12 @@ class ContestMeasureManager(models.Manager):
             if positive_value_exists(read_only):
                 contest_measures_are_not_duplicates_list_query = \
                     ContestMeasuresAreNotDuplicates.objects.using('readonly').filter(
-                        contest_measure1_we_vote_id__iexact=contest_measure_we_vote_id,
+                        contest_measure1_we_vote_id=contest_measure_we_vote_id,
                     )
             else:
                 contest_measures_are_not_duplicates_list_query = \
                     ContestMeasuresAreNotDuplicates.objects.using('readonly').filter(
-                        contest_measure1_we_vote_id__iexact=contest_measure_we_vote_id,
+                        contest_measure1_we_vote_id=contest_measure_we_vote_id,
                     )
             contest_measures_are_not_duplicates_list1 = list(contest_measures_are_not_duplicates_list_query)
             success = True
@@ -857,12 +857,12 @@ class ContestMeasureManager(models.Manager):
                 if positive_value_exists(read_only):
                     contest_measures_are_not_duplicates_list_query = \
                         ContestMeasuresAreNotDuplicates.objects.using('readonly').filter(
-                            contest_measure2_we_vote_id__iexact=contest_measure_we_vote_id,
+                            contest_measure2_we_vote_id=contest_measure_we_vote_id,
                         )
                 else:
                     contest_measures_are_not_duplicates_list_query = \
                         ContestMeasuresAreNotDuplicates.objects.filter(
-                            contest_measure2_we_vote_id__iexact=contest_measure_we_vote_id,
+                            contest_measure2_we_vote_id=contest_measure_we_vote_id,
                         )
                 contest_measures_are_not_duplicates_list2 = list(contest_measures_are_not_duplicates_list_query)
                 success = True
@@ -1004,7 +1004,7 @@ class ContestMeasureManager(models.Manager):
         existing_measure_entry = ''
 
         try:
-            existing_measure_entry = ContestMeasure.objects.get(we_vote_id__iexact=measure_we_vote_id)
+            existing_measure_entry = ContestMeasure.objects.get(we_vote_id=measure_we_vote_id)
             if existing_measure_entry:
                 # found the existing entry, update the values
                 existing_measure_entry.measure_title = measure_title
@@ -1691,11 +1691,11 @@ class ContestMeasureListManager(models.Manager):
             measure_queryset = measure_queryset.filter(google_civic_election_id=google_civic_election_id)
             # We don't look for contest_measure_we_vote_id because of the chance that locally we are using a
             # different we_vote_id
-            # measure_queryset = measure_queryset.filter(contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+            # measure_queryset = measure_queryset.filter(contest_measure_we_vote_id=contest_measure_we_vote_id)
 
             # Ignore entries with we_vote_id coming in from master server
             if positive_value_exists(we_vote_id_from_master):
-                measure_queryset = measure_queryset.filter(~Q(we_vote_id__iexact=we_vote_id_from_master))
+                measure_queryset = measure_queryset.filter(~Q(we_vote_id=we_vote_id_from_master))
 
             # We want to find measures with *any* of these values
             if positive_value_exists(measure_title):
@@ -1871,7 +1871,7 @@ class ContestMeasureListManager(models.Manager):
                 contest_measures_are_not_duplicates, new_contest_measures_are_not_duplicates_created = \
                     ContestMeasuresAreNotDuplicates.objects.update_or_create(
                         contest_measure1_we_vote_id__exact=contest_measure1_we_vote_id,
-                        contest_measure2_we_vote_id__iexact=contest_measure2_we_vote_id,
+                        contest_measure2_we_vote_id=contest_measure2_we_vote_id,
                         defaults=updated_values)
                 success = True
                 status += "CONTEST_MEASURES_ARE_NOT_DUPLICATES_UPDATED_OR_CREATED "

--- a/measure/views_admin.py
+++ b/measure/views_admin.py
@@ -474,7 +474,7 @@ def measure_list_view(request):
                 new_filter = Q(state_code__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = Q(measure_title__icontains=one_word)
@@ -827,7 +827,7 @@ def measure_summary_view(request, measure_id):
     if positive_value_exists(measure_search) and positive_value_exists(measure_we_vote_id):
         measure_queryset = ContestMeasure.objects.all()
         measure_queryset = measure_queryset.filter(google_civic_election_id=google_civic_election_id)
-        measure_queryset = measure_queryset.exclude(we_vote_id__iexact=measure_we_vote_id)
+        measure_queryset = measure_queryset.exclude(we_vote_id=measure_we_vote_id)
 
         if positive_value_exists(state_code):
             measure_queryset = measure_queryset.filter(state_code__iexact=state_code)
@@ -838,7 +838,7 @@ def measure_summary_view(request, measure_id):
             new_filter = Q(measure_title__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(we_vote_id__iexact=one_word)
+            new_filter = Q(we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(ballotpedia_measure_name__icontains=one_word)
@@ -882,7 +882,7 @@ def measure_summary_view(request, measure_id):
         try:
             measure_position_query = PositionEntered.objects.order_by('stance')
             measure_position_query = measure_position_query.filter(
-                contest_measure_we_vote_id__iexact=measure_on_stage.we_vote_id)
+                contest_measure_we_vote_id=measure_on_stage.we_vote_id)
             # if positive_value_exists(google_civic_election_id):
             #     measure_position_query = measure_position_query.filter(
             #         google_civic_election_id=google_civic_election_id)

--- a/office/models.py
+++ b/office/models.py
@@ -403,12 +403,12 @@ class ContestOfficeManager(models.Manager):
             if positive_value_exists(read_only):
                 contest_offices_are_not_duplicates_list_query = \
                     ContestOfficesAreNotDuplicates.objects.using('readonly').filter(
-                        contest_office1_we_vote_id__iexact=contest_office_we_vote_id,
+                        contest_office1_we_vote_id=contest_office_we_vote_id,
                     )
             else:
                 contest_offices_are_not_duplicates_list_query = \
                     ContestOfficesAreNotDuplicates.objects.filter(
-                        contest_office1_we_vote_id__iexact=contest_office_we_vote_id,
+                        contest_office1_we_vote_id=contest_office_we_vote_id,
                     )
             contest_offices_are_not_duplicates_list1 = list(contest_offices_are_not_duplicates_list_query)
             success = True
@@ -426,12 +426,12 @@ class ContestOfficeManager(models.Manager):
                 if positive_value_exists(read_only):
                     contest_offices_are_not_duplicates_list_query = \
                         ContestOfficesAreNotDuplicates.objects.using('readonly').filter(
-                            contest_office2_we_vote_id__iexact=contest_office_we_vote_id,
+                            contest_office2_we_vote_id=contest_office_we_vote_id,
                         )
                 else:
                     contest_offices_are_not_duplicates_list_query = \
                         ContestOfficesAreNotDuplicates.objects.filter(
-                            contest_office2_we_vote_id__iexact=contest_office_we_vote_id,
+                            contest_office2_we_vote_id=contest_office_we_vote_id,
                         )
                 contest_offices_are_not_duplicates_list2 = list(contest_offices_are_not_duplicates_list_query)
                 success = True
@@ -587,7 +587,7 @@ class ContestOfficeManager(models.Manager):
                 try:
                     contest_office_on_stage, new_office_created = ContestOffice.objects.update_or_create(
                         google_civic_election_id__exact=google_civic_election_id,
-                        we_vote_id__iexact=office_we_vote_id,
+                        we_vote_id=office_we_vote_id,
                         defaults=updated_contest_office_values)  # Cannot be readonly
                     contest_office_found = True
                     office_updated = not new_office_created
@@ -800,7 +800,7 @@ class ContestOfficeManager(models.Manager):
                 contest_offices_are_not_duplicates, new_contest_offices_are_not_duplicates_created = \
                     ContestOfficesAreNotDuplicates.objects.update_or_create(
                         contest_office1_we_vote_id__exact=contest_office1_we_vote_id,
-                        contest_office2_we_vote_id__iexact=contest_office2_we_vote_id,
+                        contest_office2_we_vote_id=contest_office2_we_vote_id,
                         defaults=updated_values)
                 success = True
                 status += "CONTEST_OFFICES_ARE_NOT_DUPLICATES_UPDATED_OR_CREATED "
@@ -1164,7 +1164,7 @@ class ContestOfficeManager(models.Manager):
 
         try:
             if positive_value_exists(contest_office_we_vote_id):
-                existing_office_entry = ContestOffice.objects.get(we_vote_id__iexact=contest_office_we_vote_id)  # Cannot be readonly
+                existing_office_entry = ContestOffice.objects.get(we_vote_id=contest_office_we_vote_id)  # Cannot be readonly
                 contest_office_found = True
             elif positive_value_exists(ctcl_uuid):
                 existing_office_entry = ContestOffice.objects.get(ctcl_uuid=ctcl_uuid)  # Cannot be readonly
@@ -1473,7 +1473,7 @@ class ContestOfficeListManager(models.Manager):
 
             # Ignore we_vote_id coming in from master server
             if positive_value_exists(we_vote_id_from_master):
-                office_queryset = office_queryset.filter(~Q(we_vote_id__iexact=we_vote_id_from_master))
+                office_queryset = office_queryset.filter(~Q(we_vote_id=we_vote_id_from_master))
 
             office_list_objects = office_queryset
 

--- a/office/views_admin.py
+++ b/office/views_admin.py
@@ -248,7 +248,7 @@ def offices_copy_to_another_election_view(request):
                 new_filter = Q(vote_usa_office_id__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = Q(wikipedia_id__icontains=one_word)
@@ -744,7 +744,7 @@ def office_list_view(request):
                 new_filter = Q(vote_usa_office_id__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = Q(wikipedia_id__icontains=one_word)
@@ -905,7 +905,7 @@ def office_list_process_view(request):
         for organization_we_vote_id in select_for_marking_office_we_vote_ids:
             try:
                 contest_office_on_stage = ContestOffice.objects.get(
-                    we_vote_id__iexact=organization_we_vote_id)  # Cannot be readonly
+                    we_vote_id=organization_we_vote_id)  # Cannot be readonly
                 if which_marking == "is_battleground_race":
                     contest_office_on_stage.is_battleground_race = True
                 contest_office_on_stage.save()
@@ -1561,7 +1561,7 @@ def office_summary_merge_with_other_office_process_view(
     if positive_value_exists(office_search):
         office_queryset = ContestOffice.objects.all()  # Cannot be readonly
         office_queryset = office_queryset.filter(google_civic_election_id=google_civic_election_id)
-        office_queryset = office_queryset.exclude(we_vote_id__iexact=contest_office_we_vote_id)
+        office_queryset = office_queryset.exclude(we_vote_id=contest_office_we_vote_id)
 
         if positive_value_exists(state_code):
             office_queryset = office_queryset.filter(state_code__iexact=state_code)
@@ -1578,7 +1578,7 @@ def office_summary_merge_with_other_office_process_view(
             new_filter = Q(vote_usa_office_id__iexact=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(we_vote_id__iexact=one_word)
+            new_filter = Q(we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(wikipedia_id__iexact=one_word)

--- a/office_held/models.py
+++ b/office_held/models.py
@@ -793,7 +793,7 @@ class OfficeHeldManager(models.Manager):
         office_held = None
 
         try:
-            office_held = OfficeHeld.objects.get(we_vote_id__iexact=office_held_we_vote_id)
+            office_held = OfficeHeld.objects.get(we_vote_id=office_held_we_vote_id)
             if office_held:
                 office_held_found = True
                 # found the existing entry, update the values
@@ -1002,7 +1002,7 @@ class OfficeHeldManager(models.Manager):
 
             # Ignore we_vote_id coming in from master server
             if positive_value_exists(we_vote_id_from_master):
-                queryset = queryset.filter(~Q(we_vote_id__iexact=we_vote_id_from_master))
+                queryset = queryset.filter(~Q(we_vote_id=we_vote_id_from_master))
 
             office_held_list_objects = queryset
 

--- a/office_held/views_admin.py
+++ b/office_held/views_admin.py
@@ -103,7 +103,7 @@ def office_held_list_view(request):
                 new_filter = Q(state_code__iexact=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
                 # Add the first query
@@ -826,10 +826,10 @@ def offices_held_for_location_list_view(request):
             search_words = location_search.split()
             filters = []  # Reset for each search word
             for one_word in search_words:
-                new_filter = Q(polling_location_we_vote_id__iexact=one_word)
+                new_filter = Q(polling_location_we_vote_id=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(voter_we_vote_id__iexact=one_word)
+                new_filter = Q(voter_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 count = 1

--- a/organization/controllers.py
+++ b/organization/controllers.py
@@ -268,7 +268,7 @@ def delete_membership_link_entries_for_voter(from_voter_we_vote_id):
         return results
 
     voter_members_query = OrganizationMembershipLinkToVoter.objects.all()
-    voter_members_query = voter_members_query.filter(voter_we_vote_id__iexact=from_voter_we_vote_id)
+    voter_members_query = voter_members_query.filter(voter_we_vote_id=from_voter_we_vote_id)
     voter_members_list = list(voter_members_query)
     for voter_member_link in voter_members_list:
         try:
@@ -297,7 +297,7 @@ def delete_organization_membership_link_for_organization(from_organization_we_vo
 
     organization_members_query = OrganizationMembershipLinkToVoter.objects.all()
     organization_members_query = organization_members_query.filter(
-        organization_we_vote_id__iexact=from_organization_we_vote_id)
+        organization_we_vote_id=from_organization_we_vote_id)
     organization_members_list = list(organization_members_query)
     for organization_member_link in organization_members_list:
         try:
@@ -660,7 +660,7 @@ def organization_analytics_by_voter_for_api(voter_device_id='',
     for election_participation in election_participation_list:
         link_query = OrganizationMembershipLinkToVoter.objects.all()
         link_query = link_query.filter(organization_we_vote_id=organization_we_vote_id)
-        link_query = link_query.filter(voter_we_vote_id__iexact=election_participation.voter_we_vote_id)
+        link_query = link_query.filter(voter_we_vote_id=election_participation.voter_we_vote_id)
         link_list = list(link_query)
         if len(link_list) > 0:
             for external_voter in link_list:
@@ -1123,7 +1123,7 @@ def move_membership_link_entries_to_another_voter(from_voter_we_vote_id, to_vote
 
     voter_members_query = OrganizationMembershipLinkToVoter.objects.all()
     voter_members_query = voter_members_query.filter(
-        voter_we_vote_id__iexact=from_voter_we_vote_id)
+        voter_we_vote_id=from_voter_we_vote_id)
     voter_members_list = list(voter_members_query)
     for voter_member_link in voter_members_list:
         try:
@@ -1357,7 +1357,7 @@ def move_organization_team_member_entries_to_another_organization(
     # Move based on organization_we_vote_id
     try:
         organization_team_member_entries_moved += OrganizationTeamMember.objects \
-            .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+            .filter(organization_we_vote_id=from_organization_we_vote_id) \
             .update(organization_we_vote_id=to_organization_we_vote_id)
     except Exception as e:
         status += "FAILED-ORG_TEAM_MEMBER_UPDATE_ORG-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
@@ -1412,7 +1412,7 @@ def move_organization_team_member_entries_to_another_voter(
     # Move based on voter_we_vote_id
     try:
         organization_team_member_entries_moved += OrganizationTeamMember.objects\
-            .filter(voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(voter_we_vote_id=from_voter_we_vote_id)\
             .update(voter_we_vote_id=to_voter_we_vote_id)
     except Exception as e:
         status += "FAILED-ORG_TEAM_MEMBER_VOTER_UPDATE: " + str(e) + " "
@@ -1423,7 +1423,7 @@ def move_organization_team_member_entries_to_another_voter(
         if positive_value_exists(to_organization_name):
             try:
                 organization_team_member_entries_moved += OrganizationTeamMember.objects \
-                    .filter(team_member_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                    .filter(team_member_organization_we_vote_id=from_organization_we_vote_id) \
                     .update(organization_name=to_organization_name,
                             team_member_organization_we_vote_id=to_organization_we_vote_id)
             except Exception as e:
@@ -1431,7 +1431,7 @@ def move_organization_team_member_entries_to_another_voter(
         else:
             try:
                 organization_team_member_entries_moved += OrganizationTeamMember.objects \
-                    .filter(team_member_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                    .filter(team_member_organization_we_vote_id=from_organization_we_vote_id) \
                     .update(team_member_organization_we_vote_id=to_organization_we_vote_id)
             except Exception as e:
                 status += "FAILED-ORG_TEAM_MEMBER_UPDATE-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
@@ -1439,7 +1439,7 @@ def move_organization_team_member_entries_to_another_voter(
         # Move based on organization_we_vote_id
         try:
             organization_team_member_entries_moved += OrganizationTeamMember.objects \
-                .filter(organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(organization_we_vote_id=from_organization_we_vote_id) \
                 .update(organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-ORG_TEAM_MEMBER_UPDATE_ORG-FROM_ORG_WE_VOTE_ID: " + str(e) + " "
@@ -1589,7 +1589,7 @@ def move_organization_membership_link_to_another_organization(from_organization_
 
     organization_members_query = OrganizationMembershipLinkToVoter.objects.all()
     organization_members_query = organization_members_query.filter(
-        organization_we_vote_id__iexact=from_organization_we_vote_id)
+        organization_we_vote_id=from_organization_we_vote_id)
     organization_members_list = list(organization_members_query)
     for organization_member_link in organization_members_list:
         try:

--- a/organization/models.py
+++ b/organization/models.py
@@ -260,7 +260,7 @@ class OrganizationManager(models.Manager):
                 "hashtag_text": hashtag_text,
             }
             new_organization_link_to_hastag, created = OrganizationLinkToHashtag.objects.update_or_create(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
                 hashtag_text__iexact=hashtag_text,
                 defaults=defaults,)
             # NOTE: Hashtags are only significant if there are more than one for a particular issue so I'm not sure
@@ -318,9 +318,9 @@ class OrganizationManager(models.Manager):
                 "voter_we_vote_id":         voter_we_vote_id,
             }
             new_organization_link_to_voter, created = OrganizationMembershipLinkToVoter.objects.update_or_create(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
                 external_voter_id=external_voter_id,
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
                 defaults=defaults,)
             status += "CREATE_ORGANIZATION_LINK_TO_VOTER_SUCCESSFUL "
             success = True

--- a/organization/views_admin.py
+++ b/organization/views_admin.py
@@ -557,13 +557,13 @@ def organization_list_view(request):
             new_filter = Q(organization_website__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(politician_we_vote_id__iexact=one_word)
+            new_filter = Q(politician_we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(twitter_description__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(we_vote_id__iexact=one_word)
+            new_filter = Q(we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(vote_smart_id__icontains=one_word)
@@ -1023,7 +1023,7 @@ def organization_edit_view(request, organization_id=0, organization_we_vote_id="
     voter = fetch_voter_from_voter_device_link(voter_device_id)
     if hasattr(voter, 'is_admin') and voter.is_admin:
         queryset = OrganizationChangeLog.objects.using('readonly').all()
-        queryset = queryset.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+        queryset = queryset.filter(organization_we_vote_id=organization_we_vote_id)
         queryset = queryset.order_by('-log_datetime')
         change_log_list = list(queryset)
     else:
@@ -2171,7 +2171,7 @@ def organization_position_list_view(request, organization_id=0, organization_we_
         if positive_value_exists(organization_id):
             organization_query = Organization.objects.using('readonly').filter(id=organization_id)
         else:
-            organization_query = Organization.objects.using('readonly').filter(we_vote_id__iexact=organization_we_vote_id)
+            organization_query = Organization.objects.using('readonly').filter(we_vote_id=organization_we_vote_id)
         if organization_query.count():
             organization_on_stage = organization_query[0]
             organization_on_stage_found = True
@@ -2300,7 +2300,7 @@ def organization_position_list_view(request, organization_id=0, organization_we_
     organization_search_results_list = []
     if positive_value_exists(organization_search_for_merge) and positive_value_exists(organization_we_vote_id):
         organization_query = Organization.objects.using('readonly').all()
-        organization_query = organization_query.exclude(we_vote_id__iexact=organization_we_vote_id)
+        organization_query = organization_query.exclude(we_vote_id=organization_we_vote_id)
 
         search_words = organization_search_for_merge.split()
         for one_word in search_words:
@@ -2308,7 +2308,7 @@ def organization_position_list_view(request, organization_id=0, organization_we_
             new_filter = Q(organization_name__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(we_vote_id__iexact=one_word)
+            new_filter = Q(we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(organization_description__icontains=one_word)
@@ -2381,7 +2381,7 @@ def organization_position_list_view(request, organization_id=0, organization_we_
     voter = fetch_voter_from_voter_device_link(voter_device_id)
     if hasattr(voter, 'is_admin') and voter.is_admin:
         queryset = OrganizationChangeLog.objects.using('readonly').all()
-        queryset = queryset.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+        queryset = queryset.filter(organization_we_vote_id=organization_we_vote_id)
         queryset = queryset.order_by('-log_datetime')
         change_log_list = list(queryset)
     else:

--- a/pledge_to_vote/models.py
+++ b/pledge_to_vote/models.py
@@ -71,8 +71,8 @@ class PledgeToVoteManager(models.Manager):
         status = ""
         try:
             pledge_queryset = PledgeToVote.objects.all()
-            pledge_queryset = pledge_queryset.filter(voter_we_vote_id__iexact=voter_we_vote_id)
-            pledge_queryset = pledge_queryset.filter(voter_guide_we_vote_id__iexact=voter_guide_we_vote_id)
+            pledge_queryset = pledge_queryset.filter(voter_we_vote_id=voter_we_vote_id)
+            pledge_queryset = pledge_queryset.filter(voter_guide_we_vote_id=voter_guide_we_vote_id)
             pledge_list = list(pledge_queryset)
             for one_pledge in pledge_list:
                 one_pledge.delete()
@@ -103,15 +103,15 @@ class PledgeToVoteManager(models.Manager):
         try:
             pledge_queryset = PledgeToVote.objects.using('readonly').all()
             if positive_value_exists(pledge_to_vote_we_vote_id):
-                pledge_queryset = pledge_queryset.filter(we_vote_id__iexact=pledge_to_vote_we_vote_id)
+                pledge_queryset = pledge_queryset.filter(we_vote_id=pledge_to_vote_we_vote_id)
             else:
-                pledge_queryset = pledge_queryset.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                pledge_queryset = pledge_queryset.filter(voter_we_vote_id=voter_we_vote_id)
                 if positive_value_exists(voter_guide_we_vote_id):
                     pledge_queryset = pledge_queryset.filter(
-                        voter_guide_we_vote_id__iexact=voter_guide_we_vote_id)
+                        voter_guide_we_vote_id=voter_guide_we_vote_id)
                 else:
                     pledge_queryset = pledge_queryset.filter(
-                        organization_we_vote_id__iexact=organization_we_vote_id)
+                        organization_we_vote_id=organization_we_vote_id)
             pledge_to_vote = pledge_queryset.get()
             pledge_found = True
             success = True
@@ -176,15 +176,15 @@ class PledgeToVoteManager(models.Manager):
         try:
             pledge_queryset = PledgeToVote.objects.using('readonly').all()
             if positive_value_exists(pledge_to_vote_we_vote_id):
-                pledge_queryset = pledge_queryset.filter(we_vote_id__iexact=pledge_to_vote_we_vote_id)
+                pledge_queryset = pledge_queryset.filter(we_vote_id=pledge_to_vote_we_vote_id)
             else:
-                pledge_queryset = pledge_queryset.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                pledge_queryset = pledge_queryset.filter(voter_we_vote_id=voter_we_vote_id)
                 if positive_value_exists(voter_guide_we_vote_id):
                     pledge_queryset = pledge_queryset.filter(
-                        voter_guide_we_vote_id__iexact=voter_guide_we_vote_id)
+                        voter_guide_we_vote_id=voter_guide_we_vote_id)
                 else:
                     pledge_queryset = pledge_queryset.filter(
-                        organization_we_vote_id__iexact=organization_we_vote_id)
+                        organization_we_vote_id=organization_we_vote_id)
                     pledge_queryset = pledge_queryset.filter(
                         google_civic_election_id__iexact=google_civic_election_id)
             pledge_to_vote = pledge_queryset.get()
@@ -234,7 +234,7 @@ class PledgeToVoteManager(models.Manager):
     #     try:
     #         email_address_queryset = EmailAddress.objects.all()
     #         email_address_queryset = email_address_queryset.filter(
-    #             voter_we_vote_id__iexact=voter_we_vote_id,
+    #             voter_we_vote_id=voter_we_vote_id,
     #             deleted=False
     #         )
     #         email_address_queryset = email_address_queryset.order_by('-id')  # Put most recent email at top of list
@@ -299,10 +299,10 @@ class PledgeToVoteManager(models.Manager):
             pledge_queryset = PledgeToVote.objects.using('readonly').all()
             if positive_value_exists(organization_we_vote_id):
                 pledge_queryset = pledge_queryset.filter(
-                    organization_we_vote_id__iexact=organization_we_vote_id)
+                    organization_we_vote_id=organization_we_vote_id)
             else:
                 pledge_queryset = pledge_queryset.filter(
-                    voter_guide_we_vote_id__iexact=voter_guide_we_vote_id)
+                    voter_guide_we_vote_id=voter_guide_we_vote_id)
             pledge_count = pledge_queryset.count()
             pledge_count_found = True
             success = True
@@ -378,7 +378,7 @@ class PledgeToVoteManager(models.Manager):
             if positive_value_exists(google_civic_election_id):
                 list_query = list_query.filter(google_civic_election_id=google_civic_election_id)
             if positive_value_exists(organization_we_vote_id):
-                list_query = list_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                list_query = list_query.filter(organization_we_vote_id=organization_we_vote_id)
             pledge_to_vote_list = list(list_query)
             pledge_to_vote_list_found = True
             status += "PLEDGE_TO_VOTE_LIST_FOUND "

--- a/politician/controllers.py
+++ b/politician/controllers.py
@@ -289,7 +289,7 @@ def find_campaignx_list_to_link_to_this_politician(politician=None):
     try:
         related_list = CampaignX.objects.using('readonly').all()
         related_list = related_list.exclude(
-            linked_politician_we_vote_id__iexact=politician.we_vote_id)
+            linked_politician_we_vote_id=politician.we_vote_id)
         related_list = related_list.filter(campaign_title__icontains=politician.first_name)
         related_list = related_list.filter(campaign_title__icontains=politician.last_name)
 
@@ -329,7 +329,7 @@ def find_candidates_to_link_to_this_politician(politician=None):
     try:
         related_candidate_list = CandidateCampaign.objects.using('readonly').all()
         related_candidate_list = related_candidate_list.exclude(
-            politician_we_vote_id__iexact=politician.we_vote_id)
+            politician_we_vote_id=politician.we_vote_id)
 
         filters = []
         new_filter = \
@@ -415,7 +415,7 @@ def find_representatives_to_link_to_this_politician(politician=None):
     try:
         related_representative_list = Representative.objects.using('readonly').all()
         related_representative_list = related_representative_list.exclude(
-            politician_we_vote_id__iexact=politician.we_vote_id)
+            politician_we_vote_id=politician.we_vote_id)
 
         filters = []
         new_filter = \
@@ -713,7 +713,7 @@ def match_politician_to_organization(
     # Search the Organization table to see if there is already an organization linked to this politician
     try:
         queryset = Organization.objects.using('readonly').all()
-        queryset = queryset.filter(politician_we_vote_id__iexact=politician.we_vote_id)
+        queryset = queryset.filter(politician_we_vote_id=politician.we_vote_id)
         linked_organization_list = list(queryset)
         if len(linked_organization_list) > 1:
             politician.organization_analysis_needed = False
@@ -755,7 +755,7 @@ def match_politician_to_organization(
         queryset = Organization.objects.all()  # Cannot be 'readonly' because we save link to Politician below
         queryset = queryset.filter(
             Q(politician_we_vote_id__isnull=True) |
-            Q(politician_we_vote_id__iexact=''))
+            Q(politician_we_vote_id=''))
         filters = []
 
         if positive_value_exists(politician.politician_twitter_handle):
@@ -827,7 +827,7 @@ def match_politician_to_organization(
             queryset = Organization.objects.all()  # Cannot be 'readonly'
             queryset = queryset.filter(
                 Q(politician_we_vote_id__isnull=True) |
-                Q(politician_we_vote_id__iexact=''))
+                Q(politician_we_vote_id=''))
             queryset = queryset.filter(organization_name__iexact=politician.politician_name)
             if positive_value_exists(politician.state_code):
                 # If the politician has a state code, only match to an existing organization by name if
@@ -1405,7 +1405,7 @@ def merge_these_two_politicians(
     # Preserve the shortcuts used by politician2
     try:
         shortcuts_moved = PoliticianSEOFriendlyPath.objects \
-            .filter(politician_we_vote_id__iexact=politician2_we_vote_id) \
+            .filter(politician_we_vote_id=politician2_we_vote_id) \
             .update(politician_we_vote_id=politician1_we_vote_id)
         status += "SHORTCUTS_MOVED: " + str(shortcuts_moved) + " "
     except Exception as e:
@@ -1464,7 +1464,7 @@ def merge_these_two_politicians(
     # Update any CampaignXPolitician entries to new politician_we_vote_id
     from campaign.models import CampaignXPolitician
     campaign_politicians_moved = CampaignXPolitician.objects \
-        .filter(politician_we_vote_id__iexact=politician2_we_vote_id) \
+        .filter(politician_we_vote_id=politician2_we_vote_id) \
         .update(politician_we_vote_id=politician1_we_vote_id)
     status += "CAMPAIGNX_POLITICIANS_MOVED: " + str(campaign_politicians_moved) + " "
 
@@ -1488,7 +1488,7 @@ def merge_these_two_politicians(
     # Update any WeVoteImage entries to new politician_we_vote_id
     from image.models import WeVoteImage
     images_moved = WeVoteImage.objects \
-        .filter(politician_we_vote_id__iexact=politician2_we_vote_id) \
+        .filter(politician_we_vote_id=politician2_we_vote_id) \
         .update(politician_we_vote_id=politician1_we_vote_id)
     status += "WE_VOTE_IMAGE_ENTRIES_MOVED: " + str(images_moved) + " "
 

--- a/politician/models.py
+++ b/politician/models.py
@@ -585,7 +585,7 @@ class PoliticianManager(models.Manager):
         empty_list = []
         try:
             suggested_politicians = RecommendedPoliticianLinkByPolitician.objects.using('readonly').filter(
-                from_politician_we_vote_id__iexact=we_vote_id)
+                from_politician_we_vote_id=we_vote_id)
             suggested_politicians = list(suggested_politicians)
             if len(suggested_politicians):
                 recommend_found = True
@@ -1039,9 +1039,9 @@ class PoliticianManager(models.Manager):
                 politician_found = True
             elif positive_value_exists(politician_we_vote_id):
                 if positive_value_exists(read_only):
-                    politician = Politician.objects.using('readonly').get(we_vote_id__iexact=politician_we_vote_id)
+                    politician = Politician.objects.using('readonly').get(we_vote_id=politician_we_vote_id)
                 else:
-                    politician = Politician.objects.get(we_vote_id__iexact=politician_we_vote_id)
+                    politician = Politician.objects.get(we_vote_id=politician_we_vote_id)
                 politician_id = politician.id
                 politician_we_vote_id = politician.we_vote_id
                 politician_found = True
@@ -1573,7 +1573,7 @@ class PoliticianManager(models.Manager):
             if positive_value_exists(politician_we_vote_id):
                 politician, new_politician_created = \
                     Politician.objects.update_or_create(
-                        we_vote_id__iexact=politician_we_vote_id,
+                        we_vote_id=politician_we_vote_id,
                         defaults=updated_politician_values)
                 politician_found = True
             elif positive_value_exists(vote_smart_id):
@@ -1897,7 +1897,7 @@ class PoliticianManager(models.Manager):
         existing_politician_entry = ''
 
         try:
-            existing_politician_entry = Politician.objects.get(we_vote_id__iexact=politician_we_vote_id)
+            existing_politician_entry = Politician.objects.get(we_vote_id=politician_we_vote_id)
             if existing_politician_entry:
                 # found the existing entry, update the values
                 existing_politician_entry.politician_name = politician_name
@@ -2343,11 +2343,11 @@ class PoliticianManager(models.Manager):
             if positive_value_exists(read_only):
                 politicians_are_not_duplicates_list_query = \
                     PoliticiansAreNotDuplicates.objects.using('readonly').filter(
-                        politician1_we_vote_id__iexact=politician_we_vote_id,
+                        politician1_we_vote_id=politician_we_vote_id,
                     )
             else:
                 politicians_are_not_duplicates_list_query = PoliticiansAreNotDuplicates.objects.filter(
-                    politician1_we_vote_id__iexact=politician_we_vote_id,
+                    politician1_we_vote_id=politician_we_vote_id,
                 )
             politicians_are_not_duplicates_list1 = list(politicians_are_not_duplicates_list_query)
             success = True
@@ -2365,12 +2365,12 @@ class PoliticianManager(models.Manager):
                 if positive_value_exists(read_only):
                     politicians_are_not_duplicates_list_query = \
                         PoliticiansAreNotDuplicates.objects.using('readonly').filter(
-                            politician2_we_vote_id__iexact=politician_we_vote_id,
+                            politician2_we_vote_id=politician_we_vote_id,
                         )
                 else:
                     politicians_are_not_duplicates_list_query = \
                         PoliticiansAreNotDuplicates.objects.filter(
-                            politician2_we_vote_id__iexact=politician_we_vote_id,
+                            politician2_we_vote_id=politician_we_vote_id,
                         )
                 politicians_are_not_duplicates_list2 = list(politicians_are_not_duplicates_list_query)
                 success = True
@@ -2656,7 +2656,7 @@ class PoliticianManager(models.Manager):
                 politicians_are_not_duplicates, new_politicians_are_not_duplicates_created = \
                     PoliticiansAreNotDuplicates.objects.update_or_create(
                         politician1_we_vote_id__exact=politician1_we_vote_id,
-                        politician2_we_vote_id__iexact=politician2_we_vote_id,
+                        politician2_we_vote_id=politician2_we_vote_id,
                         defaults=updated_values)
                 success = True
                 status += "POLITICIANS_ARE_NOT_DUPLICATES_UPDATED_OR_CREATED "

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -275,7 +275,7 @@ def match_politician_to_organization_view(request, politician_we_vote_id):
 
     try:
         queryset = Politician.objects.all()
-        politician = queryset.get(we_vote_id__iexact=politician_we_vote_id)
+        politician = queryset.get(we_vote_id=politician_we_vote_id)
     except Exception as e:
         status += "POLITICIAN_RETRIEVE_ERROR: " + str(e) + " "
 
@@ -930,7 +930,7 @@ def politician_list_view(request):
                 new_filter = Q(last_name__iexact=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(linked_campaignx_we_vote_id__iexact=one_word)
+                new_filter = Q(linked_campaignx_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = (
@@ -961,7 +961,7 @@ def politician_list_view(request):
                 new_filter = Q(vote_usa_politician_id__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
                 # Add the first query
@@ -990,7 +990,7 @@ def politician_list_view(request):
     #     try:
     #         linked_candidate_query = CandidateCampaign.objects.using('readonly').all()
     #         linked_candidate_query = linked_candidate_query.filter(
-    #             Q(politician_we_vote_id__iexact=one_politician.we_vote_id) |
+    #             Q(politician_we_vote_id=one_politician.we_vote_id) |
     #             Q(politician_id=one_politician.id))
     #         linked_candidate_list_count = linked_candidate_query.count()
     #         one_politician.linked_candidate_list_count = linked_candidate_list_count
@@ -1103,7 +1103,7 @@ def politician_list_view(request):
         if one_politician.we_vote_id:
             try:
                 queryset = Representative.objects.all()
-                queryset = queryset.filter(politician_we_vote_id__iexact=one_politician.we_vote_id)
+                queryset = queryset.filter(politician_we_vote_id=one_politician.we_vote_id)
                 linked_representative_we_vote_id_list = []
                 linked_representative_list = list(queryset)
                 if positive_value_exists(show_ocd_id_state_mismatch):
@@ -1191,8 +1191,8 @@ def politician_merge_process_view(request):
             politician1_we_vote_id, politician2_we_vote_id)
         if results['success']:
             queryset = PoliticiansArePossibleDuplicates.objects.filter(
-                politician1_we_vote_id__iexact=politician1_we_vote_id,
-                politician2_we_vote_id__iexact=politician2_we_vote_id,
+                politician1_we_vote_id=politician1_we_vote_id,
+                politician2_we_vote_id=politician2_we_vote_id,
             )
             queryset.delete()
             messages.add_message(request, messages.INFO, 'Prior politicians skipped, and not merged.')
@@ -1267,8 +1267,8 @@ def politician_merge_process_view(request):
         messages.add_message(request, messages.INFO, "Politician '{politician_name}' merged."
                                                      "".format(politician_name=politician.politician_name))
         queryset = PoliticiansArePossibleDuplicates.objects.filter(
-            politician1_we_vote_id__iexact=politician1_we_vote_id,
-            politician2_we_vote_id__iexact=politician2_we_vote_id,
+            politician1_we_vote_id=politician1_we_vote_id,
+            politician2_we_vote_id=politician2_we_vote_id,
         )
         queryset.delete()
         if positive_value_exists(voter_we_vote_id):
@@ -1758,7 +1758,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             from politician.models import PoliticianSEOFriendlyPath
             try:
                 path_query = PoliticianSEOFriendlyPath.objects.using('readonly').all()
-                path_query = path_query.filter(politician_we_vote_id__iexact=politician_we_vote_id)
+                path_query = path_query.filter(politician_we_vote_id=politician_we_vote_id)
                 path_count = path_query.count()
                 path_list = list(path_query[:4])
             except Exception as e:
@@ -1783,7 +1783,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
                 from organization.models import Organization
                 organization_queryset = Organization.objects.using('readonly').all()
                 organization_by_we_vote_id = organization_queryset.get(
-                    we_vote_id__iexact=politician_on_stage.organization_we_vote_id)
+                    we_vote_id=politician_on_stage.organization_we_vote_id)
                 if organization_by_we_vote_id.politician_we_vote_id != politician_on_stage.we_vote_id:
                     please_update_politician = True
                     organization_error += " ERROR: Organization politician_we_vote_id doesn't match this politician. "
@@ -1799,7 +1799,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             from organization.models import Organization
             organization_queryset = Organization.objects.using('readonly').all()
             organization_queryset = organization_queryset.filter(
-                politician_we_vote_id__iexact=politician_on_stage.we_vote_id)
+                politician_we_vote_id=politician_on_stage.we_vote_id)
             organization_linked_to_politician_list = list(organization_queryset)
             if len(organization_linked_to_politician_list) > 0:
                 if not positive_value_exists(politician_on_stage.organization_we_vote_id):
@@ -1832,7 +1832,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         try:
             politician_position_query = PositionEntered.objects.using('readonly').all()
             politician_position_list = politician_position_query.filter(
-                politician_we_vote_id__iexact=politician_on_stage.we_vote_id)
+                politician_we_vote_id=politician_on_stage.we_vote_id)
         except Exception as e:
             politician_position_list = []
 
@@ -1848,7 +1848,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             try:
                 follow_query = FollowOrganization.objects.using('readonly').all()
                 follow_query = follow_query\
-                    .filter(organization_we_vote_id__iexact=organization_we_vote_id_linked_to_politician)
+                    .filter(organization_we_vote_id=organization_we_vote_id_linked_to_politician)
                 follow_query = follow_query.filter(
                     organization_we_vote_id_that_is_following__in=organizations_with_positions_about_this_politician)
                 follow_list = list(follow_query)
@@ -1869,7 +1869,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         try:
             linked_candidate_list = CandidateCampaign.objects.using('readonly').all()
             linked_candidate_list = linked_candidate_list.filter(
-                Q(politician_we_vote_id__iexact=politician_on_stage.we_vote_id) |
+                Q(politician_we_vote_id=politician_on_stage.we_vote_id) |
                 Q(politician_id=politician_on_stage.id))
         except Exception as e:
             linked_candidate_list = []
@@ -1911,7 +1911,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             try:
                 duplicate_politician_list = Politician.objects.using('readonly').all()
                 duplicate_politician_list = duplicate_politician_list.exclude(
-                    we_vote_id__iexact=politician_on_stage.we_vote_id)
+                    we_vote_id=politician_on_stage.we_vote_id)
 
                 filters = []
                 if positive_value_exists(politician_on_stage.politician_name):
@@ -2007,7 +2007,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         linked_representative_list = []
         if positive_value_exists(politician_we_vote_id):
             queryset = Representative.objects.using('readonly').all()
-            queryset = queryset.filter(politician_we_vote_id__iexact=politician_we_vote_id)
+            queryset = queryset.filter(politician_we_vote_id=politician_we_vote_id)
             linked_representative_list = list(queryset)
 
         # ##################################
@@ -2022,7 +2022,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         if positive_value_exists(politician_we_vote_id):
             from campaign.models import CampaignX
             queryset = CampaignX.objects.using('readonly').all()
-            queryset = queryset.filter(linked_politician_we_vote_id__iexact=politician_we_vote_id)
+            queryset = queryset.filter(linked_politician_we_vote_id=politician_we_vote_id)
             linked_campaignx_list = list(queryset)
 
         # ##################################
@@ -2037,7 +2037,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         if positive_value_exists(politician_we_vote_id):
             from politician.models import RecommendedPoliticianLinkByPolitician
             queryset = RecommendedPoliticianLinkByPolitician.objects.using('readonly').all()
-            queryset = queryset.filter(from_politician_we_vote_id__iexact=politician_we_vote_id)
+            queryset = queryset.filter(from_politician_we_vote_id=politician_we_vote_id)
             recommended_politicians = list(queryset)
         recommended_politician_we_vote_ids = [rec.recommended_politician_we_vote_id for rec in recommended_politicians]
         recommended_politicians_list = []
@@ -2053,7 +2053,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             politician_linked_campaignx_we_vote_id = politician_on_stage.linked_campaignx_we_vote_id
 
         queryset = PoliticianChangeLog.objects.using('readonly').all()
-        queryset = queryset.filter(politician_we_vote_id__iexact=politician_we_vote_id)
+        queryset = queryset.filter(politician_we_vote_id=politician_we_vote_id)
         queryset = queryset.order_by('-log_datetime')
         change_log_list = list(queryset)
 
@@ -2295,8 +2295,8 @@ def politicians_not_duplicates_view(request):
         politician1_we_vote_id, politician2_we_vote_id)
     if results['success']:
         queryset = PoliticiansArePossibleDuplicates.objects.filter(
-            politician1_we_vote_id__iexact=politician1_we_vote_id,
-            politician2_we_vote_id__iexact=politician2_we_vote_id,
+            politician1_we_vote_id=politician1_we_vote_id,
+            politician2_we_vote_id=politician2_we_vote_id,
         )
         queryset.delete()
         messages.add_message(request, messages.INFO, 'Two politicians marked as not duplicates.')
@@ -2931,7 +2931,7 @@ def politician_edit_process_view(request):
                     from organization.models import Organization
                     organization_queryset = Organization.objects.all()  # Cannot be 'readonly'
                     organization_by_we_vote_id = organization_queryset.get(
-                        we_vote_id__iexact=politician_on_stage.organization_we_vote_id)
+                        we_vote_id=politician_on_stage.organization_we_vote_id)
                     if organization_by_we_vote_id.politician_we_vote_id != politician_on_stage.we_vote_id:
                         # Since politician is the master link, clear Organization.politician_we_vote_id
                         organization_by_we_vote_id.politician_we_vote_id = ''
@@ -2948,7 +2948,7 @@ def politician_edit_process_view(request):
                     from organization.models import Organization
                     organization_queryset = Organization.objects.using('readonly').all()
                     organization_queryset = organization_queryset.filter(
-                        politician_we_vote_id__iexact=politician_on_stage.we_vote_id)
+                        politician_we_vote_id=politician_on_stage.we_vote_id)
                     organization_linked_list = list(organization_queryset)
                     if len(organization_linked_list) > 0:
                         # Just use the first
@@ -3325,7 +3325,7 @@ def politician_edit_process_view(request):
     try:
         linked_candidate_query = CandidateCampaign.objects.all()
         linked_candidate_query = linked_candidate_query.filter(
-            Q(politician_we_vote_id__iexact=politician_on_stage.we_vote_id) |
+            Q(politician_we_vote_id=politician_on_stage.we_vote_id) |
             Q(politician_id=politician_on_stage.id)
         )
         linked_candidate_list = list(linked_candidate_query)
@@ -3358,7 +3358,7 @@ def politician_edit_process_view(request):
     try:
         linked_representative_query = Representative.objects.all()
         linked_representative_query = linked_representative_query.filter(
-            Q(politician_we_vote_id__iexact=politician_on_stage.we_vote_id) |
+            Q(politician_we_vote_id=politician_on_stage.we_vote_id) |
             Q(politician_id=politician_on_stage.id)
         )
         linked_representative_list = list(linked_representative_query)
@@ -3842,7 +3842,7 @@ def politicians_sync_out_view(request):  # politiciansSyncOut
             new_filter = Q(party__icontains=politician_search)
             filters.append(new_filter)
 
-            new_filter = Q(we_vote_id__iexact=politician_search)
+            new_filter = Q(we_vote_id=politician_search)
             filters.append(new_filter)
 
             # Add the first query
@@ -4019,7 +4019,7 @@ def repair_ocd_id_mismatch_damage_view(request):
             # Now find all representative ids related to this politician
             try:
                 queryset = Representative.objects.all()
-                queryset = queryset.filter(politician_we_vote_id__iexact=one_politician.we_vote_id)
+                queryset = queryset.filter(politician_we_vote_id=one_politician.we_vote_id)
                 linked_representative_list = list(queryset)
                 linked_representative = linked_representative_list[0]  # For now, just take the first one
                 if positive_value_exists(linked_representative.ocd_division_id) and \
@@ -4087,9 +4087,9 @@ def update_politician_from_candidate_view(request):
     politician_we_vote_id = politician.we_vote_id
 
     queryset = CandidateCampaign.objects.using('readonly').all()
-    queryset = queryset.filter(politician_we_vote_id__iexact=politician_we_vote_id)
+    queryset = queryset.filter(politician_we_vote_id=politician_we_vote_id)
     if positive_value_exists(candidate_we_vote_id):
-        queryset = queryset.filter(we_vote_id__iexact=candidate_we_vote_id)
+        queryset = queryset.filter(we_vote_id=candidate_we_vote_id)
     queryset = queryset.order_by('-candidate_year', '-candidate_ultimate_election_date')
     candidate_list = list(queryset)
     candidate_list_by_politician_we_vote_id = {}

--- a/polling_location/models.py
+++ b/polling_location/models.py
@@ -1268,7 +1268,7 @@ class PollingLocationManager(models.Manager):
 
             # Ignore entries with we_vote_id coming in from master server
             if positive_value_exists(we_vote_id_from_master):
-                polling_location_queryset = polling_location_queryset.filter(~Q(we_vote_id__iexact=
+                polling_location_queryset = polling_location_queryset.filter(~Q(we_vote_id=
                                                                                 we_vote_id_from_master))
 
             # We want to find candidates with *any* of these values

--- a/polling_location/views_admin.py
+++ b/polling_location/views_admin.py
@@ -604,7 +604,7 @@ def polling_location_list_view(request):
         for one_word in search_words:
             filters = []
 
-            new_filter = Q(we_vote_id__iexact=one_word)
+            new_filter = Q(we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(location_name__icontains=one_word)

--- a/position/controllers.py
+++ b/position/controllers.py
@@ -153,7 +153,7 @@ def find_organizations_referenced_in_positions_for_this_voter(voter):
     position_filters = []
     final_position_filters = []
     if positive_value_exists(voter.we_vote_id):
-        new_position_filter = Q(voter_we_vote_id__iexact=voter.we_vote_id)
+        new_position_filter = Q(voter_we_vote_id=voter.we_vote_id)
         position_filters.append(new_position_filter)
     if positive_value_exists(voter.id):
         new_position_filter = Q(voter_id=voter.id)
@@ -189,7 +189,7 @@ def find_organizations_referenced_in_positions_for_this_voter(voter):
         if positive_value_exists(one_position.organization_we_vote_id) and \
                 one_position.organization_we_vote_id not in organization_we_vote_ids_found:
             organization_we_vote_ids_found.append(one_position.organization_we_vote_id)
-            new_organization_filter = Q(we_vote_id__iexact=one_position.organization_we_vote_id)
+            new_organization_filter = Q(we_vote_id=one_position.organization_we_vote_id)
             organization_filters.append(new_organization_filter)
 
     # PositionForFriends
@@ -208,7 +208,7 @@ def find_organizations_referenced_in_positions_for_this_voter(voter):
         if positive_value_exists(one_position.organization_we_vote_id) and \
                 one_position.organization_we_vote_id not in organization_we_vote_ids_found:
             organization_we_vote_ids_found.append(one_position.organization_we_vote_id)
-            new_organization_filter = Q(we_vote_id__iexact=one_position.organization_we_vote_id)
+            new_organization_filter = Q(we_vote_id=one_position.organization_we_vote_id)
             organization_filters.append(new_organization_filter)
 
     # Now that we have a list of all possible organization_id or organization_we_vote_id entries, retrieve all
@@ -1323,7 +1323,7 @@ def move_positions_to_another_politician(
     if positive_value_exists(from_politician_we_vote_id):
         try:
             position_entries_moved += PositionEntered.objects \
-                .filter(politician_we_vote_id__iexact=from_politician_we_vote_id) \
+                .filter(politician_we_vote_id=from_politician_we_vote_id) \
                 .update(politician_id=to_politician_id,
                         politician_we_vote_id=to_politician_we_vote_id)
         except Exception as e:
@@ -1332,7 +1332,7 @@ def move_positions_to_another_politician(
 
         try:
             position_entries_moved += PositionForFriends.objects \
-                .filter(politician_we_vote_id__iexact=from_politician_we_vote_id) \
+                .filter(politician_we_vote_id=from_politician_we_vote_id) \
                 .update(politician_id=to_politician_id,
                         politician_we_vote_id=to_politician_we_vote_id)
         except Exception as e:

--- a/position/models.py
+++ b/position/models.py
@@ -1105,7 +1105,7 @@ class PositionListManager(models.Manager):
                 public_position_list = public_position_list.filter(candidate_campaign_id=candidate_id)
             else:
                 public_position_list = public_position_list.filter(
-                    candidate_campaign_we_vote_id__iexact=candidate_we_vote_id)
+                    candidate_campaign_we_vote_id=candidate_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             # if stance_we_are_looking_for != ANY_STANCE:
             #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
@@ -1151,7 +1151,7 @@ class PositionListManager(models.Manager):
                     candidate_campaign_id=candidate_id)
             else:
                 friends_only_position_list = friends_only_position_list.filter(
-                    candidate_campaign_we_vote_id__iexact=candidate_we_vote_id)
+                    candidate_campaign_we_vote_id=candidate_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             # if stance_we_are_looking_for != ANY_STANCE:
             #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
@@ -1223,7 +1223,7 @@ class PositionListManager(models.Manager):
                 public_position_list = public_position_list.filter(contest_measure_id=contest_measure_id)
             else:
                 public_position_list = public_position_list.filter(
-                    contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+                    contest_measure_we_vote_id=contest_measure_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             # if stance_we_are_looking_for != ANY_STANCE:
             #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
@@ -1269,7 +1269,7 @@ class PositionListManager(models.Manager):
                 friends_only_position_list = friends_only_position_list.filter(contest_measure_id=contest_measure_id)
             else:
                 friends_only_position_list = friends_only_position_list.filter(
-                    contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+                    contest_measure_we_vote_id=contest_measure_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             # if stance_we_are_looking_for != ANY_STANCE:
             #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
@@ -1394,7 +1394,7 @@ class PositionListManager(models.Manager):
             position_on_stage_starter = PositionForFriends
 
             position_query = position_on_stage_starter.objects.using('readonly').all()
-            position_query = position_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            position_query = position_query.filter(voter_we_vote_id=voter_we_vote_id)
             position_count = position_query.count()
         except Exception as e:
             pass
@@ -1406,7 +1406,7 @@ class PositionListManager(models.Manager):
             position_on_stage_starter = PositionEntered
 
             position_query = position_on_stage_starter.objects.using('readonly').all()
-            position_query = position_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            position_query = position_query.filter(voter_we_vote_id=voter_we_vote_id)
             position_count = position_query.count()
         except Exception as e:
             pass
@@ -1567,14 +1567,14 @@ class PositionListManager(models.Manager):
             public_number_changed += PositionEntered.objects.all().filter(
                 voter_id=voter_id,
             ).exclude(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).update(
                 voter_we_vote_id=voter_we_vote_id,
             )
             friend_number_changed += PositionForFriends.objects.all().filter(
                 voter_id=voter_id,
             ).exclude(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).update(
                 voter_we_vote_id=voter_we_vote_id,
             )
@@ -1599,14 +1599,14 @@ class PositionListManager(models.Manager):
             public_number_changed += PositionEntered.objects.all().filter(
                 voter_id=voter_id,
             ).exclude(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).update(
                 organization_we_vote_id=organization_we_vote_id,
             )
             friend_number_changed += PositionForFriends.objects.all().filter(
                 voter_id=voter_id,
             ).exclude(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).update(
                 organization_we_vote_id=organization_we_vote_id,
             )
@@ -1620,14 +1620,14 @@ class PositionListManager(models.Manager):
         try:
             # ...without the right voter_id should be updated
             public_number_changed += PositionEntered.objects.all().filter(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).exclude(
                 voter_id=voter_id,
             ).update(
                 voter_id=voter_id,
             )
             friend_number_changed += PositionForFriends.objects.all().filter(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).exclude(
                 voter_id=voter_id,
             ).update(
@@ -1636,14 +1636,14 @@ class PositionListManager(models.Manager):
 
             # ...without the right organization_id should be updated
             public_number_changed += PositionEntered.objects.all().filter(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).exclude(
                 organization_id=organization_id,
             ).update(
                 organization_id=organization_id,
             )
             friend_number_changed += PositionForFriends.objects.all().filter(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).exclude(
                 organization_id=organization_id,
             ).update(
@@ -1652,16 +1652,16 @@ class PositionListManager(models.Manager):
 
             # ...without the right organization_we_vote_id should be updated
             public_number_changed += PositionEntered.objects.all().filter(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).exclude(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).update(
                 organization_we_vote_id=organization_we_vote_id,
             )
             friend_number_changed += PositionForFriends.objects.all().filter(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).exclude(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).update(
                 organization_we_vote_id=organization_we_vote_id,
             )
@@ -1693,14 +1693,14 @@ class PositionListManager(models.Manager):
             public_number_changed += PositionEntered.objects.all().filter(
                 organization_id=organization_id,
             ).exclude(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).update(
                 voter_we_vote_id=voter_we_vote_id,
             )
             friend_number_changed += PositionForFriends.objects.all().filter(
                 organization_id=organization_id,
             ).exclude(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).update(
                 voter_we_vote_id=voter_we_vote_id,
             )
@@ -1709,14 +1709,14 @@ class PositionListManager(models.Manager):
             public_number_changed += PositionEntered.objects.all().filter(
                 organization_id=organization_id,
             ).exclude(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).update(
                 organization_we_vote_id=organization_we_vote_id,
             )
             friend_number_changed += PositionForFriends.objects.all().filter(
                 organization_id=organization_id,
             ).exclude(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).update(
                 organization_we_vote_id=organization_we_vote_id,
             )
@@ -1730,14 +1730,14 @@ class PositionListManager(models.Manager):
         try:
             # ...without the right voter_id should be updated
             public_number_changed += PositionEntered.objects.all().filter(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).exclude(
                 voter_id=voter_id,
             ).update(
                 voter_id=voter_id,
             )
             friend_number_changed += PositionForFriends.objects.all().filter(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).exclude(
                 voter_id=voter_id,
             ).update(
@@ -1746,30 +1746,30 @@ class PositionListManager(models.Manager):
 
             # ...without the right voter_we_vote_id should be updated
             public_number_changed += PositionEntered.objects.all().filter(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).exclude(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).update(
                 voter_we_vote_id=voter_we_vote_id,
             )
             friend_number_changed += PositionForFriends.objects.all().filter(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).exclude(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
             ).update(
                 voter_we_vote_id=voter_we_vote_id,
             )
 
             # ...without the right organization_id should be updated
             public_number_changed += PositionEntered.objects.all().filter(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).exclude(
                 organization_id=organization_id,
             ).update(
                 organization_id=organization_id,
             )
             friend_number_changed += PositionForFriends.objects.all().filter(
-                organization_we_vote_id__iexact=organization_we_vote_id,
+                organization_we_vote_id=organization_we_vote_id,
             ).exclude(
                 organization_id=organization_id,
             ).update(
@@ -2019,7 +2019,7 @@ class PositionListManager(models.Manager):
                 position_list_query = position_list_query.filter(candidate_campaign_id=candidate_id)
             else:
                 position_list_query = position_list_query.filter(
-                    candidate_campaign_we_vote_id__iexact=candidate_we_vote_id)
+                    candidate_campaign_we_vote_id=candidate_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             # if stance_we_are_looking_for != ANY_STANCE:
             #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
@@ -2035,7 +2035,7 @@ class PositionListManager(models.Manager):
                 # Find positions from organizations in shared_items. Look for we_vote_id case insensitive.
                 we_vote_id_filter = Q()
                 for we_vote_id in shared_by_organization_we_vote_id_list:
-                    we_vote_id_filter |= Q(organization_we_vote_id__iexact=we_vote_id)
+                    we_vote_id_filter |= Q(organization_we_vote_id=we_vote_id)
                 position_list_query = position_list_query.filter(we_vote_id_filter)
             position_list = list(position_list_query)
 
@@ -2149,7 +2149,7 @@ class PositionListManager(models.Manager):
                 position_list_query = position_list_query.filter(contest_measure_id=contest_measure_id)
             else:
                 position_list_query = position_list_query.filter(
-                    contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+                    contest_measure_we_vote_id=contest_measure_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
                 # If we passed in the stance "ANY" it means we want to not filter down the list
@@ -2164,13 +2164,13 @@ class PositionListManager(models.Manager):
                 # Find positions from friends. Look for we_vote_id case insensitive.
                 we_vote_id_filter = Q()
                 for we_vote_id in friends_we_vote_id_list:
-                    we_vote_id_filter |= Q(voter_we_vote_id__iexact=we_vote_id)
+                    we_vote_id_filter |= Q(voter_we_vote_id=we_vote_id)
                 position_list_query = position_list_query.filter(we_vote_id_filter)
             if retrieve_public_positions and organizations_followed_we_vote_id_list is not False:
                 # Find positions from organizations voter follows.
                 we_vote_id_filter = Q()
                 for we_vote_id in organizations_followed_we_vote_id_list:
-                    we_vote_id_filter |= Q(organization_we_vote_id__iexact=we_vote_id)
+                    we_vote_id_filter |= Q(organization_we_vote_id=we_vote_id)
                 position_list_query = position_list_query.filter(we_vote_id_filter)
             # Limit to positions in the last x years - currently we are not limiting
             # position_list = position_list.filter(election_id=election_id)
@@ -2260,7 +2260,7 @@ class PositionListManager(models.Manager):
                 position_list_query = position_list_query.filter(contest_measure_id=contest_measure_id)
             else:
                 position_list_query = position_list_query.filter(
-                    contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+                    contest_measure_we_vote_id=contest_measure_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
                 # If we passed in the stance "ANY" it means we want to not filter down the list
@@ -2274,7 +2274,7 @@ class PositionListManager(models.Manager):
             if type(shared_by_organization_we_vote_id_list) is list and len(shared_by_organization_we_vote_id_list) > 0:
                 we_vote_id_filter = Q()
                 for we_vote_id in shared_by_organization_we_vote_id_list:
-                    we_vote_id_filter |= Q(organization_we_vote_id__iexact=we_vote_id)
+                    we_vote_id_filter |= Q(organization_we_vote_id=we_vote_id)
                 position_list_query = position_list_query.filter(we_vote_id_filter)
 
             # We don't need to filter out the positions that have a percent rating that doesn't match
@@ -2371,7 +2371,7 @@ class PositionListManager(models.Manager):
                 # Find positions from friends. Look for we_vote_id case-insensitive.
                 we_vote_id_filter = Q()
                 for we_vote_id in friends_we_vote_id_list:
-                    we_vote_id_filter |= Q(voter_we_vote_id__iexact=we_vote_id)
+                    we_vote_id_filter |= Q(voter_we_vote_id=we_vote_id)
                 position_list_query = position_list_query.filter(we_vote_id_filter)
             # Limit to positions in the last x years - currently we are not limiting
             # position_list = position_list.filter(election_id=election_id)
@@ -2457,7 +2457,7 @@ class PositionListManager(models.Manager):
 
             if positive_value_exists(contest_office_we_vote_id):
                 position_list_query = position_list_query.filter(
-                    contest_office_we_vote_id__iexact=contest_office_we_vote_id)
+                    contest_office_we_vote_id=contest_office_we_vote_id)
             else:
                 position_list_query = position_list_query.filter(contest_office_id=contest_office_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
@@ -2473,7 +2473,7 @@ class PositionListManager(models.Manager):
                 # Find positions from friends. Look for we_vote_id case insensitive.
                 we_vote_id_filter = Q()
                 for we_vote_id in shared_by_organization_we_vote_id_list:
-                    we_vote_id_filter |= Q(organization_we_vote_id__iexact=we_vote_id)
+                    we_vote_id_filter |= Q(organization_we_vote_id=we_vote_id)
                     position_list_query = position_list_query.filter(we_vote_id_filter)
 
             # We don't need to filter out the positions that have a percent rating that doesn't match
@@ -2573,7 +2573,7 @@ class PositionListManager(models.Manager):
 
         # Visible to the Public
         public_positions_list = PositionEntered.objects.all()
-        public_positions_list = public_positions_list.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+        public_positions_list = public_positions_list.filter(organization_we_vote_id=organization_we_vote_id)
         for one_position in public_positions_list:
             results = position_manager.refresh_cached_position_info(
                 one_position, force_update,
@@ -2593,7 +2593,7 @@ class PositionListManager(models.Manager):
         # Visible to We Vote friends only
         friends_only_positions_list = PositionForFriends.objects.all()
         friends_only_positions_list = friends_only_positions_list.filter(
-            organization_we_vote_id__iexact=organization_we_vote_id)
+            organization_we_vote_id=organization_we_vote_id)
         for one_position in friends_only_positions_list:
             results = position_manager.refresh_cached_position_info(
                 one_position, force_update,
@@ -2696,7 +2696,7 @@ class PositionListManager(models.Manager):
                     public_positions_query = public_positions_query.filter(organization_id=organization_id)
                 else:
                     public_positions_query = public_positions_query.filter(
-                        organization_we_vote_id__iexact=organization_we_vote_id)
+                        organization_we_vote_id=organization_we_vote_id)
                 # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
                 # if stance_we_are_looking_for != ANY_STANCE:
                 #     # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
@@ -2898,7 +2898,7 @@ class PositionListManager(models.Manager):
                             voter_id=organization_voter_local_id)
                     else:
                         friends_positions_query = friends_positions_query.filter(
-                            voter_we_vote_id__iexact=organization_voter_we_vote_id)
+                            voter_we_vote_id=organization_voter_we_vote_id)
 
                     # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
                     # if stance_we_are_looking_for != ANY_STANCE:
@@ -3178,7 +3178,7 @@ class PositionListManager(models.Manager):
                     public_positions_list_query = public_positions_list_query.filter(voter_id=voter_id)
                 elif positive_value_exists(voter_we_vote_id):
                     public_positions_list_query = public_positions_list_query.filter(
-                        voter_we_vote_id__iexact=voter_we_vote_id)
+                        voter_we_vote_id=voter_we_vote_id)
                 if retrieve_this_election_only:
                     public_positions_list_query = public_positions_list_query.filter(
                         google_civic_election_id=google_civic_election_id)
@@ -3238,7 +3238,7 @@ class PositionListManager(models.Manager):
                     friends_positions_list_query = friends_positions_list_query.filter(voter_id=voter_id)
                 elif positive_value_exists(voter_we_vote_id):
                     friends_positions_list_query = friends_positions_list_query.filter(
-                        voter_we_vote_id__iexact=voter_we_vote_id)
+                        voter_we_vote_id=voter_we_vote_id)
                 if retrieve_this_election_only:
                     friends_positions_list_query = friends_positions_list_query.filter(
                         google_civic_election_id=google_civic_election_id)
@@ -3418,7 +3418,7 @@ class PositionListManager(models.Manager):
                 public_positions_list_query = public_positions_list_query.filter(voter_id=voter_id)
             elif positive_value_exists(voter_we_vote_id):
                 public_positions_list_query = public_positions_list_query.filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id)
+                    voter_we_vote_id=voter_we_vote_id)
             if positive_value_exists(google_civic_election_id):
                 public_positions_list_query = public_positions_list_query.filter(
                     Q(candidate_campaign_we_vote_id__in=candidate_we_vote_id_list) |
@@ -3457,7 +3457,7 @@ class PositionListManager(models.Manager):
                 friends_positions_list_query = friends_positions_list_query.filter(voter_id=voter_id)
             elif positive_value_exists(voter_we_vote_id):
                 friends_positions_list_query = friends_positions_list_query.filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id)
+                    voter_we_vote_id=voter_we_vote_id)
             if positive_value_exists(google_civic_election_id):
                 friends_positions_list_query = friends_positions_list_query.filter(
                     Q(candidate_campaign_we_vote_id__in=candidate_we_vote_id_list) |
@@ -3933,7 +3933,7 @@ class PositionListManager(models.Manager):
                 position_list_query = position_list_query.filter(candidate_campaign_id=candidate_id)
             else:
                 position_list_query = position_list_query.filter(
-                    candidate_campaign_we_vote_id__iexact=candidate_we_vote_id)
+                    candidate_campaign_we_vote_id=candidate_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
                 # # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
@@ -3966,13 +3966,13 @@ class PositionListManager(models.Manager):
                 # Find positions from friends. Look for we_vote_id case insensitive.
                 we_vote_id_filter = Q()
                 for we_vote_id in friends_we_vote_id_list:
-                    we_vote_id_filter |= Q(voter_we_vote_id__iexact=we_vote_id)
+                    we_vote_id_filter |= Q(voter_we_vote_id=we_vote_id)
                 position_list_query = position_list_query.filter(we_vote_id_filter)
             if retrieve_public_positions and organizations_followed_we_vote_id_list is not False:
                 # Find positions from organizations voter follows.
                 we_vote_id_filter = Q()
                 for we_vote_id in organizations_followed_we_vote_id_list:
-                    we_vote_id_filter |= Q(organization_we_vote_id__iexact=we_vote_id)
+                    we_vote_id_filter |= Q(organization_we_vote_id=we_vote_id)
                 position_list_query = position_list_query.filter(we_vote_id_filter)
 
             # Limit to positions in the last x years - currently we are not limiting
@@ -4129,7 +4129,7 @@ class PositionListManager(models.Manager):
                 position_list_query = position_list_query.filter(contest_measure_id=contest_measure_id)
             else:
                 position_list_query = position_list_query.filter(
-                    contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+                    contest_measure_we_vote_id=contest_measure_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
                 # # If we passed in the stance "ANY_STANCE" it means we want to not filter down the list
@@ -4190,7 +4190,7 @@ class PositionListManager(models.Manager):
                 position_list_query = position_list_query.filter(politician_id=politician_id)
             else:
                 position_list_query = position_list_query.filter(
-                    politician_we_vote_id__iexact=politician_we_vote_id)
+                    politician_we_vote_id=politician_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
                 position_list_query = position_list_query.filter(stance__iexact=stance_we_are_looking_for)
@@ -4291,7 +4291,7 @@ class PositionListManager(models.Manager):
                 position_list_query = position_list_query.filter(organization_id=organization_id)
             else:
                 position_list_query = position_list_query.filter(
-                    organization_we_vote_id__iexact=organization_we_vote_id)
+                    organization_we_vote_id=organization_we_vote_id)
             # SUPPORT, STILL_DECIDING, INFORMATION_ONLY, NO_STANCE, OPPOSE, PERCENT_RATING
             if stance_we_are_looking_for != ANY_STANCE:
                 position_list_query = position_list_query.filter(stance__iexact=stance_we_are_looking_for)
@@ -4301,13 +4301,13 @@ class PositionListManager(models.Manager):
                 # Find positions from friends. Look for we_vote_id case insensitive.
                 we_vote_id_filter = Q()
                 for we_vote_id in friends_we_vote_id_list:
-                    we_vote_id_filter |= Q(voter_we_vote_id__iexact=we_vote_id)
+                    we_vote_id_filter |= Q(voter_we_vote_id=we_vote_id)
                 position_list_query = position_list_query.filter(we_vote_id_filter)
             if retrieve_public_positions and organizations_followed_we_vote_id_list is not False:
                 # Find positions from organizations voter follows.
                 we_vote_id_filter = Q()
                 for we_vote_id in organizations_followed_we_vote_id_list:
-                    we_vote_id_filter |= Q(organization_we_vote_id__iexact=we_vote_id)
+                    we_vote_id_filter |= Q(organization_we_vote_id=we_vote_id)
                 position_list_query = position_list_query.filter(we_vote_id_filter)
 
             # Limit to positions in the last x years - currently we are not limiting
@@ -4342,22 +4342,22 @@ class PositionListManager(models.Manager):
             position_queryset = position_queryset.filter(google_civic_election_id=google_civic_election_id)
             # We don't look for office_we_vote_id because of the chance that locally we are using a
             # different we_vote_id
-            # position_queryset = position_queryset.filter(contest_measure_we_vote_id__iexact=office_we_vote_id)
+            # position_queryset = position_queryset.filter(contest_measure_we_vote_id=office_we_vote_id)
 
             # Ignore entries with we_vote_id coming in from master server
             if positive_value_exists(we_vote_id_from_master):
-                position_queryset = position_queryset.filter(~Q(we_vote_id__iexact=we_vote_id_from_master))
+                position_queryset = position_queryset.filter(~Q(we_vote_id=we_vote_id_from_master))
 
             # Situation 1 organization_we_vote_id + candidate_we_vote_id matches an entry already in the db
             if positive_value_exists(organization_we_vote_id) and positive_value_exists(candidate_we_vote_id):
-                new_filter = (Q(organization_we_vote_id__iexact=organization_we_vote_id) &
-                              Q(organization_we_vote_id__iexact=candidate_we_vote_id))
+                new_filter = (Q(organization_we_vote_id=organization_we_vote_id) &
+                              Q(organization_we_vote_id=candidate_we_vote_id))
                 filters.append(new_filter)
 
             # Situation 2 organization_we_vote_id + measure_we_vote_id matches an entry already in the db
             if positive_value_exists(organization_we_vote_id) and positive_value_exists(measure_we_vote_id):
-                new_filter = (Q(organization_we_vote_id__iexact=organization_we_vote_id) &
-                              Q(contest_measure_we_vote_id__iexact=measure_we_vote_id))
+                new_filter = (Q(organization_we_vote_id=organization_we_vote_id) &
+                              Q(contest_measure_we_vote_id=measure_we_vote_id))
                 filters.append(new_filter)
 
             # Add the first query
@@ -4965,7 +4965,7 @@ class PositionManager(models.Manager):
             if positive_value_exists(position_we_vote_id):
                 status += "MERGE_POSITION_DUPLICATES_WITH_WE_VOTE_ID "
                 duplicates_list = duplicates_list_starter.objects.filter(
-                    we_vote_id__iexact=position_we_vote_id)
+                    we_vote_id=position_we_vote_id)
                 duplicates_count = len(duplicates_list)
                 duplicates_found = True if duplicates_count > 1 else False
                 success = True
@@ -5037,7 +5037,7 @@ class PositionManager(models.Manager):
                 #     status += "MERGE_POSITION_DUPLICATES_WITH_ORG_CANDIDATE_WE_VOTE_ID_AND_ELECTION "
                 #     duplicates_list = duplicates_list_starter.objects.filter(
                 #         organization_id=organization_id,
-                #         candidate_campaign_we_vote_id__iexact=candidate_we_vote_id,
+                #         candidate_campaign_we_vote_id=candidate_we_vote_id,
                 #         google_civic_election_id=google_civic_election_id)
                 #     # If still here, we found an existing position
                 #     duplicates_count = len(duplicates_list)
@@ -5049,7 +5049,7 @@ class PositionManager(models.Manager):
                 #     status += "MERGE_POSITION_DUPLICATES_WITH_ORG_CANDIDATE_WE_VOTE_ID_AND_VOTE_SMART_TIME_SPAN "
                 #     duplicates_list = duplicates_list_starter.objects.filter(
                 #         organization_id=organization_id,
-                #         candidate_campaign_we_vote_id__iexact=candidate_we_vote_id,
+                #         candidate_campaign_we_vote_id=candidate_we_vote_id,
                 #         vote_smart_time_span__iexact=vote_smart_time_span)
                 #     # If still here, we found an existing position
                 #     duplicates_count = len(duplicates_list)
@@ -5059,7 +5059,7 @@ class PositionManager(models.Manager):
                 status += "MERGE_POSITION_DUPLICATES_WITH_ORG_AND_CANDIDATE_WE_VOTE_ID "
                 duplicates_list = duplicates_list_starter.objects.filter(
                     organization_id=organization_id,
-                    candidate_campaign_we_vote_id__iexact=candidate_we_vote_id)
+                    candidate_campaign_we_vote_id=candidate_we_vote_id)
                 # If still here, we found an existing position
                 duplicates_count = len(duplicates_list)
                 duplicates_found = True if duplicates_count > 1 else False
@@ -5099,7 +5099,7 @@ class PositionManager(models.Manager):
                 #     status += "MERGE_POSITION_DUPLICATES_WITH_ORG_MEASURE_WE_VOTE_ID_AND_ELECTION "
                 #     duplicates_list = duplicates_list_starter.objects.filter(
                 #         organization_id=organization_id,
-                #         contest_measure_we_vote_id__iexact=contest_measure_we_vote_id,
+                #         contest_measure_we_vote_id=contest_measure_we_vote_id,
                 #         google_civic_election_id=google_civic_election_id)
                 #     # If still here, we found an existing position
                 #     duplicates_count = len(duplicates_list)
@@ -5111,7 +5111,7 @@ class PositionManager(models.Manager):
                 #     status += "MERGE_POSITION_DUPLICATES_WITH_ORG_MEASURE_WE_VOTE_ID_AND_VOTE_SMART_TIME_SPAN "
                 #     duplicates_list = duplicates_list_starter.objects.filter(
                 #         organization_id=organization_id,
-                #         contest_measure_we_vote_id__iexact=contest_measure_we_vote_id,
+                #         contest_measure_we_vote_id=contest_measure_we_vote_id,
                 #         vote_smart_time_span__iexact=vote_smart_time_span)
                 #     # If still here, we found an existing position
                 #     duplicates_count = len(duplicates_list)
@@ -5120,7 +5120,7 @@ class PositionManager(models.Manager):
                 # else:
                 status += "MERGE_POSITION_DUPLICATES_WITH_ORG_AND_MEASURE_WE_VOTE_ID "
                 duplicates_list = duplicates_list_starter.objects.filter(
-                    organization_id=organization_id, contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+                    organization_id=organization_id, contest_measure_we_vote_id=contest_measure_we_vote_id)
                 duplicates_count = len(duplicates_list)
                 duplicates_found = True if duplicates_count > 1 else False
                 success = True
@@ -5149,7 +5149,7 @@ class PositionManager(models.Manager):
                 #     status += "MERGE_POSITION_DUPLICATES_WITH_ORG_POLITICIAN_WE_VOTE_ID_AND_VOTE_SMART_TIME_SPAN "
                 #     duplicates_list = duplicates_list_starter.objects.filter(
                 #         organization_id=organization_id,
-                #         politician_we_vote_id__iexact=politician_we_vote_id,
+                #         politician_we_vote_id=politician_we_vote_id,
                 #         vote_smart_time_span__iexact=vote_smart_time_span)
                 #     # If still here, we found an existing position
                 #     duplicates_count = len(duplicates_list)
@@ -5158,7 +5158,7 @@ class PositionManager(models.Manager):
                 # else:
                 status += "MERGE_POSITION_DUPLICATES_WITH_ORG_AND_POLITICIAN_WE_VOTE_ID "
                 duplicates_list = duplicates_list_starter.objects.filter(
-                    organization_id=organization_id, politician_we_vote_id__iexact=politician_we_vote_id)
+                    organization_id=organization_id, politician_we_vote_id=politician_we_vote_id)
                 duplicates_count = len(duplicates_list)
                 duplicates_found = True if duplicates_count > 1 else False
                 success = True
@@ -5174,7 +5174,7 @@ class PositionManager(models.Manager):
             elif positive_value_exists(voter_id) and positive_value_exists(contest_office_we_vote_id):
                 status += "MERGE_POSITION_DUPLICATES_WITH_VOTER_AND_OFFICE_WE_VOTE_ID "
                 duplicates_list = duplicates_list_starter.objects.filter(
-                    voter_id=voter_id, contest_office_we_vote_id__iexact=contest_office_we_vote_id)
+                    voter_id=voter_id, contest_office_we_vote_id=contest_office_we_vote_id)
                 duplicates_count = len(duplicates_list)
                 duplicates_found = True if duplicates_count > 1 else False
                 success = True
@@ -5188,7 +5188,7 @@ class PositionManager(models.Manager):
             elif positive_value_exists(voter_id) and positive_value_exists(candidate_we_vote_id):
                 status += "MERGE_POSITION_DUPLICATES_WITH_VOTER_AND_CANDIDATE_WE_VOTE_ID "
                 duplicates_list = duplicates_list_starter.objects.filter(
-                    voter_id=voter_id, candidate_campaign_we_vote_id__iexact=candidate_we_vote_id)
+                    voter_id=voter_id, candidate_campaign_we_vote_id=candidate_we_vote_id)
                 duplicates_count = len(duplicates_list)
                 duplicates_found = True if duplicates_count > 1 else False
                 success = True
@@ -5202,7 +5202,7 @@ class PositionManager(models.Manager):
             elif positive_value_exists(voter_id) and positive_value_exists(contest_measure_we_vote_id):
                 status += "MERGE_POSITION_DUPLICATES_WITH_VOTER_AND_MEASURE_WE_VOTE_ID "
                 duplicates_list = duplicates_list_starter.objects.filter(
-                    voter_id=voter_id, contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+                    voter_id=voter_id, contest_measure_we_vote_id=contest_measure_we_vote_id)
                 duplicates_count = len(duplicates_list)
                 duplicates_found = True if duplicates_count > 1 else False
                 success = True
@@ -5216,7 +5216,7 @@ class PositionManager(models.Manager):
             elif positive_value_exists(voter_id) and positive_value_exists(politician_we_vote_id):
                 status += "MERGE_POSITION_DUPLICATES_WITH_VOTER_AND_POLITICIAN_WE_VOTE_ID "
                 duplicates_list = duplicates_list_starter.objects.filter(
-                    voter_id=voter_id, politician_we_vote_id__iexact=politician_we_vote_id)
+                    voter_id=voter_id, politician_we_vote_id=politician_we_vote_id)
                 duplicates_count = len(duplicates_list)
                 duplicates_found = True if duplicates_count > 1 else False
                 success = True
@@ -5316,7 +5316,7 @@ class PositionManager(models.Manager):
         try:
             if positive_value_exists(position_we_vote_id):
                 status += "RETRIEVE_POSITION_FOUND_WITH_WE_VOTE_ID "
-                position_on_stage = position_on_stage_starter.objects.get(we_vote_id__iexact=position_we_vote_id)
+                position_on_stage = position_on_stage_starter.objects.get(we_vote_id=position_we_vote_id)
                 position_found = True
                 success = True
             # ###############################
@@ -5381,7 +5381,7 @@ class PositionManager(models.Manager):
                 #     status += "RETRIEVE_POSITION_FOUND_WITH_ORG_CANDIDATE_WE_VOTE_ID_AND_ELECTION "
                 #     position_on_stage = position_on_stage_starter.objects.get(
                 #         organization_id=organization_id,
-                #         candidate_campaign_we_vote_id__iexact=candidate_we_vote_id,
+                #         candidate_campaign_we_vote_id=candidate_we_vote_id,
                 #         google_civic_election_id=google_civic_election_id)
                 #     # If still here, we found an existing position
                 #     position_found = True
@@ -5392,7 +5392,7 @@ class PositionManager(models.Manager):
                 #     status += "RETRIEVE_POSITION_FOUND_WITH_ORG_CANDIDATE_WE_VOTE_ID_AND_VOTE_SMART_TIME_SPAN "
                 #     position_on_stage = position_on_stage_starter.objects.get(
                 #         organization_id=organization_id,
-                #         candidate_campaign_we_vote_id__iexact=candidate_we_vote_id,
+                #         candidate_campaign_we_vote_id=candidate_we_vote_id,
                 #         vote_smart_time_span__iexact=vote_smart_time_span)
                 #     # If still here, we found an existing position
                 #     position_found = True
@@ -5401,7 +5401,7 @@ class PositionManager(models.Manager):
                 status += "RETRIEVE_POSITION_FOUND_WITH_ORG_AND_CANDIDATE_WE_VOTE_ID "
                 position_on_stage = position_on_stage_starter.objects.get(
                     organization_id=organization_id,
-                    candidate_campaign_we_vote_id__iexact=candidate_we_vote_id)
+                    candidate_campaign_we_vote_id=candidate_we_vote_id)
                 # If still here, we found an existing position
                 position_found = True
                 success = True
@@ -5437,7 +5437,7 @@ class PositionManager(models.Manager):
                 #     status += "RETRIEVE_POSITION_FOUND_WITH_ORG_MEASURE_WE_VOTE_ID_AND_ELECTION "
                 #     position_on_stage = position_on_stage_starter.objects.get(
                 #         organization_id=organization_id,
-                #         contest_measure_we_vote_id__iexact=contest_measure_we_vote_id,
+                #         contest_measure_we_vote_id=contest_measure_we_vote_id,
                 #         google_civic_election_id=google_civic_election_id)
                 #     # If still here, we found an existing position
                 #     position_found = True
@@ -5447,7 +5447,7 @@ class PositionManager(models.Manager):
                 # if positive_value_exists(vote_smart_time_span):
                 #     status += "RETRIEVE_POSITION_FOUND_WITH_ORG_MEASURE_WE_VOTE_ID_AND_VOTE_SMART_TIME_SPAN "
                 #     position_on_stage = position_on_stage_starter.objects.get(
-                #         organization_id=organization_id, contest_measure_we_vote_id__iexact=contest_measure_we_vote_id,
+                #         organization_id=organization_id, contest_measure_we_vote_id=contest_measure_we_vote_id,
                 #         vote_smart_time_span__iexact=vote_smart_time_span)
                 #     # If still here, we found an existing position
                 #     position_found = True
@@ -5455,7 +5455,7 @@ class PositionManager(models.Manager):
                 # else:
                 status += "RETRIEVE_POSITION_FOUND_WITH_ORG_AND_MEASURE_WE_VOTE_ID "
                 position_on_stage = position_on_stage_starter.objects.get(
-                    organization_id=organization_id, contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+                    organization_id=organization_id, contest_measure_we_vote_id=contest_measure_we_vote_id)
                 position_found = True
                 success = True
             elif positive_value_exists(organization_id) and (
@@ -5465,7 +5465,7 @@ class PositionManager(models.Manager):
                     status += "RETRIEVE_POSITION_FOUND_WITH_ORG_AND_POLITICIAN_WE_VOTE_ID "
                     position_on_stage = position_on_stage_starter.objects.get(
                         organization_id=organization_id,
-                        politician_we_vote_id__iexact=politician_we_vote_id,
+                        politician_we_vote_id=politician_we_vote_id,
                         position_ultimate_election_not_linked=True)
                     position_found = True
                     success = True
@@ -5488,7 +5488,7 @@ class PositionManager(models.Manager):
             elif positive_value_exists(voter_id) and positive_value_exists(contest_office_we_vote_id):
                 status += "RETRIEVE_POSITION_FOUND_WITH_VOTER_AND_OFFICE_WE_VOTE_ID "
                 position_on_stage = position_on_stage_starter.objects.get(
-                    voter_id=voter_id, contest_office_we_vote_id__iexact=contest_office_we_vote_id)
+                    voter_id=voter_id, contest_office_we_vote_id=contest_office_we_vote_id)
                 position_found = True
                 success = True
             elif positive_value_exists(voter_id) and positive_value_exists(candidate_id):
@@ -5500,7 +5500,7 @@ class PositionManager(models.Manager):
             elif positive_value_exists(voter_id) and positive_value_exists(candidate_we_vote_id):
                 status += "RETRIEVE_POSITION_FOUND_WITH_VOTER_AND_CANDIDATE_WE_VOTE_ID "
                 position_on_stage = position_on_stage_starter.objects.get(
-                    voter_id=voter_id, candidate_campaign_we_vote_id__iexact=candidate_we_vote_id)
+                    voter_id=voter_id, candidate_campaign_we_vote_id=candidate_we_vote_id)
                 position_found = True
                 success = True
             elif positive_value_exists(voter_id) and positive_value_exists(contest_measure_id):
@@ -5512,7 +5512,7 @@ class PositionManager(models.Manager):
             elif positive_value_exists(voter_id) and positive_value_exists(contest_measure_we_vote_id):
                 status += "RETRIEVE_POSITION_FOUND_WITH_VOTER_AND_MEASURE_WE_VOTE_ID "
                 position_on_stage = position_on_stage_starter.objects.get(
-                    voter_id=voter_id, contest_measure_we_vote_id__iexact=contest_measure_we_vote_id)
+                    voter_id=voter_id, contest_measure_we_vote_id=contest_measure_we_vote_id)
                 position_found = True
                 success = True
             elif positive_value_exists(voter_id) and (
@@ -5522,7 +5522,7 @@ class PositionManager(models.Manager):
                     status += "RETRIEVE_POSITION_FOUND_WITH_VOTER_AND_POLITICIAN_WE_VOTE_ID "
                     position_on_stage = position_on_stage_starter.objects.get(
                         voter_id=voter_id,
-                        politician_we_vote_id__iexact=politician_we_vote_id,
+                        politician_we_vote_id=politician_we_vote_id,
                         position_ultimate_election_not_linked=True)
                     position_found = True
                     success = True
@@ -7564,7 +7564,7 @@ class PositionManager(models.Manager):
         existing_position_entry = None
 
         try:
-            existing_position_entry = PositionEntered.objects.get(we_vote_id__iexact=position_we_vote_id)
+            existing_position_entry = PositionEntered.objects.get(we_vote_id=position_we_vote_id)
             values_changed = False
 
             if existing_position_entry:
@@ -8054,8 +8054,8 @@ class PositionManager(models.Manager):
                     try:
                         # TODO DALE replace with retrieve_position_table_unknown
                         position_on_stage = position_on_stage_starter.objects.get(
-                            contest_measure_we_vote_id__iexact=measure_we_vote_id,
-                            public_figure_we_vote_id__iexact=public_figure_we_vote_id,
+                            contest_measure_we_vote_id=measure_we_vote_id,
+                            public_figure_we_vote_id=public_figure_we_vote_id,
                             state_code__iexact=state_code,
                         )
                         position_on_stage_found = False  # TODO Update when working
@@ -8074,8 +8074,8 @@ class PositionManager(models.Manager):
                     try:
                         # TODO DALE replace with retrieve_position_table_unknown
                         position_on_stage = position_on_stage_starter.objects.get(
-                            contest_office_we_vote_id__iexact=office_we_vote_id,
-                            public_figure_we_vote_id__iexact=public_figure_we_vote_id,
+                            contest_office_we_vote_id=office_we_vote_id,
+                            public_figure_we_vote_id=public_figure_we_vote_id,
                             state_code__iexact=state_code
                         )
                         position_on_stage_found = False  # TODO Update when public_figure working
@@ -8495,7 +8495,7 @@ class PositionManager(models.Manager):
                         else:
                             try:
                                 linked_voter = Voter.objects.get(
-                                    linked_organization_we_vote_id__iexact=organization.we_vote_id)
+                                    linked_organization_we_vote_id=organization.we_vote_id)
                                 linked_voter_found = True
                                 voters_by_linked_org_dict[organization.we_vote_id] = linked_voter
                             except Voter.DoesNotExist:
@@ -9102,7 +9102,7 @@ class PositionMetricsManager(models.Manager):
             count_query = PositionForFriends.objects.using('readonly').all()
             # As of Aug 2018 we are no longer using PERCENT_RATING
             # count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
-            count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            count_query = count_query.filter(voter_we_vote_id=voter_we_vote_id)
             count_query = count_query.exclude(
                 (Q(statement_text__isnull=True) | Q(statement_text__exact=''))
                 # Not working with statement_html yet
@@ -9123,7 +9123,7 @@ class PositionMetricsManager(models.Manager):
             # As of Aug 2018 we are no longer using PERCENT_RATING
             # count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
 
-            count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            count_query = count_query.filter(voter_we_vote_id=voter_we_vote_id)
             count_query = count_query.exclude(
                 (Q(statement_text__isnull=True) | Q(statement_text__exact=''))
                 # Not working with statement_html yet
@@ -9142,7 +9142,7 @@ class PositionMetricsManager(models.Manager):
             count_query = PositionForFriends.objects.using('readonly').all()
             # As of Aug 2018 we are no longer using PERCENT_RATING
             # count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
-            count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            count_query = count_query.filter(voter_we_vote_id=voter_we_vote_id)
             count_result = count_query.count()
         except Exception as e:
             pass
@@ -9157,7 +9157,7 @@ class PositionMetricsManager(models.Manager):
             # As of Aug 2018 we are no longer using PERCENT_RATING
             # count_query = count_query.exclude(stance__iexact=PERCENT_RATING)
 
-            count_query = count_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            count_query = count_query.filter(voter_we_vote_id=voter_we_vote_id)
             count_result = count_query.count()
         except Exception as e:
             pass
@@ -9169,7 +9169,7 @@ class PositionMetricsManager(models.Manager):
         position_filters = []
         final_position_filters = []
         if positive_value_exists(voter.we_vote_id):
-            new_position_filter = Q(voter_we_vote_id__iexact=voter.we_vote_id)
+            new_position_filter = Q(voter_we_vote_id=voter.we_vote_id)
             position_filters.append(new_position_filter)
         if positive_value_exists(voter.id):
             new_position_filter = Q(voter_id=voter.id)

--- a/position/views_admin.py
+++ b/position/views_admin.py
@@ -547,22 +547,22 @@ def position_list_view(request):
                 new_filter = Q(state_code__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(candidate_campaign_we_vote_id__iexact=one_word)
+                new_filter = Q(candidate_campaign_we_vote_id=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(contest_measure_we_vote_id__iexact=one_word)
+                new_filter = Q(contest_measure_we_vote_id=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(contest_office_we_vote_id__iexact=one_word)
+                new_filter = Q(contest_office_we_vote_id=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(organization_we_vote_id__iexact=one_word)
+                new_filter = Q(organization_we_vote_id=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(voter_we_vote_id__iexact=one_word)
+                new_filter = Q(voter_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = Q(google_civic_measure_title__icontains=one_word)
@@ -619,25 +619,25 @@ def position_list_view(request):
                 new_filter = Q(state_code__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(candidate_campaign_we_vote_id__iexact=one_word)
+                new_filter = Q(candidate_campaign_we_vote_id=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(contest_measure_we_vote_id__iexact=one_word)
+                new_filter = Q(contest_measure_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 # new_filter = Q(contest_office_name__icontains=one_word)
                 # filters.append(new_filter)
                 #
-                # new_filter = Q(contest_office_we_vote_id__iexact=one_word)
+                # new_filter = Q(contest_office_we_vote_id=one_word)
                 # filters.append(new_filter)
 
-                new_filter = Q(organization_we_vote_id__iexact=one_word)
+                new_filter = Q(organization_we_vote_id=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(voter_we_vote_id__iexact=one_word)
+                new_filter = Q(voter_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = Q(google_civic_measure_title__icontains=one_word)

--- a/reaction/models.py
+++ b/reaction/models.py
@@ -43,7 +43,7 @@ class ReactionManager(models.Manager):
         # How many people, across the entire network, like this position?
         try:
             reaction_like_query = ReactionLike.objects.using('readonly').all()
-            reaction_like_query = reaction_like_query.filter(liked_item_we_vote_id__iexact=liked_item_we_vote_id)
+            reaction_like_query = reaction_like_query.filter(liked_item_we_vote_id=liked_item_we_vote_id)
             number_of_likes = reaction_like_query.count()
             status = "REACTION_LIKE_ALL_COUNT_RETRIEVED"
             success = True

--- a/representative/controllers.py
+++ b/representative/controllers.py
@@ -807,7 +807,7 @@ def move_representatives_to_another_politician(
     if positive_value_exists(from_politician_we_vote_id):
         try:
             representatives_entries_moved += Representative.objects \
-                .filter(politician_we_vote_id__iexact=from_politician_we_vote_id) \
+                .filter(politician_we_vote_id=from_politician_we_vote_id) \
                 .update(politician_id=to_politician_id,
                         politician_we_vote_id=to_politician_we_vote_id)
         except Exception as e:

--- a/representative/models.py
+++ b/representative/models.py
@@ -733,13 +733,13 @@ class RepresentativeManager(models.Manager):
         try:
             if positive_value_exists(read_only):
                 representatives_are_not_duplicates = RepresentativesAreNotDuplicates.objects.using('readonly').get(
-                    representative1_we_vote_id__iexact=representative1_we_vote_id,
-                    representative2_we_vote_id__iexact=representative2_we_vote_id,
+                    representative1_we_vote_id=representative1_we_vote_id,
+                    representative2_we_vote_id=representative2_we_vote_id,
                 )
             else:
                 representatives_are_not_duplicates = RepresentativesAreNotDuplicates.objects.get(
-                    representative1_we_vote_id__iexact=representative1_we_vote_id,
-                    representative2_we_vote_id__iexact=representative2_we_vote_id,
+                    representative1_we_vote_id=representative1_we_vote_id,
+                    representative2_we_vote_id=representative2_we_vote_id,
                 )
             representatives_are_not_duplicates_found = True
             success = True
@@ -760,14 +760,14 @@ class RepresentativeManager(models.Manager):
                 if positive_value_exists(read_only):
                     representatives_are_not_duplicates = \
                         RepresentativesAreNotDuplicates.objects.using('readonly').get(
-                            representative1_we_vote_id__iexact=representative2_we_vote_id,
-                            representative2_we_vote_id__iexact=representative1_we_vote_id,
+                            representative1_we_vote_id=representative2_we_vote_id,
+                            representative2_we_vote_id=representative1_we_vote_id,
                         )
                 else:
                     representatives_are_not_duplicates = \
                         RepresentativesAreNotDuplicates.objects.get(
-                            representative1_we_vote_id__iexact=representative2_we_vote_id,
-                            representative2_we_vote_id__iexact=representative1_we_vote_id
+                            representative1_we_vote_id=representative2_we_vote_id,
+                            representative2_we_vote_id=representative1_we_vote_id
                         )
                 representatives_are_not_duplicates_found = True
                 success = True
@@ -807,12 +807,12 @@ class RepresentativeManager(models.Manager):
             if positive_value_exists(read_only):
                 representatives_are_not_duplicates_list_query = \
                     RepresentativesAreNotDuplicates.objects.using('readonly').filter(
-                        representative1_we_vote_id__iexact=representative_we_vote_id,
+                        representative1_we_vote_id=representative_we_vote_id,
                     )
             else:
                 representatives_are_not_duplicates_list_query = \
                     RepresentativesAreNotDuplicates.objects.filter(
-                        representative1_we_vote_id__iexact=representative_we_vote_id)
+                        representative1_we_vote_id=representative_we_vote_id)
             representatives_are_not_duplicates_list1 = list(representatives_are_not_duplicates_list_query)
             success = True
             status += "REPRESENTATIVES_NOT_DUPLICATES_LIST_UPDATED_OR_CREATED1 "
@@ -829,12 +829,12 @@ class RepresentativeManager(models.Manager):
                 if positive_value_exists(read_only):
                     representatives_are_not_duplicates_list_query = \
                         RepresentativesAreNotDuplicates.objects.using('readonly').filter(
-                            representative2_we_vote_id__iexact=representative_we_vote_id,
+                            representative2_we_vote_id=representative_we_vote_id,
                         )
                 else:
                     representatives_are_not_duplicates_list_query = \
                         RepresentativesAreNotDuplicates.objects.filter(
-                            representative2_we_vote_id__iexact=representative_we_vote_id)
+                            representative2_we_vote_id=representative_we_vote_id)
                 representatives_are_not_duplicates_list2 = list(representatives_are_not_duplicates_list_query)
                 success = True
                 status += "REPRESENTATIVES_NOT_DUPLICATES_LIST_UPDATED_OR_CREATED2 "
@@ -1273,7 +1273,7 @@ class RepresentativeManager(models.Manager):
                 representatives_are_not_duplicates, new_representatives_are_not_duplicates_created = \
                     RepresentativesAreNotDuplicates.objects.update_or_create(
                         representative1_we_vote_id__exact=representative1_we_vote_id,
-                        representative2_we_vote_id__iexact=representative2_we_vote_id,
+                        representative2_we_vote_id=representative2_we_vote_id,
                         defaults=updated_values)
                 success = True
                 status += "REPRESENTATIVES_ARE_NOT_DUPLICATES_UPDATED_OR_CREATED "
@@ -1629,7 +1629,7 @@ class RepresentativeManager(models.Manager):
         representative_updated = False
 
         try:
-            representative = Representative.objects.get(we_vote_id__iexact=representative_we_vote_id)
+            representative = Representative.objects.get(we_vote_id=representative_we_vote_id)
             representative_found = True
         except Representative.DoesNotExist:
             status += "REPRESENTATIVE_NOT_FOUND "

--- a/representative/views_admin.py
+++ b/representative/views_admin.py
@@ -694,7 +694,7 @@ def representative_list_view(request):
                 new_filter = Q(office_held_name__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(office_held_we_vote_id__iexact=one_word)
+                new_filter = Q(office_held_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 new_filter = Q(political_party__icontains=one_word)
@@ -717,7 +717,7 @@ def representative_list_view(request):
                 )
                 filters.append(new_filter)
 
-                new_filter = Q(we_vote_id__iexact=one_word)
+                new_filter = Q(we_vote_id=one_word)
                 filters.append(new_filter)
 
                 # Add the first query
@@ -1030,7 +1030,7 @@ def representative_edit_view(request, representative_id):
         duplicate_representative_query = \
             duplicate_representative_query.filter(state_code=representative_on_stage.state_code)
         duplicate_representative_query = duplicate_representative_query.exclude(
-            we_vote_id__iexact=representative_on_stage.we_vote_id)
+            we_vote_id=representative_on_stage.we_vote_id)
         filter_list = Q(representative_name__icontains=representative_on_stage.representative_name)
         filter_list |= Q(google_civic_representative_name__iexact=representative_on_stage.representative_name)
         filter_list |= Q(google_civic_representative_name2__iexact=representative_on_stage.representative_name)
@@ -1819,7 +1819,7 @@ def update_representative_from_politician_view(request):
     representative_id = representative.id
 
     queryset = Politician.objects.using('readonly').all()
-    queryset = queryset.filter(we_vote_id__iexact=politician_we_vote_id)
+    queryset = queryset.filter(we_vote_id=politician_we_vote_id)
     politician_list = list(queryset)
 
     if len(politician_list) > 0:

--- a/share/controllers.py
+++ b/share/controllers.py
@@ -69,27 +69,27 @@ def move_shared_items_to_another_voter(from_voter_we_vote_id, to_voter_we_vote_i
     if positive_value_exists(to_organization_we_vote_id):
         try:
             shared_item_entries_moved += SharedItem.objects\
-                .filter(shared_by_voter_we_vote_id__iexact=from_voter_we_vote_id)\
+                .filter(shared_by_voter_we_vote_id=from_voter_we_vote_id)\
                 .update(shared_by_voter_we_vote_id=to_voter_we_vote_id,
                         shared_by_organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-SHARED_ITEM-SHARED_BY_VOTER_WE_VOTE_ID-INCLUDING_ORG: " + str(e) + " "
             success = False
         try:
-            SharedLinkClicked.objects.filter(shared_by_voter_we_vote_id__iexact=from_voter_we_vote_id) \
+            SharedLinkClicked.objects.filter(shared_by_voter_we_vote_id=from_voter_we_vote_id) \
                 .update(shared_by_voter_we_vote_id=to_voter_we_vote_id,
                         shared_by_organization_we_vote_id=to_organization_we_vote_id)
-            SharedLinkClicked.objects.filter(viewed_by_voter_we_vote_id__iexact=from_voter_we_vote_id) \
+            SharedLinkClicked.objects.filter(viewed_by_voter_we_vote_id=from_voter_we_vote_id) \
                 .update(viewed_by_voter_we_vote_id=to_voter_we_vote_id,
                         viewed_by_organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-SHARED_LINK_CLICKED-SHARED_BY_VOTER_WE_VOTE_ID-INCLUDING_ORG: " + str(e) + " "
             success = False
         try:
-            SharedPermissionsGranted.objects.filter(shared_by_voter_we_vote_id__iexact=from_voter_we_vote_id) \
+            SharedPermissionsGranted.objects.filter(shared_by_voter_we_vote_id=from_voter_we_vote_id) \
                 .update(shared_by_voter_we_vote_id=to_voter_we_vote_id,
                         shared_by_organization_we_vote_id=to_organization_we_vote_id)
-            SharedPermissionsGranted.objects.filter(shared_to_voter_we_vote_id__iexact=from_voter_we_vote_id) \
+            SharedPermissionsGranted.objects.filter(shared_to_voter_we_vote_id=from_voter_we_vote_id) \
                 .update(shared_to_voter_we_vote_id=to_voter_we_vote_id,
                         shared_to_organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
@@ -97,23 +97,23 @@ def move_shared_items_to_another_voter(from_voter_we_vote_id, to_voter_we_vote_i
             success = False
     else:
         try:
-            SharedItem.objects.filter(shared_by_voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            SharedItem.objects.filter(shared_by_voter_we_vote_id=from_voter_we_vote_id)\
                 .update(shared_by_voter_we_vote_id=to_voter_we_vote_id)
         except Exception as e:
             status += "FAILED-SHARED_ITEM-SHARED_BY_VOTER_WE_VOTE_ID: " + str(e) + " "
             success = False
         try:
-            SharedLinkClicked.objects.filter(shared_by_voter_we_vote_id__iexact=from_voter_we_vote_id) \
+            SharedLinkClicked.objects.filter(shared_by_voter_we_vote_id=from_voter_we_vote_id) \
                 .update(shared_by_voter_we_vote_id=to_voter_we_vote_id)
-            SharedLinkClicked.objects.filter(viewed_by_voter_we_vote_id__iexact=from_voter_we_vote_id) \
+            SharedLinkClicked.objects.filter(viewed_by_voter_we_vote_id=from_voter_we_vote_id) \
                 .update(viewed_by_voter_we_vote_id=to_voter_we_vote_id)
         except Exception as e:
             status += "FAILED-SHARED_LINK_CLICKED-SHARED_BY_VOTER_WE_VOTE_ID: " + str(e) + " "
             success = False
         try:
-            SharedPermissionsGranted.objects.filter(shared_by_voter_we_vote_id__iexact=from_voter_we_vote_id) \
+            SharedPermissionsGranted.objects.filter(shared_by_voter_we_vote_id=from_voter_we_vote_id) \
                 .update(shared_by_voter_we_vote_id=to_voter_we_vote_id)
-            SharedPermissionsGranted.objects.filter(shared_to_voter_we_vote_id__iexact=from_voter_we_vote_id) \
+            SharedPermissionsGranted.objects.filter(shared_to_voter_we_vote_id=from_voter_we_vote_id) \
                 .update(shared_to_voter_we_vote_id=to_voter_we_vote_id)
         except Exception as e:
             status += "FAILED-SHARED_PERMISSIONS_GRANTED-SHARED_BY_VOTER_WE_VOTE_ID: " + str(e) + " "
@@ -121,27 +121,27 @@ def move_shared_items_to_another_voter(from_voter_we_vote_id, to_voter_we_vote_i
 
     if positive_value_exists(from_organization_we_vote_id) and positive_value_exists(to_organization_we_vote_id):
         try:
-            SharedItem.objects.filter(site_owner_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+            SharedItem.objects.filter(site_owner_organization_we_vote_id=from_organization_we_vote_id) \
                 .update(site_owner_organization_we_vote_id=to_organization_we_vote_id)
-            SharedItem.objects.filter(shared_by_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+            SharedItem.objects.filter(shared_by_organization_we_vote_id=from_organization_we_vote_id) \
                 .update(shared_by_organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-SHARED_ITEM-SITE_OWNER_ORGANIZATION_WE_VOTE_ID: " + str(e) + " "
             success = False
         try:
-            SharedLinkClicked.objects.filter(shared_by_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+            SharedLinkClicked.objects.filter(shared_by_organization_we_vote_id=from_organization_we_vote_id) \
                 .update(shared_by_organization_we_vote_id=to_organization_we_vote_id)
-            SharedLinkClicked.objects.filter(viewed_by_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+            SharedLinkClicked.objects.filter(viewed_by_organization_we_vote_id=from_organization_we_vote_id) \
                 .update(viewed_by_organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-SHARED_LINK_CLICKED-SHARED_BY_ORGANIZATION_WE_VOTE_ID: " + str(e) + " "
             success = False
         try:
             SharedPermissionsGranted.objects\
-                .filter(shared_by_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(shared_by_organization_we_vote_id=from_organization_we_vote_id) \
                 .update(shared_by_organization_we_vote_id=to_organization_we_vote_id)
             SharedPermissionsGranted.objects\
-                .filter(shared_to_organization_we_vote_id__iexact=from_organization_we_vote_id) \
+                .filter(shared_to_organization_we_vote_id=from_organization_we_vote_id) \
                 .update(shared_to_organization_we_vote_id=to_organization_we_vote_id)
         except Exception as e:
             status += "FAILED-SHARED_PERMISSIONS_GRANTED-SHARED_BY_ORGANIZATION_WE_VOTE_ID: " + str(e) + " "

--- a/share/models.py
+++ b/share/models.py
@@ -1086,14 +1086,14 @@ class ShareManager(models.Manager):
                 if positive_value_exists(google_civic_election_id):
                     shared_item_queryset = shared_item_queryset.filter(
                         destination_full_url__iexact=destination_full_url,
-                        shared_by_voter_we_vote_id__iexact=shared_by_voter_we_vote_id,
+                        shared_by_voter_we_vote_id=shared_by_voter_we_vote_id,
                         google_civic_election_id=google_civic_election_id,
                         deleted=False
                     )
                 else:
                     shared_item_queryset = shared_item_queryset.filter(
                         destination_full_url__iexact=destination_full_url,
-                        shared_by_voter_we_vote_id__iexact=shared_by_voter_we_vote_id,
+                        shared_by_voter_we_vote_id=shared_by_voter_we_vote_id,
                         deleted=False
                     )
                 # We need the sms that has been verified sms at top of list
@@ -1195,8 +1195,8 @@ class ShareManager(models.Manager):
                 else:
                     shared_permissions_granted_queryset = SharedPermissionsGranted.objects.all()
                 shared_permissions_granted_queryset = shared_permissions_granted_queryset.filter(
-                    shared_by_voter_we_vote_id__iexact=shared_by_voter_we_vote_id,
-                    shared_to_voter_we_vote_id__iexact=shared_to_voter_we_vote_id,
+                    shared_by_voter_we_vote_id=shared_by_voter_we_vote_id,
+                    shared_to_voter_we_vote_id=shared_to_voter_we_vote_id,
                     deleted=False
                 )
                 if positive_value_exists(google_civic_election_id):
@@ -1282,11 +1282,11 @@ class ShareManager(models.Manager):
             )
             if positive_value_exists(shared_by_voter_we_vote_id):
                 shared_permissions_granted_queryset = shared_permissions_granted_queryset.filter(
-                    shared_by_voter_we_vote_id__iexact=shared_by_voter_we_vote_id,
+                    shared_by_voter_we_vote_id=shared_by_voter_we_vote_id,
                 )
             if positive_value_exists(shared_to_voter_we_vote_id):
                 shared_permissions_granted_queryset = shared_permissions_granted_queryset.filter(
-                    shared_to_voter_we_vote_id__iexact=shared_to_voter_we_vote_id,
+                    shared_to_voter_we_vote_id=shared_to_voter_we_vote_id,
                 )
             if positive_value_exists(google_civic_election_id):
                 shared_permissions_granted_queryset = shared_permissions_granted_queryset.filter(
@@ -1414,8 +1414,8 @@ class ShareManager(models.Manager):
                 else:
                     super_share_item_queryset = SuperShareItem.objects.all()
                 super_share_item_queryset = super_share_item_queryset.filter(
-                    shared_by_voter_we_vote_id__iexact=shared_by_voter_we_vote_id,
-                    campaignx_we_vote_id__iexact=campaignx_we_vote_id,
+                    shared_by_voter_we_vote_id=shared_by_voter_we_vote_id,
+                    campaignx_we_vote_id=campaignx_we_vote_id,
                     in_draft_mode=True
                 )
                 super_share_item_queryset = super_share_item_queryset.order_by('-date_created')

--- a/share/views_admin.py
+++ b/share/views_admin.py
@@ -138,16 +138,16 @@ def shared_item_list_view(request):
         search_words = shared_item_search.split()
         for one_word in search_words:
             filters = []  # Reset for each search word
-            new_filter = Q(campaignx_we_vote_id__iexact=one_word)
+            new_filter = Q(campaignx_we_vote_id=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(candidate_we_vote_id__iexact=one_word)
+            new_filter = Q(candidate_we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(destination_full_url__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(measure_we_vote_id__iexact=one_word)
+            new_filter = Q(measure_we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(other_voter_display_name__icontains=one_word)
@@ -159,7 +159,7 @@ def shared_item_list_view(request):
             new_filter = Q(other_voter_last_name__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(other_voter_we_vote_id__iexact=one_word)
+            new_filter = Q(other_voter_we_vote_id=one_word)
             filters.append(new_filter)
 
             if len(voter_we_vote_ids_with_email) > 0:
@@ -179,7 +179,7 @@ def shared_item_list_view(request):
             new_filter = Q(other_voter_email_address_text__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(office_we_vote_id__iexact=one_word)
+            new_filter = Q(office_we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(shared_by_display_name__icontains=one_word)
@@ -191,7 +191,7 @@ def shared_item_list_view(request):
             new_filter = Q(shared_by_last_name__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(shared_by_voter_we_vote_id__iexact=one_word)
+            new_filter = Q(shared_by_voter_we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(shared_message__icontains=one_word)
@@ -418,7 +418,7 @@ def voter_who_shares_summary_list_view(request):
             new_filter = Q(shared_by_display_name__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(voter_we_vote_id__iexact=one_word)
+            new_filter = Q(voter_we_vote_id=one_word)
             filters.append(new_filter)
 
             # Add the first query

--- a/sms/controllers.py
+++ b/sms/controllers.py
@@ -15,6 +15,7 @@ from wevote_functions.functions import is_voter_device_id_valid, positive_value_
 
 logger = wevote_functions.admin.get_logger(__name__)
 
+SMS_BYPASS_MOBILE_NUMBER = get_environment_variable("SMS_BYPASS_MOBILE_NUMBER", no_exception=True)
 WE_VOTE_SERVER_ROOT_URL = get_environment_variable("WE_VOTE_SERVER_ROOT_URL")
 
 
@@ -1205,7 +1206,10 @@ def voter_sms_phone_number_save_for_api(  # voterSMSPhoneNumberSave
             if positive_value_exists(sms_phone_number_we_vote_id) \
             else incoming_sms_we_vote_id
         # We need to link a randomly generated 6-digit code to this voter_device_id
-        cordova_review_bypass = normalized_sms_phone_number == '+1 808-935-8555'
+        sms_bypass_mobile_number = SMS_BYPASS_MOBILE_NUMBER
+        if not positive_value_exists(sms_bypass_mobile_number):
+            sms_bypass_mobile_number = '+1 808-935-8555'
+        cordova_review_bypass = normalized_sms_phone_number == sms_bypass_mobile_number
         results = voter_device_link_manager.retrieve_voter_secret_code_up_to_date(voter_device_id,
                                                                                   cordova_review_bypass)
         secret_code = results['secret_code']

--- a/sms/models.py
+++ b/sms/models.py
@@ -353,13 +353,13 @@ class SMSManager(models.Manager):
             if positive_value_exists(sms_phone_number_we_vote_id):
                 if positive_value_exists(voter_we_vote_id):
                     sms_phone_number = SMSPhoneNumber.objects.get(
-                        we_vote_id__iexact=sms_phone_number_we_vote_id,
-                        voter_we_vote_id__iexact=voter_we_vote_id,
+                        we_vote_id=sms_phone_number_we_vote_id,
+                        voter_we_vote_id=voter_we_vote_id,
                         deleted=False
                     )
                 else:
                     sms_phone_number = SMSPhoneNumber.objects.get(
-                        we_vote_id__iexact=sms_phone_number_we_vote_id,
+                        we_vote_id=sms_phone_number_we_vote_id,
                         deleted=False
                     )
                 sms_phone_number_id = sms_phone_number.id
@@ -372,7 +372,7 @@ class SMSManager(models.Manager):
                 if positive_value_exists(voter_we_vote_id):
                     sms_phone_number_queryset = sms_phone_number_queryset.filter(
                         normalized_sms_phone_number__iexact=normalized_sms_phone_number,
-                        voter_we_vote_id__iexact=voter_we_vote_id,
+                        voter_we_vote_id=voter_we_vote_id,
                         deleted=False
                     )
                 else:
@@ -588,7 +588,7 @@ class SMSManager(models.Manager):
         try:
             sms_phone_number_queryset = SMSPhoneNumber.objects.all()
             sms_phone_number_queryset = sms_phone_number_queryset.filter(
-                voter_we_vote_id__iexact=voter_we_vote_id,
+                voter_we_vote_id=voter_we_vote_id,
                 deleted=False
             )
             sms_phone_number_queryset = sms_phone_number_queryset.order_by('-id')  # Put most recent sms at top of list
@@ -636,7 +636,7 @@ class SMSManager(models.Manager):
             if positive_value_exists(voter_we_vote_id):
                 sms_phone_number_queryset = SMSPhoneNumber.objects.all()
                 sms_phone_number_queryset = sms_phone_number_queryset.filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id,
+                    voter_we_vote_id=voter_we_vote_id,
                     sms_ownership_is_verified=True,
                     deleted=False
                 )
@@ -654,7 +654,7 @@ class SMSManager(models.Manager):
             elif positive_value_exists(sms_we_vote_id):
                 sms_phone_number_queryset = SMSPhoneNumber.objects.all()
                 sms_phone_number_queryset = sms_phone_number_queryset.filter(
-                    we_vote_id__iexact=sms_we_vote_id,
+                    we_vote_id=sms_we_vote_id,
                     sms_ownership_is_verified=True,
                     deleted=False
                 )

--- a/stripe_donations/models.py
+++ b/stripe_donations/models.py
@@ -245,7 +245,7 @@ class StripeManager(models.Manager):
         if positive_value_exists(voter_we_vote_id):
             try:
                 stripe_customer_id_queryset = StripeLinkToVoter.objects.filter(
-                    voter_we_vote_id__iexact=voter_we_vote_id).values()
+                    voter_we_vote_id=voter_we_vote_id).values()
                 stripe_customer_id = stripe_customer_id_queryset[0]['stripe_customer_id']
                 if positive_value_exists(stripe_customer_id):
                     success = True
@@ -925,7 +925,7 @@ class StripeManager(models.Manager):
 
         try:
             donation_queryset = StripePayments.objects.all().order_by('-created')
-            donation_queryset = donation_queryset.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            donation_queryset = donation_queryset.filter(voter_we_vote_id=voter_we_vote_id)
             donation_journal_list = list(donation_queryset)
 
             if len(donation_journal_list):
@@ -966,7 +966,7 @@ class StripeManager(models.Manager):
         try:
             subscription_queryset = StripeSubscription.objects.all().order_by('-subscription_created_at')
             subscription_queryset = subscription_queryset.filter(
-                Q(voter_we_vote_id__iexact=voter_we_vote_id) | Q(not_loggedin_voter_we_vote_id__iexact=voter_we_vote_id)
+                Q(voter_we_vote_id=voter_we_vote_id) | Q(not_loggedin_voter_we_vote_id=voter_we_vote_id)
             )
             subscription_list = list(subscription_queryset)
 
@@ -1045,7 +1045,7 @@ class StripeManager(models.Manager):
         try:
             payment_queryset = StripePayments.objects.all().order_by('-created')
             payment_queryset = payment_queryset.filter(
-                Q(voter_we_vote_id__iexact=voter_we_vote_id) | Q(not_loggedin_voter_we_vote_id__iexact=voter_we_vote_id)
+                Q(voter_we_vote_id=voter_we_vote_id) | Q(not_loggedin_voter_we_vote_id=voter_we_vote_id)
             )
             payment_list = list(payment_queryset)
 
@@ -1084,9 +1084,9 @@ class StripeManager(models.Manager):
         try:
             donation_queryset = StripeSubscription.objects.all().order_by('-id')
             if positive_value_exists(voter_we_vote_id):
-                donation_queryset = donation_queryset.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                donation_queryset = donation_queryset.filter(voter_we_vote_id=voter_we_vote_id)
             elif positive_value_exists(linked_organization_we_vote_id):
-                donation_queryset = donation_queryset.filter(linked_organization_we_vote_id__iexact=linked_organization_we_vote_id)
+                donation_queryset = donation_queryset.filter(linked_organization_we_vote_id=linked_organization_we_vote_id)
             donation_queryset = donation_queryset.filter(is_premium_plan=is_premium_plan)
             if positive_value_exists(premium_plan_type_enum):
                 donation_queryset = donation_queryset.filter(premium_plan_type_enum__iexact=premium_plan_type_enum)
@@ -1130,9 +1130,9 @@ class StripeManager(models.Manager):
         try:
             donation_queryset = StripeSubscription.objects.all().order_by('-id')
             if positive_value_exists(voter_we_vote_id):
-                donation_queryset = donation_queryset.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                donation_queryset = donation_queryset.filter(voter_we_vote_id=voter_we_vote_id)
             if positive_value_exists(linked_organization_we_vote_id):
-                donation_queryset = donation_queryset.filter(linked_organization_we_vote_id__iexact=linked_organization_we_vote_id)
+                donation_queryset = donation_queryset.filter(linked_organization_we_vote_id=linked_organization_we_vote_id)
             subscription_list = list(donation_queryset)
 
             if len(subscription_list):
@@ -1398,7 +1398,7 @@ class StripeManager(models.Manager):
             voter_manager = VoterManager()
             org_we_vote_id = voter_manager.fetch_linked_organization_we_vote_id_by_voter_we_vote_id(voter_we_vote_id)
 
-            rows = StripeSubscription.objects.get(linked_organization_we_vote_id__iexact=org_we_vote_id,
+            rows = StripeSubscription.objects.get(linked_organization_we_vote_id=org_we_vote_id,
                                                   is_premium_plan=True,
                                                   donation_plan_is_active=True)
             if len(rows):
@@ -1431,7 +1431,7 @@ class StripeManager(models.Manager):
 
         try:
             donate_link_query = StripeLinkToVoter.objects.all()
-            donate_link_query = donate_link_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            donate_link_query = donate_link_query.filter(voter_we_vote_id=voter_we_vote_id)
             donate_link_list = list(donate_link_query)
             status += "move_donate_link_to_voter_from_voter_to_voter LIST_RETRIEVED-" + \
                       voter_we_vote_id + "-TO-" + to_voter_we_vote_id + " LENGTH: " + str(len(donate_link_list)) + " "
@@ -1481,7 +1481,7 @@ class StripeManager(models.Manager):
         try:
             donation_payments_query = StripePayments.objects.all()
             donation_payments_query = donation_payments_query.filter(
-                Q(voter_we_vote_id__iexact=voter_we_vote_id) | Q(not_loggedin_voter_we_vote_id__iexact=voter_we_vote_id)
+                Q(voter_we_vote_id=voter_we_vote_id) | Q(not_loggedin_voter_we_vote_id=voter_we_vote_id)
             )
             donation_payments_list = list(donation_payments_query)
             status += "move_donation_payment_entries_from_voter_to_voter LIST_RETRIEVED-" + \
@@ -1533,7 +1533,7 @@ class StripeManager(models.Manager):
         try:
             donation_subscription_query = StripeSubscription.objects.all()
             # donation_plan_definition_query = donation_plan_definition_query.filter(
-            #     voter_we_vote_id__iexact=voter_we_vote_id)
+            #     voter_we_vote_id=voter_we_vote_id)
 
             donation_subscription_query = donation_subscription_query.filter(
                 Q(voter_we_vote_id=voter_we_vote_id) | Q(not_loggedin_voter_we_vote_id=voter_we_vote_id)
@@ -1588,7 +1588,7 @@ class StripeManager(models.Manager):
         try:
             donation_payments_query = StripePayments.objects.all()
             donation_payments_query = donation_payments_query.filter(
-                linked_organization_we_vote_id__iexact=from_organization_we_vote_id)
+                linked_organization_we_vote_id=from_organization_we_vote_id)
             donation_payments_list = list(donation_payments_query)
             status += "move_donation_payment_entries_from_organization_to_organization LIST_RETRIEVED-" + \
                       from_organization_we_vote_id + "-TO-" + to_organization_we_vote_id +  \
@@ -1638,7 +1638,7 @@ class StripeManager(models.Manager):
         try:
             payments_query = StripeSubscription.objects.all()
             payments_query = payments_query.filter(
-                linked_organization_we_vote_id__iexact=from_organization_we_vote_id)
+                linked_organization_we_vote_id=from_organization_we_vote_id)
             payments_list = list(payments_query)
             status += "move_stripe_donation_payments_from_organization_to_organization LIST_RETRIEVED-" + \
                       from_organization_we_vote_id + "-TO-" + to_organization_we_vote_id + \
@@ -1917,7 +1917,7 @@ class StripeManager(models.Manager):
     @staticmethod
     def update_journal_entry_for_refund(charge, voter_we_vote_id, refund):
         if refund and refund['amount'] > 0 and refund['status'] == "succeeded":
-            row = StripePayments.objects.get(charge_id__iexact=charge, voter_we_vote_id__iexact=voter_we_vote_id)
+            row = StripePayments.objects.get(charge_id__iexact=charge, voter_we_vote_id=voter_we_vote_id)
             row.status = textwrap.shorten(row.status + " CHARGE_REFUND_REQUESTED" + "_" + str(refund['created']) +
                                           "_" + refund['currency'] + "_" + str(refund['amount']) + "_REFUND_ID" +
                                           refund['id'] + " ", width=255, placeholder="...")
@@ -1934,7 +1934,7 @@ class StripeManager(models.Manager):
 
     @staticmethod
     def update_journal_entry_for_already_refunded(charge, voter_we_vote_id):
-        row = StripePayments.objects.get(charge_id__iexact=charge, voter_we_vote_id__iexact=voter_we_vote_id)
+        row = StripePayments.objects.get(charge_id__iexact=charge, voter_we_vote_id=voter_we_vote_id)
         row.status = textwrap.shorten(row.status + "CHARGE_WAS_ALREADY_REFUNDED_" + str(datetime.utcnow()) + " ",
                                       width=255, placeholder="...")
         row.amount_refunded = row.amount
@@ -1981,7 +1981,7 @@ class StripeManager(models.Manager):
         try:
             subscription_definition_query = StripeSubscription.objects.all()
             subscription_definition_query = subscription_definition_query.filter(
-                linked_organization_we_vote_id__iexact=from_organization_we_vote_id)
+                linked_organization_we_vote_id=from_organization_we_vote_id)
             subscription_definition_list = list(subscription_definition_query)
             status += "move_subscription_entries_from_organization_to_organization LIST_RETRIEVED-" + \
                       from_organization_we_vote_id + "-TO-" + to_organization_we_vote_id + \
@@ -2030,13 +2030,13 @@ class StripeManager(models.Manager):
             if voter_wevote_id and len(voter_wevote_id) > 0:
                 payment_queryset = payment_queryset.filter(
                     Q(is_chip_in=True) &
-                    Q(campaignx_we_vote_id__iexact=campaignx_we_vote_id) &
-                    Q(voter_we_vote_id__iexact=voter_wevote_id)
+                    Q(campaignx_we_vote_id=campaignx_we_vote_id) &
+                    Q(voter_we_vote_id=voter_wevote_id)
                 )
             else:
                 payment_queryset = payment_queryset.filter(
                     Q(is_chip_in=True) &
-                    Q(campaignx_we_vote_id__iexact=campaignx_we_vote_id)
+                    Q(campaignx_we_vote_id=campaignx_we_vote_id)
                 )
             amount_int_pennies = payment_queryset.aggregate(Sum('amount'))['amount__sum']
             amount_dollars = amount_int_pennies / 100 if positive_value_exists(amount_int_pennies) else 0
@@ -2063,11 +2063,11 @@ class StripeManager(models.Manager):
         try:
             payment_queryset = StripePayments.objects.all()
             payment_queryset = payment_queryset.filter(
-                Q(voter_we_vote_id__iexact=voter_wevote_id)
+                Q(voter_we_vote_id=voter_wevote_id)
                 # The not logged in donations are messy and should just be considered lost if the donation does not also
                 # have a voter_we_vote_id -- i.e. an id that is associated with a not_loggedin id when the voter logs in
                 # within the session.
-                # |Q(not_loggedin_voter_we_vote_id__iexact=voter_wevote_id)
+                # |Q(not_loggedin_voter_we_vote_id=voter_wevote_id)
             )
             amount_int_pennies = payment_queryset.aggregate(Sum('amount'))['amount__sum']
             amount_dollars = amount_int_pennies / 100 if positive_value_exists(amount_int_pennies) else 0

--- a/stripe_donations/views_admin.py
+++ b/stripe_donations/views_admin.py
@@ -106,8 +106,8 @@ def suspect_charges_list_view(request):
     template_values['page_offset_suspects'] = page_offset_suspects
     template_values['number_of_suspects'] = number_of_suspects
     suspects_query = StripePayments.objects.all().order_by('-created')
-    suspects_query = suspects_query.exclude((Q(voter_we_vote_id__isnull=True) | Q(voter_we_vote_id__iexact="")) &
-        (Q(not_loggedin_voter_we_vote_id__isnull=True) | Q(not_loggedin_voter_we_vote_id__iexact="")))[page_offset_suspects:page_offset_suspects+page_limit]
+    suspects_query = suspects_query.exclude((Q(voter_we_vote_id__isnull=True) | Q(voter_we_vote_id="")) &
+        (Q(not_loggedin_voter_we_vote_id__isnull=True) | Q(not_loggedin_voter_we_vote_id="")))[page_offset_suspects:page_offset_suspects+page_limit]
     template_values['suspects_list'] = list(suspects_query)
     template_values['prev_page_url_suspects'] = None if page_offset_suspects == 0 else \
         server_root + '/stripe_donations/suspects_list?dispute=false&page_offset_suspects=' + str(page_offset_suspects - page_limit)

--- a/twitter/models.py
+++ b/twitter/models.py
@@ -221,7 +221,7 @@ class TwitterUserManager(models.Manager):
         status = ""
         tweet_list = []
         try:
-            tweet_list_query = Tweet.objects.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+            tweet_list_query = Tweet.objects.filter(organization_we_vote_id=organization_we_vote_id)
             tweet_list_query = tweet_list_query.order_by('date_published').reverse()
             tweet_list = list(tweet_list_query)
             status += "TWEET_FOUND "
@@ -549,10 +549,10 @@ class TwitterUserManager(models.Manager):
             elif positive_value_exists(organization_we_vote_id):
                 if read_only:
                     twitter_link_to_organization = TwitterLinkToOrganization.objects.using('readonly').get(
-                        organization_we_vote_id__iexact=organization_we_vote_id)
+                        organization_we_vote_id=organization_we_vote_id)
                 else:
                     twitter_link_to_organization = TwitterLinkToOrganization.objects.get(
-                        organization_we_vote_id__iexact=organization_we_vote_id)
+                        organization_we_vote_id=organization_we_vote_id)
                 twitter_link_to_organization_id = twitter_link_to_organization.id
                 twitter_link_to_organization_found = True
                 success = True
@@ -696,9 +696,9 @@ class TwitterUserManager(models.Manager):
             elif positive_value_exists(voter_we_vote_id):
                 if read_only:
                     twitter_link_to_voter = TwitterLinkToVoter.objects.using('readonly').get(
-                        voter_we_vote_id__iexact=voter_we_vote_id)
+                        voter_we_vote_id=voter_we_vote_id)
                 else:
-                    twitter_link_to_voter = TwitterLinkToVoter.objects.get(voter_we_vote_id__iexact=voter_we_vote_id)
+                    twitter_link_to_voter = TwitterLinkToVoter.objects.get(voter_we_vote_id=voter_we_vote_id)
                 twitter_link_to_voter_id = twitter_link_to_voter.id
                 twitter_link_to_voter_found = True
                 status += "RETRIEVE_TWITTER_LINK_TO_VOTER_FOUND_BY_VOTER_WE_VOTE_ID "

--- a/voter/controllers_changes.py
+++ b/voter/controllers_changes.py
@@ -39,11 +39,11 @@ def move_candidate_change_log_entries_to_another_voter(from_voter_we_vote_id, to
     # Migrations
     try:
         entries_moved += CandidateChangeLog.objects\
-            .filter(changed_by_voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(changed_by_voter_we_vote_id=from_voter_we_vote_id)\
             .update(changed_by_voter_we_vote_id=to_voter_we_vote_id)
 
         entries_deleted = \
-            CandidateChangeLog.objects.filter(changed_by_voter_we_vote_id__iexact=from_voter_we_vote_id).delete()
+            CandidateChangeLog.objects.filter(changed_by_voter_we_vote_id=from_voter_we_vote_id).delete()
         status += "ENTRIES_DELETED: " + str(entries_deleted) + " "
     except Exception as e:
         status += "FAILED-CANDIDATE_CHANGE_LOG_UPDATE: " + str(e) + " "
@@ -92,11 +92,11 @@ def move_voter_change_log_entries_to_another_voter(from_voter_we_vote_id, to_vot
     # Migrations
     try:
         entries_moved += VoterChangeLog.objects\
-            .filter(voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(voter_we_vote_id=from_voter_we_vote_id)\
             .update(voter_we_vote_id=to_voter_we_vote_id)
 
         entries_deleted = \
-            VoterChangeLog.objects.filter(voter_we_vote_id__iexact=from_voter_we_vote_id).delete()
+            VoterChangeLog.objects.filter(voter_we_vote_id=from_voter_we_vote_id).delete()
         status += "ENTRIES_DELETED: " + str(entries_deleted) + " "
     except Exception as e:
         status += "FAILED-VOTER_CHANGE_LOG_UPDATE: " + str(e) + " "

--- a/voter/controllers_contacts.py
+++ b/voter/controllers_contacts.py
@@ -59,18 +59,18 @@ def move_voter_contact_email_to_another_voter(from_voter_we_vote_id, to_voter_we
     # Migrations
     try:
         query = VoterContactEmail.objects.all()
-        query = query.filter(imported_by_voter_we_vote_id__iexact=to_voter_we_vote_id)
+        query = query.filter(imported_by_voter_we_vote_id=to_voter_we_vote_id)
         query = query.exclude(google_contact_id__isnull=True)
         query = query.values_list('google_contact_id', flat=True).distinct()
         google_contact_id_list_to_not_overwrite = list(query)
 
         voter_contact_email_entries_moved += VoterContactEmail.objects\
-            .filter(imported_by_voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(imported_by_voter_we_vote_id=from_voter_we_vote_id)\
             .exclude(google_contact_id__in=google_contact_id_list_to_not_overwrite)\
             .update(imported_by_voter_we_vote_id=to_voter_we_vote_id)
 
         entries_deleted = \
-            VoterContactEmail.objects.filter(imported_by_voter_we_vote_id__iexact=from_voter_we_vote_id).delete()
+            VoterContactEmail.objects.filter(imported_by_voter_we_vote_id=from_voter_we_vote_id).delete()
         status += "ENTRIES_DELETED: " + str(entries_deleted) + " "
     except Exception as e:
         status += "FAILED-VOTER_CONTACT_EMAIL_UPDATE_IMPORTED_BY: " + str(e) + " "
@@ -78,7 +78,7 @@ def move_voter_contact_email_to_another_voter(from_voter_we_vote_id, to_voter_we
 
     try:
         voter_contact_email_entries_moved += VoterContactEmail.objects\
-            .filter(voter_we_vote_id__iexact=from_voter_we_vote_id)\
+            .filter(voter_we_vote_id=from_voter_we_vote_id)\
             .update(voter_we_vote_id=to_voter_we_vote_id)
     except Exception as e:
         status += "FAILED-VOTER_CONTACT_EMAIL_UPDATE: " + str(e) + " "
@@ -102,7 +102,7 @@ def delete_all_voter_contact_emails_for_voter(voter_we_vote_id=''):  # voterCont
     try:
         google_contacts_deleted_tuple = VoterContactEmail.objects\
             .filter(
-                imported_by_voter_we_vote_id__iexact=voter_we_vote_id,
+                imported_by_voter_we_vote_id=voter_we_vote_id,
             )\
             .delete()
         google_contacts_deleted_count = google_contacts_deleted_tuple[0]

--- a/voter/models.py
+++ b/voter/models.py
@@ -1247,7 +1247,7 @@ class VoterManager(BaseUserManager):
         try:
             # This way of retrieving the voter_we_vote_id has led to some very slow queries
             # queryset = Voter.objects.using('readonly').filter(
-            #     linked_organization_we_vote_id__iexact=linked_organization_we_vote_id)
+            #     linked_organization_we_vote_id=linked_organization_we_vote_id)
             # we_vote_id_list = queryset.values_list('we_vote_id', flat=True)
             # return we_vote_id_list[0] if we_vote_id_list else None
             voter = Voter.objects.using('readonly').get(linked_organization_we_vote_id=linked_organization_we_vote_id)
@@ -1723,9 +1723,9 @@ class VoterManager(BaseUserManager):
                     success = True
             elif positive_value_exists(voter_we_vote_id):
                 if read_only:
-                    voter_on_stage = Voter.objects.using('readonly').get(we_vote_id__iexact=voter_we_vote_id)
+                    voter_on_stage = Voter.objects.using('readonly').get(we_vote_id=voter_we_vote_id)
                 else:
-                    voter_on_stage = Voter.objects.get(we_vote_id__iexact=voter_we_vote_id)
+                    voter_on_stage = Voter.objects.get(we_vote_id=voter_we_vote_id)
                 # If still here, we found an existing voter
                 voter_id = voter_on_stage.id
                 voter_found = True
@@ -1794,9 +1794,9 @@ class VoterManager(BaseUserManager):
             elif positive_value_exists(primary_email_we_vote_id):
                 if read_only:
                     voter_on_stage = Voter.objects.using('readonly').get(
-                        primary_email_we_vote_id__iexact=primary_email_we_vote_id)
+                        primary_email_we_vote_id=primary_email_we_vote_id)
                 else:
-                    voter_on_stage = Voter.objects.get(primary_email_we_vote_id__iexact=primary_email_we_vote_id)
+                    voter_on_stage = Voter.objects.get(primary_email_we_vote_id=primary_email_we_vote_id)
                 # If still here, we found an existing voter
                 voter_id = voter_on_stage.id
                 voter_found = True
@@ -3468,7 +3468,7 @@ class Voter(AbstractBaseUser):
 
     def signed_in_with_apple(self):
         try:
-            apple_object = AppleUser.objects.using('readonly').get(voter_we_vote_id__iexact=self.we_vote_id)
+            apple_object = AppleUser.objects.using('readonly').get(voter_we_vote_id=self.we_vote_id)
             return True
         except AppleUser.DoesNotExist:
             return False

--- a/voter/views_admin.py
+++ b/voter/views_admin.py
@@ -606,7 +606,7 @@ def voter_edit_process_view(request):
         if positive_value_exists(voter_we_vote_id):
             from campaign.models import CampaignXSupporter
             supporters_query = CampaignXSupporter.objects.all()
-            supporters_query = supporters_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            supporters_query = supporters_query.filter(voter_we_vote_id=voter_we_vote_id)
             supporters_list = list(supporters_query)
             update_campaignx_supporter_count = False
             from campaign.views_admin import deleting_or_editing_campaignx_supporter_list
@@ -734,8 +734,8 @@ def voter_edit_process_view(request):
                 try:
                     number_deleted, details = VolunteerTeamMember.objects \
                         .filter(
-                            team_we_vote_id__iexact=team_we_vote_id,
-                            voter_we_vote_id__iexact=voter_we_vote_id,
+                            team_we_vote_id=team_we_vote_id,
+                            voter_we_vote_id=voter_we_vote_id,
                         ) \
                         .delete()
                     messages.add_message(request, messages.INFO,
@@ -835,7 +835,7 @@ def voter_edit_view(request, voter_id=0, voter_we_vote_id=""):
         # Get FacebookLinkToVoter
         try:
             facebook_link_to_voter = FacebookLinkToVoter.objects.get(
-                voter_we_vote_id__iexact=voter_on_stage.we_vote_id)
+                voter_we_vote_id=voter_on_stage.we_vote_id)
             if positive_value_exists(facebook_link_to_voter.facebook_user_id):
                 facebook_id_from_link_to_voter = facebook_link_to_voter.facebook_user_id
                 voter_on_stage.facebook_id_from_link_to_voter = facebook_link_to_voter.facebook_user_id
@@ -845,7 +845,7 @@ def voter_edit_view(request, voter_id=0, voter_we_vote_id=""):
         # Get TwitterLinkToVoter
         try:
             twitter_link_to_voter = TwitterLinkToVoter.objects.get(
-                voter_we_vote_id__iexact=voter_on_stage.we_vote_id)
+                voter_we_vote_id=voter_on_stage.we_vote_id)
             if positive_value_exists(twitter_link_to_voter.twitter_id):
                 twitter_id_from_link_to_voter = twitter_link_to_voter.twitter_id
                 voter_on_stage.twitter_id_from_link_to_voter = twitter_link_to_voter.twitter_id
@@ -907,7 +907,7 @@ def voter_edit_view(request, voter_id=0, voter_we_vote_id=""):
             for one_duplicate_voter in voter_list_duplicate_facebook:
                 try:
                     facebook_link_to_another_voter = FacebookLinkToVoter.objects.get(
-                        voter_we_vote_id__iexact=one_duplicate_voter.we_vote_id)
+                        voter_we_vote_id=one_duplicate_voter.we_vote_id)
                     if positive_value_exists(facebook_link_to_another_voter.facebook_user_id):
                         facebook_id_from_link_to_voter_for_another_voter = True
                         one_duplicate_voter.facebook_id_from_link_to_voter = \
@@ -950,7 +950,7 @@ def voter_edit_view(request, voter_id=0, voter_we_vote_id=""):
             for one_duplicate_voter in voter_list_duplicate_twitter:
                 try:
                     twitter_link_to_another_voter = TwitterLinkToVoter.objects.get(
-                        voter_we_vote_id__iexact=one_duplicate_voter.we_vote_id)
+                        voter_we_vote_id=one_duplicate_voter.we_vote_id)
                     if positive_value_exists(twitter_link_to_another_voter.twitter_id):
                         twitter_id_from_link_to_voter_for_another_voter = True
                         one_duplicate_voter.twitter_id_from_link_to_voter = twitter_link_to_another_voter.twitter_id
@@ -996,7 +996,7 @@ def voter_edit_view(request, voter_id=0, voter_we_vote_id=""):
             for one_duplicate_organization in organization_list_with_duplicate_twitter:
                 try:
                     linked_voter = Voter.objects.get(
-                        linked_organization_we_vote_id__iexact=one_duplicate_organization.we_vote_id)
+                        linked_organization_we_vote_id=one_duplicate_organization.we_vote_id)
                     one_duplicate_organization.linked_voter = linked_voter
                 except Voter.DoesNotExist:
                     pass
@@ -1008,13 +1008,13 @@ def voter_edit_view(request, voter_id=0, voter_we_vote_id=""):
         linked_organization_we_vote_id_list_updated = []
         linked_organization_we_vote_id_list = Organization.objects.using('readonly').all()
         linked_organization_we_vote_id_list = linked_organization_we_vote_id_list.filter(
-            we_vote_id__iexact=voter_on_stage.linked_organization_we_vote_id)
+            we_vote_id=voter_on_stage.linked_organization_we_vote_id)
 
         linked_organization_found = False
         for one_linked_organization in linked_organization_we_vote_id_list:
             try:
                 linked_voter = Voter.objects.using('readonly').get(
-                    linked_organization_we_vote_id__iexact=one_linked_organization.we_vote_id)
+                    linked_organization_we_vote_id=one_linked_organization.we_vote_id)
                 one_linked_organization.linked_voter = linked_voter
                 linked_organization_found = True
             except Voter.DoesNotExist:
@@ -1037,10 +1037,10 @@ def voter_edit_view(request, voter_id=0, voter_we_vote_id=""):
 
         # Do some checks on all the public positions owned by this voter
         position_filters = []
-        new_filter = Q(voter_we_vote_id__iexact=voter_on_stage.we_vote_id)
+        new_filter = Q(voter_we_vote_id=voter_on_stage.we_vote_id)
         position_filters.append(new_filter)
         if positive_value_exists(voter_on_stage.linked_organization_we_vote_id):
-            new_filter = Q(organization_we_vote_id__iexact=voter_on_stage.linked_organization_we_vote_id)
+            new_filter = Q(organization_we_vote_id=voter_on_stage.linked_organization_we_vote_id)
             position_filters.append(new_filter)
 
         final_position_filters = []
@@ -1219,7 +1219,7 @@ def voter_edit_view(request, voter_id=0, voter_we_vote_id=""):
         if positive_value_exists(voter_we_vote_id):
             from campaign.models import CampaignXSupporter
             supporters_query = CampaignXSupporter.objects.all()
-            supporters_query = supporters_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+            supporters_query = supporters_query.filter(voter_we_vote_id=voter_we_vote_id)
             # if positive_value_exists(only_show_supporters_with_endorsements):
             #     supporters_query = supporters_query.exclude(
             #         Q(supporter_endorsement__isnull=True) |
@@ -1264,7 +1264,7 @@ def voter_edit_view(request, voter_id=0, voter_we_vote_id=""):
         volunteer_team_member_dict = {}
         try:
             queryset = VolunteerTeamMember.objects.using('readonly').all()\
-                .filter(voter_we_vote_id__iexact=voter_we_vote_id)
+                .filter(voter_we_vote_id=voter_we_vote_id)
             volunteer_team_membership_list = list(queryset)
             if len(volunteer_team_membership_list) > 0:
                 for volunteer_team_member in volunteer_team_membership_list:
@@ -1732,7 +1732,7 @@ def voter_list_view(request):
             new_filter = Q(last_name__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(we_vote_id__iexact=one_word)
+            new_filter = Q(we_vote_id=one_word)
             filters.append(new_filter)
 
             if len(voter_we_vote_ids_with_email) > 0:
@@ -1758,7 +1758,7 @@ def voter_list_view(request):
             new_filter = Q(twitter_name__icontains=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(linked_organization_we_vote_id__iexact=one_word)
+            new_filter = Q(linked_organization_we_vote_id=one_word)
             filters.append(new_filter)
 
             # Add the first query
@@ -1807,8 +1807,8 @@ def voter_list_view(request):
         voter_query = voter_query.filter(we_vote_id__in=merge_data_we_vote_id_list)
         for voter_merge_status in voter_merge_status_list:
             log_queryset = VoterMergeLog.objects.filter(
-                from_voter_we_vote_id__iexact=voter_merge_status.from_voter_we_vote_id,
-                to_voter_we_vote_id__iexact=voter_merge_status.to_voter_we_vote_id,
+                from_voter_we_vote_id=voter_merge_status.from_voter_we_vote_id,
+                to_voter_we_vote_id=voter_merge_status.to_voter_we_vote_id,
             ).order_by('id')
             voter_merge_log_list = list(log_queryset)
             voter_merge_status.voter_merge_log_list = voter_merge_log_list
@@ -1942,7 +1942,7 @@ def voter_summary_view(request, voter_id=0, voter_we_vote_id=''):
     else:
         # Otherwise, use VoterWhoSharesSummaryAllTime object
         voter_who_shares_query = VoterWhoSharesSummaryAllTime.objects.using('readonly').all()
-    voter_who_shares_query = voter_who_shares_query.filter(voter_we_vote_id__iexact=voter_we_vote_id)
+    voter_who_shares_query = voter_who_shares_query.filter(voter_we_vote_id=voter_we_vote_id)
     voter_who_shares_summary_list = list(voter_who_shares_query)
 
     voter_who_shares_summary_list_modified = []
@@ -1983,7 +1983,7 @@ def voter_summary_view(request, voter_id=0, voter_we_vote_id=''):
                 new_filter = Q(shared_by_display_name__icontains=one_word)
                 filters.append(new_filter)
 
-                new_filter = Q(shared_by_voter_we_vote_id__iexact=one_word)
+                new_filter = Q(shared_by_voter_we_vote_id=one_word)
                 filters.append(new_filter)
 
                 # Add the first query

--- a/voter_guide/controllers.py
+++ b/voter_guide/controllers.py
@@ -1568,7 +1568,7 @@ def move_voter_guide_possibility_positions_to_requested_voter_guide_possibility(
 
     voter_guide_possibility_query = VoterGuidePossibility.objects.filter(
         Q(voter_guide_possibility_url__contains=net_location) &
-        Q(organization_we_vote_id__iexact=organization_we_vote_id) &
+        Q(organization_we_vote_id=organization_we_vote_id) &
         Q(date_last_changed__range=[startdate, enddate])).order_by('-date_last_changed')
     # leave destination in set     .exclude(id=voter_guide_possibility_id)
     voter_guide_possibility_list = list(voter_guide_possibility_query)

--- a/voter_guide/models.py
+++ b/voter_guide/models.py
@@ -283,7 +283,7 @@ class VoterGuideManager(models.Manager):
                 try:
                     voter_guide_on_stage, new_voter_guide_created = VoterGuide.objects.update_or_create(
                         google_civic_election_id__exact=google_civic_election_id,
-                        organization_we_vote_id__iexact=organization_we_vote_id,
+                        organization_we_vote_id=organization_we_vote_id,
                         defaults=updated_values)
                 except VoterGuide.MultipleObjectsReturned as e:
                     handle_record_found_more_than_one_exception(e, logger=logger)
@@ -401,7 +401,7 @@ class VoterGuideManager(models.Manager):
                         updated_values['we_vote_hosted_profile_image_url_tiny'] = we_vote_hosted_profile_image_url_tiny
                     voter_guide_on_stage, new_voter_guide_created = VoterGuide.objects.update_or_create(
                         vote_smart_time_span__exact=vote_smart_time_span,
-                        organization_we_vote_id__iexact=organization_we_vote_id,
+                        organization_we_vote_id=organization_we_vote_id,
                         defaults=updated_values)
                     success = True
                     if new_voter_guide_created:
@@ -519,7 +519,7 @@ class VoterGuideManager(models.Manager):
                 }
                 voter_guide, new_voter_guide_created = VoterGuide.objects.update_or_create(
                     google_civic_election_id__exact=google_civic_election_id,
-                    organization_we_vote_id__iexact=linked_organization_we_vote_id,
+                    organization_we_vote_id=linked_organization_we_vote_id,
                     defaults=updated_values)
                 success = True
                 if new_voter_guide_created:
@@ -558,7 +558,7 @@ class VoterGuideManager(models.Manager):
         try:
             if positive_value_exists(organization_we_vote_id) and positive_value_exists(google_civic_election_id):
                 voter_guide_query = VoterGuide.objects.filter(google_civic_election_id=google_civic_election_id,
-                                                              organization_we_vote_id__iexact=organization_we_vote_id)
+                                                              organization_we_vote_id=organization_we_vote_id)
                 voter_guide_found = True if voter_guide_query.count() > 0 else False
         except VoterGuide.MultipleObjectsReturned as e:
             handle_exception(e, logger=logger)
@@ -618,11 +618,11 @@ class VoterGuideManager(models.Manager):
                 if read_only:
                     voter_guide_on_stage = VoterGuide.objects.using('readonly').get(
                         google_civic_election_id=google_civic_election_id,
-                        organization_we_vote_id__iexact=organization_we_vote_id)
+                        organization_we_vote_id=organization_we_vote_id)
                 else:
                     voter_guide_on_stage = VoterGuide.objects.get(
                         google_civic_election_id=google_civic_election_id,
-                        organization_we_vote_id__iexact=organization_we_vote_id)
+                        organization_we_vote_id=organization_we_vote_id)
                 voter_guide_on_stage_id = voter_guide_on_stage.id
                 voter_guide_on_stage_we_vote_id = voter_guide_on_stage.we_vote_id
                 status = "VOTER_GUIDE_FOUND_WITH_ORGANIZATION_WE_VOTE_ID "
@@ -632,11 +632,11 @@ class VoterGuideManager(models.Manager):
             #     if read_only:
             #         voter_guide_on_stage = VoterGuide.objects.using('readonly').get(
             #             vote_smart_time_span=vote_smart_time_span,
-            #             organization_we_vote_id__iexact=organization_we_vote_id)
+            #             organization_we_vote_id=organization_we_vote_id)
             #     else:
             #         voter_guide_on_stage = VoterGuide.objects.get(
             #             vote_smart_time_span=vote_smart_time_span,
-            #             organization_we_vote_id__iexact=organization_we_vote_id)
+            #             organization_we_vote_id=organization_we_vote_id)
             #     voter_guide_on_stage_id = voter_guide_on_stage.id
             #     voter_guide_on_stage_we_vote_id = voter_guide_on_stage.we_vote_id
             #     status = "VOTER_GUIDE_FOUND_WITH_ORGANIZATION_WE_VOTE_ID_AND_TIME_SPAN "
@@ -645,11 +645,11 @@ class VoterGuideManager(models.Manager):
                 if read_only:
                     voter_guide_on_stage = VoterGuide.objects.using('readonly').get(
                         google_civic_election_id=google_civic_election_id,
-                        public_figure_we_vote_id__iexact=public_figure_we_vote_id)
+                        public_figure_we_vote_id=public_figure_we_vote_id)
                 else:
                     voter_guide_on_stage = VoterGuide.objects.get(
                         google_civic_election_id=google_civic_election_id,
-                        public_figure_we_vote_id__iexact=public_figure_we_vote_id)
+                        public_figure_we_vote_id=public_figure_we_vote_id)
                 voter_guide_on_stage_id = voter_guide_on_stage.id
                 voter_guide_on_stage_we_vote_id = voter_guide_on_stage.we_vote_id
                 status = "VOTER_GUIDE_FOUND_WITH_PUBLIC_FIGURE_WE_VOTE_ID "
@@ -658,11 +658,11 @@ class VoterGuideManager(models.Manager):
                 if read_only:
                     voter_guide_on_stage = VoterGuide.objects.using('readonly').get(
                         google_civic_election_id=google_civic_election_id,
-                        owner_we_vote_id__iexact=owner_we_vote_id)
+                        owner_we_vote_id=owner_we_vote_id)
                 else:
                     voter_guide_on_stage = VoterGuide.objects.get(
                         google_civic_election_id=google_civic_election_id,
-                        owner_we_vote_id__iexact=owner_we_vote_id)
+                        owner_we_vote_id=owner_we_vote_id)
                 voter_guide_on_stage_id = voter_guide_on_stage.id
                 voter_guide_on_stage_we_vote_id = voter_guide_on_stage.we_vote_id
                 status = "VOTER_GUIDE_FOUND_WITH_VOTER_WE_VOTE_ID "
@@ -1475,13 +1475,13 @@ class VoterGuideListManager(models.Manager):
             voter_guide_query = voter_guide_query.exclude(vote_smart_ratings_only=True)
             if positive_value_exists(organization_we_vote_id):
                 voter_guide_query = voter_guide_query.filter(
-                    organization_we_vote_id__iexact=organization_we_vote_id)
+                    organization_we_vote_id=organization_we_vote_id)
             elif positive_value_exists(owner_voter_id):
                 voter_guide_query = voter_guide_query.filter(
                     owner_voter_id=owner_voter_id)
             elif positive_value_exists(owner_voter_we_vote_id):
                 voter_guide_query = voter_guide_query.filter(
-                    owner_we_vote_id__iexact=owner_voter_we_vote_id)
+                    owner_we_vote_id=owner_voter_we_vote_id)
             if positive_value_exists(maximum_number_to_retrieve):
                 voter_guide_list = voter_guide_query[:maximum_number_to_retrieve]
             else:
@@ -1612,7 +1612,7 @@ class VoterGuideListManager(models.Manager):
             filter_list = Q()
             for item in orgs_we_need_found_by_position_and_time_span_list_of_dicts:
                 filter_list |= Q(vote_smart_time_span=item['vote_smart_time_span'],
-                                 organization_we_vote_id__iexact=item['organization_we_vote_id'])
+                                 organization_we_vote_id=item['organization_we_vote_id'])
             voter_guide_query = voter_guide_query.filter(filter_list)
 
             if search_string:
@@ -1816,7 +1816,7 @@ class VoterGuideListManager(models.Manager):
                 for one_word in search_words:
                     filters = []
 
-                    new_filter = Q(we_vote_id__iexact=one_word)
+                    new_filter = Q(we_vote_id=one_word)
                     filters.append(new_filter)
 
                     new_filter = Q(display_name__icontains=one_word)
@@ -1825,13 +1825,13 @@ class VoterGuideListManager(models.Manager):
                     new_filter = Q(google_civic_election_id__iexact=one_word)
                     filters.append(new_filter)
 
-                    new_filter = Q(organization_we_vote_id__iexact=one_word)
+                    new_filter = Q(organization_we_vote_id=one_word)
                     filters.append(new_filter)
 
-                    new_filter = Q(owner_we_vote_id__iexact=one_word)
+                    new_filter = Q(owner_we_vote_id=one_word)
                     filters.append(new_filter)
 
-                    new_filter = Q(public_figure_we_vote_id__iexact=one_word)
+                    new_filter = Q(public_figure_we_vote_id=one_word)
                     filters.append(new_filter)
 
                     new_filter = Q(state_code__icontains=one_word)
@@ -1916,15 +1916,15 @@ class VoterGuideListManager(models.Manager):
 
             # Ignore entries with we_vote_id coming in from master server
             if positive_value_exists(we_vote_id_from_master):
-                voter_guide_query = voter_guide_query.exclude(we_vote_id__iexact=we_vote_id_from_master)
+                voter_guide_query = voter_guide_query.exclude(we_vote_id=we_vote_id_from_master)
 
             # We want to find candidates with *any* of these values
             if positive_value_exists(organization_we_vote_id):
-                new_filter = Q(organization_we_vote_id__iexact=organization_we_vote_id)
+                new_filter = Q(organization_we_vote_id=organization_we_vote_id)
                 filters.append(new_filter)
 
             if positive_value_exists(public_figure_we_vote_id):
-                new_filter = Q(public_figure_we_vote_id__iexact=public_figure_we_vote_id)
+                new_filter = Q(public_figure_we_vote_id=public_figure_we_vote_id)
                 filters.append(new_filter)
 
             if positive_value_exists(twitter_handle):
@@ -2342,7 +2342,7 @@ class VoterGuidePossibilityManager(models.Manager):
                 now = datetime.now()
                 voter_guide_possibility_on_stage = VoterGuidePossibility.objects.get(
                     google_civic_election_id=google_civic_election_id,
-                    organization_we_vote_id__iexact=organization_we_vote_id,
+                    organization_we_vote_id=organization_we_vote_id,
                     hide_from_active_review=False,
                     date_last_changed__year=now.year)
                 if voter_guide_possibility_on_stage is not None:
@@ -2360,7 +2360,7 @@ class VoterGuidePossibilityManager(models.Manager):
             #     # TODO: Update this to deal with the google_civic_election_id being spread across 50 fields
             #     voter_guide_possibility_on_stage = VoterGuidePossibility.objects.get(
             #         google_civic_election_id=google_civic_election_id,
-            #         voter_who_submitted_we_vote_id__iexact=voter_who_submitted_we_vote_id,
+            #         voter_who_submitted_we_vote_id=voter_who_submitted_we_vote_id,
             #         hide_from_active_review=False)
             #     if voter_guide_possibility_on_stage is not None:
             #         voter_guide_possibility_on_stage_id = voter_guide_possibility_on_stage.id
@@ -2454,7 +2454,7 @@ class VoterGuidePossibilityManager(models.Manager):
                     Q(assigned_to_voter_we_vote_id=""))
             elif positive_value_exists(assigned_to_voter_we_vote_id):
                 voter_guide_query = voter_guide_query.filter(
-                    assigned_to_voter_we_vote_id__iexact=assigned_to_voter_we_vote_id)
+                    assigned_to_voter_we_vote_id=assigned_to_voter_we_vote_id)
 
             if positive_value_exists(search_string):
                 try:
@@ -2472,7 +2472,7 @@ class VoterGuidePossibilityManager(models.Manager):
                     new_filter = Q(organization_name__icontains=one_word)
                     filters.append(new_filter)
 
-                    new_filter = Q(organization_we_vote_id__iexact=one_word)
+                    new_filter = Q(organization_we_vote_id=one_word)
                     filters.append(new_filter)
 
                     new_filter = Q(organization_twitter_handle__icontains=one_word)
@@ -2481,7 +2481,7 @@ class VoterGuidePossibilityManager(models.Manager):
                     new_filter = Q(voter_guide_possibility_url__icontains=one_word)
                     filters.append(new_filter)
 
-                    new_filter = Q(voter_who_submitted_we_vote_id__iexact=one_word)
+                    new_filter = Q(voter_who_submitted_we_vote_id=one_word)
                     filters.append(new_filter)
 
                     new_filter = Q(voter_who_submitted_name__icontains=one_word)
@@ -2490,7 +2490,7 @@ class VoterGuidePossibilityManager(models.Manager):
                     try:
                         candidate_we_vote_id_query = VoterGuidePossibilityPosition.objects.all()
                         candidate_we_vote_id_query = candidate_we_vote_id_query.filter(
-                            candidate_we_vote_id__iexact=one_word)
+                            candidate_we_vote_id=one_word)
                         candidate_we_vote_id_query = candidate_we_vote_id_query.values(
                             'voter_guide_possibility_parent_id').distinct()
                         candidate_voter_guide_possibility_parent_id_dict = list(candidate_we_vote_id_query)
@@ -2501,7 +2501,7 @@ class VoterGuidePossibilityManager(models.Manager):
 
                         measure_we_vote_id_query = VoterGuidePossibilityPosition.objects.all()
                         measure_we_vote_id_query = measure_we_vote_id_query.filter(
-                            measure_we_vote_id__iexact=one_word)
+                            measure_we_vote_id=one_word)
                         measure_we_vote_id_query = measure_we_vote_id_query.values(
                             'voter_guide_possibility_parent_id').distinct()
                         measure_voter_guide_possibility_parent_id_dict = list(measure_we_vote_id_query)

--- a/voter_guide/views_admin.py
+++ b/voter_guide/views_admin.py
@@ -1678,7 +1678,7 @@ def voter_guide_list_view(request):
         for one_word in search_words:
             filters = []
 
-            new_filter = Q(we_vote_id__iexact=one_word)
+            new_filter = Q(we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(display_name__icontains=one_word)
@@ -1687,13 +1687,13 @@ def voter_guide_list_view(request):
             new_filter = Q(google_civic_election_id__iexact=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(organization_we_vote_id__iexact=one_word)
+            new_filter = Q(organization_we_vote_id=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(owner_we_vote_id__iexact=one_word)
+            new_filter = Q(owner_we_vote_id=one_word)
             filters.append(new_filter)
 
-            new_filter = Q(public_figure_we_vote_id__iexact=one_word)
+            new_filter = Q(public_figure_we_vote_id=one_word)
             filters.append(new_filter)
 
             new_filter = Q(state_code__icontains=one_word)

--- a/wevote_settings/models.py
+++ b/wevote_settings/models.py
@@ -609,9 +609,9 @@ class RemoteRequestHistoryManager(models.Manager):
             list_query = list_query.filter(kind_of_action__iexact=kind_of_action)
             list_query = list_query.filter(google_civic_election_id=google_civic_election_id)
             if positive_value_exists(candidate_campaign_we_vote_id):
-                list_query = list_query.filter(candidate_campaign_we_vote_id__iexact=candidate_campaign_we_vote_id)
+                list_query = list_query.filter(candidate_campaign_we_vote_id=candidate_campaign_we_vote_id)
             if positive_value_exists(organization_we_vote_id):
-                list_query = list_query.filter(organization_we_vote_id__iexact=organization_we_vote_id)
+                list_query = list_query.filter(organization_we_vote_id=organization_we_vote_id)
             list_query_count = list_query.count()
             if positive_value_exists(list_query_count):
                 return True


### PR DESCRIPTION
Removing __iexact from "we_vote_id" queries. We have found that searches with __iexact are much slower and don't use indexes in the same way, so I am removing most of them. Also adding SMS_BYPASS_MOBILE_NUMBER as an environment_variables setting.