### PR TITLE
Made changes to the pattern of passing lists of performance_snapshots from the Edit Process view, over to the Edit Form view [WV-455] [WV-490] [ [WV-790]

### DIFF
--- a/templates/admin_tools/speed_statistics_banner.html
+++ b/templates/admin_tools/speed_statistics_banner.html
@@ -19,7 +19,7 @@
         <tbody>
             {% for view, stats in performance_dict.items %}
                 <tr>
-                    <td colspan="3" style="font-weight: bold; text-align: left">View: {{ view }}</td>
+                    <td colspan="3" style="font-weight: bold; text-align: left">{{ view }}</td>
                 </tr>
                 {% for stat in stats %}
                     <tr>
@@ -35,30 +35,6 @@
                     </tr>
                 {% endfor %}
             {% endfor %}
-        </tbody>
-        <tbody>
-            {% if performance_process_dict %}
-                {% for view, stats in performance_process_dict.items %}
-                    <tr>
-                        <td colspan="3" style="font-weight: bold; text-align: left">
-                            View: {{ view }}
-                        </td>
-                    </tr>
-                    {% for stat in stats %}
-                        <tr>
-                            <td>{{ stat.name }}</td>
-                            <td>{{ stat.time_difference|floatformat:4 }}</td>
-                            <td style="font-weight: 300; color: #666;">
-                                {{ stat.description }}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                {% endfor %}
-            {% else %}
-                <tr>
-                    <td colspan="3">No performance data available.</td>
-                </tr>
-            {% endif %}
         </tbody>
     </table>
 </div>


### PR DESCRIPTION
Made changes to the pattern of passing lists of performance_snapshots from the Edit Process view, over to the Edit Form view:

1) Showing data from the incoming performance_process_dict first 
2) Adding the list(s) from the performance_process_dict directly into performance_dict. 
3) Removed duplicate table for performance_process_dict from speed_statistics_banner.html, since the performance_process_dict is now woven into performance_dict. 
4) Changed all custom snapshot names (ex/ "performance_snapshot_positionEnteredFilter") to be "performance_snapshot" for easier copy/pasting as we add performance_snapshots to the code. 
5) Wrapped description lines to follow PEP8 rules.