### PR TITLE
Auto-merging candidates with matching alt names and different CTCL UUIDs. This can cause us to lose newer candidate campaign website data. Made it easier to see the state we are looking at for the Duplicate Candidates page. Added jump links when comparing two candidates.

### DIFF
--- a/candidate/controllers.py
+++ b/candidate/controllers.py
@@ -666,16 +666,43 @@ def merge_if_duplicate_candidates(candidate1_on_stage, candidate2_on_stage, conf
     elif positive_value_exists(candidate1_on_stage.ctcl_uuid) and \
             positive_value_exists(candidate2_on_stage.ctcl_uuid):
         candidate_names_match = False
+        candidate_name_matches_alt_name = False
         each_candidate_has_different_politician = False
         if positive_value_exists(candidate1_on_stage.candidate_name) and \
                 positive_value_exists(candidate2_on_stage.candidate_name):
             if candidate1_on_stage.candidate_name.strip().lower() == candidate2_on_stage.candidate_name.strip().lower():
                 candidate_names_match = True
+            # Does either primary name match any of the alternate names of the other?
+            candidate1_alt_names_list = []
+            if positive_value_exists(candidate1_on_stage.google_civic_candidate_name):
+                if candidate1_on_stage.google_civic_candidate_name.strip().lower() not in candidate1_alt_names_list:
+                    candidate1_alt_names_list.append(candidate1_on_stage.google_civic_candidate_name.strip().lower())
+            if positive_value_exists(candidate1_on_stage.google_civic_candidate_name2):
+                if candidate1_on_stage.google_civic_candidate_name2.strip().lower() not in candidate1_alt_names_list:
+                    candidate1_alt_names_list.append(candidate1_on_stage.google_civic_candidate_name2.strip().lower())
+            if positive_value_exists(candidate1_on_stage.google_civic_candidate_name3):
+                if candidate1_on_stage.google_civic_candidate_name3.strip().lower() not in candidate1_alt_names_list:
+                    candidate1_alt_names_list.append(candidate1_on_stage.google_civic_candidate_name3.strip().lower())
+            candidate2_alt_names_list = []
+            if positive_value_exists(candidate2_on_stage.google_civic_candidate_name):
+                if candidate2_on_stage.google_civic_candidate_name.strip().lower() not in candidate2_alt_names_list:
+                    candidate2_alt_names_list.append(candidate2_on_stage.google_civic_candidate_name.strip().lower())
+            if positive_value_exists(candidate2_on_stage.google_civic_candidate_name2):
+                if candidate2_on_stage.google_civic_candidate_name2.strip().lower() not in candidate2_alt_names_list:
+                    candidate2_alt_names_list.append(candidate2_on_stage.google_civic_candidate_name2.strip().lower())
+            if positive_value_exists(candidate2_on_stage.google_civic_candidate_name3):
+                if candidate2_on_stage.google_civic_candidate_name3.strip().lower() not in candidate2_alt_names_list:
+                    candidate2_alt_names_list.append(candidate2_on_stage.google_civic_candidate_name3.strip().lower())
+            if candidate1_on_stage.candidate_name.strip().lower() in candidate2_alt_names_list:
+                candidate_name_matches_alt_name = True
+            if candidate2_on_stage.candidate_name.strip().lower() in candidate1_alt_names_list:
+                candidate_name_matches_alt_name = True
+        # Make sure they don't have different politicians
         if positive_value_exists(candidate1_on_stage.politician_we_vote_id) and \
                 positive_value_exists(candidate2_on_stage.politician_we_vote_id):
             if candidate1_on_stage.politician_we_vote_id != candidate2_on_stage.politician_we_vote_id:
                 each_candidate_has_different_politician = True
-        if candidate_names_match and not each_candidate_has_different_politician:
+        if (candidate_names_match or candidate_name_matches_alt_name) and not each_candidate_has_different_politician:
             status += "IDENTICAL_CANDIDATE_NAMES_FROM_CTCL_FOUND_FOR_MERGE "
             merge_results = merge_these_two_candidates(candidate1_we_vote_id, candidate2_we_vote_id, merge_choices)
             if merge_results['candidates_merged']:

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -5170,6 +5170,7 @@ def candidate_duplicates_list_view(request):
         'google_civic_election_id':     google_civic_election_id,
         'duplicates_list':              duplicates_list_modified,
         'candidate_search':             candidate_search,
+        'possible_duplicates_count':    possible_duplicates_count,
         'show_all':                     show_all,
         'show_candidates_with_email':   show_candidates_with_email,
         'show_related_candidates':      show_related_candidates,

--- a/templates/candidate/candidate_duplicates_list.html
+++ b/templates/candidate/candidate_duplicates_list.html
@@ -1,13 +1,13 @@
 {# templates/candidate/candidate_duplicates_list.html #}
 {% extends "template_base.html" %}
 
-{% block title %}Duplicate Candidates{% endblock %}
+{% block title %}Duplicate Candidates{% if state_code %} - {{ state_code|upper }}{% endif %}{% if possible_duplicates_count %} - {{ possible_duplicates_count }} Found{% endif %}{% endblock %}
 
 {%  block content %}
 {% load template_filters %}
 {% load humanize %}
 
-<h1>Duplicate Candidates</h1>
+<h1>Duplicate Candidates{% if state_code %} - {{ state_code|upper }}{% endif %}{% if possible_duplicates_count %} - {{ possible_duplicates_count }}{% endif %}</h1>
 
     <ul>
     {% if state_code %}

--- a/templates/candidate/candidate_merge_one_field_decision.html
+++ b/templates/candidate/candidate_merge_one_field_decision.html
@@ -4,8 +4,22 @@
 <tr>
     <td>{{ field_label }}</td>
 {% if conflict_status == "CONFLICT" %}
-    <td><input type="radio" name="{{ field_name }}_choice" value="{{ candidate1.we_vote_id }}" checked /><span class="bold-select"> {{ candidate1_field_value|default_if_none:"" }}</span>&nbsp;&nbsp;</td>
-    <td><input type="radio" name="{{ field_name }}_choice" value="{{ candidate2.we_vote_id }}" /><span class="bold-select"> {{ candidate2_field_value|default_if_none:"" }}</span></td>
+    <td>
+        <input type="radio" name="{{ field_name }}_choice" value="{{ candidate1.we_vote_id }}" checked /><span class="bold-select"> {{ candidate1_field_value|default_if_none:"" }}</span>&nbsp;&nbsp;
+        {% if 'http' in candidate1_field_value %}
+            <a href="{{ candidate1_field_value }}" target="_blank">
+            <span class="glyphicon glyphicon-new-window"></span>
+            </a>&nbsp;
+        {% endif %}
+    </td>
+    <td>
+        <input type="radio" name="{{ field_name }}_choice" value="{{ candidate2.we_vote_id }}" /><span class="bold-select"> {{ candidate2_field_value|default_if_none:"" }}</span>
+        {% if 'http' in candidate2_field_value %}
+            <a href="{{ candidate2_field_value }}" target="_blank">
+            <span class="glyphicon glyphicon-new-window"></span>
+            </a>
+        {% endif %}
+    </td>
 {% else %}
     <td>
     {% if 'http' in candidate1_field_value %}


### PR DESCRIPTION
Auto-merging candidates with matching alt names and different CTCL UUIDs. This can cause us to lose newer candidate campaign website data. Made it easier to see the state we are looking at for the Duplicate Candidates page. Added jump links when comparing two candidates.