### PR TITLE
Fastload revamp experiment

### DIFF
--- a/apis_v1/documentation_source/backup_one_table_to_s3_doc.py
+++ b/apis_v1/documentation_source/backup_one_table_to_s3_doc.py
@@ -1,0 +1,69 @@
+# apis_v1/documentation_source/backup_one_table_to_s3_doc.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+
+
+def backup_one_table_to_s3_doc_template_values(url_root):
+    """
+    Show documentation about friendList
+    """
+    required_query_parameter_list = [
+        {
+            'name':         'table_name',
+            'value':        'string',  # boolean, integer, long, string
+            'description':  'the name of the table to save to s3',
+        },
+        {
+            'name':         'api_key',
+            'value':        'string (from post, cookie, or get (in that order))',  # boolean, integer, long, string
+            'description':  'The unique key provided to any organization using the WeVoteServer APIs',
+        },
+    ]
+    optional_query_parameter_list = [
+    ]
+
+    potential_status_codes_list = [
+        {
+            'code':         'VALID_VOTER_DEVICE_ID_MISSING',
+            'description':  'Cannot proceed. A valid voter_device_id parameter was not included.',
+        },
+        {
+            'code':         'VALID_VOTER_ID_MISSING',
+            'description':  'Cannot proceed. A valid voter_id was not found.',
+        },
+    ]
+
+    try_now_link_variables_dict = {
+        'table_name':     'campaign_campaignx',
+    }
+
+    api_response = '{\n' \
+                   '  "success": boolean,\n' \
+                   '  "status": string,\n' \
+                   '  "temp_file_name": string,\n' \
+                   '  "dump_table_to_tmp_completed": string,\n' \
+                   '  "tmp_file_to_s3_completed": string,\n' \
+                   '  "aws_s3_file_url": string,\n' \
+                   '}]'
+
+    template_values = {
+        'api_name': 'backupOneTableToS3',
+        'api_slug': 'backupOneTableToS3',
+        'api_introduction':
+            "Uses pg_dump to save a backup image of a postgres file to a tmp file, and copies that temp file as an "
+            "AWS s3 file for use by the local instance of server (on a developers Mac).<br>  This allows the developer to "
+            "populate their local postgres database with a limited set of files from the master server (see "
+            "allowable_tables in retrieve_tables/controllers_master.py)<br>  The response contains an s3 URL to the file "
+            "for use from the local server instance.  This is a part of the \"Fast Load\" developer's tool",
+        'try_now_link': 'apis_v1:backupOneTableToS3View',
+        'try_now_link_variables_dict': try_now_link_variables_dict,
+        'url_root': url_root,
+        'get_or_post': 'GET',
+        'required_query_parameter_list': required_query_parameter_list,
+        'optional_query_parameter_list': optional_query_parameter_list,
+        'api_response': api_response,
+        'api_response_notes':
+            "",
+        'potential_status_codes_list': potential_status_codes_list,
+    }
+    return template_values

--- a/apis_v1/urls.py
+++ b/apis_v1/urls.py
@@ -21,6 +21,7 @@ from apis_v1.views import views_activity, views_apple, views_docs, views_analyti
     views_pledge_to_vote, views_politician, views_position, views_reaction, views_representative, \
     views_retrieve_tables, views_task, views_share, views_twitter, views_voter, views_voter_guide, \
     views_googlebot_site_map
+from apis_v1.views.views_retrieve_tables import backup_one_table_to_s3_view
 from ballot.views_admin import ballot_items_sync_out_view, ballot_returned_sync_out_view
 from candidate.views_admin import candidates_sync_out_view, candidate_to_office_link_sync_out_view
 from issue.views_admin import issue_descriptions_retrieve_view, issues_followed_retrieve_view, \
@@ -333,8 +334,11 @@ urlpatterns = [
                           sitewide_daily_metrics_sync_out_view, name='sitewideDailyMetricsSyncOutView'),
                   re_path(r'^sitewideElectionMetricsSyncOut/',
                           sitewide_election_metrics_sync_out_view, name='sitewideElectionMetricsSyncOutView'),
