### PR TITLE
Fast load was mistakenly overwriting we_vote_id in a few files.

### DIFF
--- a/retrieve_tables/controllers_local.py
+++ b/retrieve_tables/controllers_local.py
@@ -53,8 +53,9 @@ def update_fast_load_db(host, voter_api_device_id, table_name, additional_record
                                         'voter_api_device_id': voter_api_device_id,
                                         })
 
+        # print('update_fast_load_db ', response.status_code, response.url, voter_api_device_id)
         # print(response.request.url)
-        print('update_fast_load_db ', response.status_code, response.url, voter_api_device_id)
+        # print('update_fast_load_db ', response.status_code, response.url, voter_api_device_id)
     except Exception as e:
         logger.error('update_fast_load_db caught: ', str(e))
 
@@ -276,8 +277,15 @@ def process_table_data(table_name, split_data):
         return 0
 
     # retrieve constraints from table
+    # Some unique_cols should not get dummy values, since these values are relied on as keys to other tables
+    do_not_touch = ['we_vote_id', 'voter_id', 'linked_campaignx_we_vote_id', 'linked_politician_we_vote_id',
+                    'organization_we_vote_id', 'google_civic_election_id']
     unique_constraints = inspector.get_unique_constraints(table_name)
     unique_cols = [con['column_names'][0] for con in unique_constraints]
+    unique_cols = [x for x in unique_cols if x not in do_not_touch]
+
+    # unique_cols = [con['column_names'][0] for (con in unique_constraints and con not in do_not_touch)]
+
     foreign_keys = inspector.get_foreign_keys(table_name)
     fk_cols = [col['constrained_columns'][0] for col in foreign_keys]
 
@@ -434,6 +442,7 @@ def get_dummy_ids(df, dummy_cols, unique_cols, not_null_id_cols, start_id):
     dummy_cols.update(set(unique_cols) - dummy_cols)
     dummy_cols.update(set(not_null_id_cols) - dummy_cols)
     dummy_cols = list(dummy_cols)
+    # print('dummy_cols -------------------> ', dummy_cols)
 
     new_ids = np.arange(start_id, start_id + len(df))
 

--- a/templates/admin_tools/sync_data_with_master_dashboard.html
+++ b/templates/admin_tools/sync_data_with_master_dashboard.html
@@ -7,30 +7,30 @@
 {% load template_filters %}
 
 <h1>Fast Load Data From We Vote Master Servers</h1>
-    <div style="padding: 25px 25px 75px 25px; font-size: 18px; display: flex; flex-direction: column;">
-        If you are loading election data for the first time to your local postgres, press the "FAST LOAD" button below, and in about
-        fifty-two minutes (on a fast Mac), it will have loaded and stored all the election data we have for all elections and for all the states.
-        <br>
+<div style="padding: 25px 0 75px 25px; font-size: 18px; display: flex; flex-direction: column;">
+    If you are loading election data for the first time to your local postgres, press the "FAST LOAD" button below, and in about
+    an hour (on a fast Mac), it will have loaded and stored all the election data we have for all elections and for all the states.
+    If you want to update to current election data, and don't care about overwriting your existing election data,
+    "FAST LOAD" is all you need.  The Python logging screen shows progress as the tables are loaded.
+    <br>
 
-        <input type="hidden" id="started_fast_update" name="started_fast_update" value="false">
-        <input type="hidden" id="started_fast_init" name="started_fast_init" value="true">
-        <div style="display: flex; flex-direction: column; align-self: center; align-items: flex-start; padding-top: 30px; padding-bottom: 30px; width: 80%;">
-            <button id="fastLoadButton" type="submit" value="1" onClick="fastLoadClick()" style="width: 100%; align-self: center;">FAST LOAD ALL THE ELECTION DATA, TO YOUR LOCAL POSTGRES</button>
-            <progress id="progress" value="0" max="100" style="display: none"></progress>
-            <div id="current_table"></div>
-            <div id="current_status"></div>
-            <div id="total_time"></div>
-            <div id="completion"></div>
-        </div>
-        If you want to update to current election data, and don't care about overwriting your existing election data,
-        "FAST LOAD" is all you need.  The Python logging screen shows progress as the tables are loaded.
-        <br><br>
-        If you are working with specific election data, and may have made local changes that you want to preserve, then the
-        "Sync Data With Master We Vote Servers" tools that follow are for you.  (Syncing data can take many hours for a big
-        state, or a national election.)
+    <input type="hidden" id="started_fast_update" name="started_fast_update" value="false">
+    <input type="hidden" id="started_fast_init" name="started_fast_init" value="true">
+    <div style="display: flex; flex-direction: column; align-self: center; align-items: flex-start; padding-top: 30px; padding-bottom: 30px; width: 80%;">
+        <button id="fastLoadButton" type="submit" value="1" onClick="fastLoadClick()" style="width: 100%; align-self: center;">FAST LOAD ALL THE ELECTION DATA, TO YOUR LOCAL POSTGRES</button>
+        <progress id="progress" value="0" max="100" style="display: none"></progress>
+        <div id="current_table"></div>
+        <div id="current_status"></div>
+        <div id="total_time"></div>
+        <div id="completion"></div>
     </div>
-
-
+</div>
+<p style="padding-left:  25px;">
+    If you are working with specific election data, and may have made local changes that you want to preserve, then the
+    "Sync Data With Master We Vote Servers" tools that follow are for you.  (Syncing data can take many hours for a big
+    state, or a national election.)
+</p>
+<br>
 
 <h1>Sync Data With Master We Vote Servers</h1>
 


### PR DESCRIPTION
Now there is an exclusion list called "do_not_touch" for columns that have UNIQUE constraints, but also have critical data on the master servers.

Fixes https://wevoteusa.atlassian.net/issues/WV-782