+                  re_path(r'^backupOneTableToS3/',
+                          backup_one_table_to_s3_view, name='backupOneTableToS3View'),
                   re_path(r'^sitewideVoterMetricsSyncOut/',
                           sitewide_voter_metrics_sync_out_view, name='sitewideVoterMetricsSyncOutView'),
+
                   # re_path(r'^taskDelete/', views_task.delete_task, name='taskDelete'),
                   # re_path(r'^taskSaveNew/', views_task.save_new_task, name='taskSaveNewView'),
                   # re_path(r'^taskCompletedOutput/', views_task.read_output_record, name='taskCompletedOutput'),
@@ -752,6 +756,9 @@ urlpatterns = [
                   re_path(r'^docs/sitewideElectionMetricsSyncOut/',
                           views_docs.sitewide_election_metrics_sync_out_doc_view,
                           name='sitewideElectionMetricsSyncOutDocs'),
+                  path('docs/backupOneTableToS3/',
+                       views_docs.backup_one_table_to_s3_doc_view,
+                       name='backupOneTableToS3Docs'),
                   re_path(r'^docs/sitewideVoterMetricsSyncOut/',
                           views_docs.sitewide_voter_metrics_sync_out_doc_view, name='sitewideVoterMetricsSyncOutDocs'),
                   path('docs/searchAll/',

--- a/apis_v1/views/views_docs.py
+++ b/apis_v1/views/views_docs.py
@@ -86,7 +86,7 @@ from apis_v1.documentation_source import \
     voter_split_into_two_accounts_doc, \
     voter_stop_opposing_save_doc, \
     voter_stop_supporting_save_doc, voter_supporting_save_doc, voter_twitter_save_to_current_account_doc, \
-    voter_update_doc, voter_verify_secret_code_doc, email_ballot_data_doc
+    voter_update_doc, voter_verify_secret_code_doc, email_ballot_data_doc, backup_one_table_to_s3_doc
 from config.base import get_environment_variable
 from voter.models import voter_setup
 from wevote_functions.functions import get_voter_api_device_id, set_voter_api_device_id, positive_value_exists
@@ -1269,6 +1269,17 @@ def sitewide_election_metrics_sync_out_doc_view(request):
         sitewide_election_metrics_sync_out_doc.sitewide_election_metrics_sync_out_doc_template_values(url_root)
     template_values['voter_api_device_id'] = get_voter_api_device_id(request)
     return render(request, 'apis_v1/api_doc_page.html', template_values)
+
+
+def backup_one_table_to_s3_doc_view(request):
+    """
+    Show documentation about backupOneTableToS3
+    """
+    url_root = WE_VOTE_SERVER_ROOT_URL
+    template_values = backup_one_table_to_s3_doc.backup_one_table_to_s3_doc_template_values(url_root)
+    template_values['voter_api_device_id'] = get_voter_api_device_id(request)
+    return render(request, 'apis_v1/api_doc_page.html', template_values)
+
 
 
 def sitewide_voter_metrics_sync_out_doc_view(request):

--- a/templates/apis_v1/apis_index.html
+++ b/templates/apis_v1/apis_index.html
@@ -1248,6 +1248,12 @@
           <td colspan="3"><strong>For Developers</strong></td>
         </tr>
          <tr>
+          <td><a href="{% url 'apis_v1:backupOneTableToS3Docs' %}">backupOneTableToS3</a></td>
+          <td></td>
+          <td>Backup a Master server postgres table, and save it to AWS s3
+          </td>
+        </tr>
+         <tr>
           <td><a href="{% url 'apis_v1:fastLoadStatusRetrieve' %}">fastLoadStatusRetrieve</a></td>
           <td></td>
           <td>Get the status of an ongoing fast load of certain tables to a developers Mac


### PR DESCRIPTION
Moving tables between postgress servers should be easy.  
It didn't work when the two postgres instances had very different versions.  
Now that they are the same, I'm trying a more conventional (and hopefully less problematic approach).  This is the master only side of the solution, with the master dumping the table to a file and saving it to s3.  And then only sending the s3 link to the client.  Once this is deployed in production, I can experiment with the local side.