### PR TITLE
WV-861 add next page UI [TEAM REVIEW]

### DIFF
--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -564,6 +564,9 @@ def politicians_import_from_master_server_view(request):
 
 @login_required
 def politician_list_view(request):
+    # Pagination parameters
+    page = int(request.GET.get('page', 0))  # Default to page 0
+    items_per_page = 25  # Number of items per page
     # admin, analytics_admin, partner_organization, political_data_manager, political_data_viewer, verified_volunteer
     authority_required = {'partner_organization', 'political_data_viewer', 'verified_volunteer'}
     if not voter_has_authority(request, authority_required):
@@ -1168,7 +1171,34 @@ def politician_list_view(request):
             show_related_candidates=show_related_candidates,
             was_candidate_recently=was_candidate_recently,
             )
+        
+    # Pagination logic
+    total_count = politician_query.count()
+    items_per_page = 25
+    page = int(request.GET.get("page", 1)) - 1  # Page is 0-indexed
+    start_index = page * items_per_page
+    end_index = start_index + items_per_page
+
+    # Fetch only the items for the current page
+    politician_list = politician_query.order_by("politician_name")[start_index:end_index]
+
+    # Determine if there are previous/next pages
+    has_previous_page = page > 0
+    has_next_page = end_index < total_count
+
+    # Update URLs for previous and next pages
+    previous_page_url = f"?page={page}&state_code={state_code}&politician_search={politician_search}" if has_previous_page else None
+    next_page_url = f"?page={page + 2}&state_code={state_code}&politician_search={politician_search}" if has_next_page else None
+    
     template_values = {
+        "start_index": start_index,
+        'politician_list': politician_list,
+        'state_code': state_code,
+        'politician_search': politician_search,
+        'current_page_number': page,
+        'previous_page_url': previous_page_url,
+        'next_page_url': next_page_url,
+        'hide_pagination': total_count <= items_per_page,
         'checkbox_url_variables':       checkbox_url_variables,
         'election_list':                election_list,
         'exclude_politician_analysis_done': exclude_politician_analysis_done,

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -1179,12 +1179,10 @@ def politician_list_view(request):
             show_related_candidates=show_related_candidates,
             was_candidate_recently=was_candidate_recently,
             )
-    
     # Update URLs for previous and next pages
-    previous_page_url = f"?page={page - 1}&state_code={state_code}&politician_search={politician_search}" if has_previous_page else None
-    next_page_url = f"?page={page + 1}&state_code={state_code}&politician_search={politician_search}" if has_next_page else None
-    
-    template_values = { 
+    previous_page_url = f"?page={page - 1}&state_code={state_code}&{checkbox_url_variables}"
+    next_page_url = f"?page={page + 1}&state_code={state_code}&{checkbox_url_variables}"
+    template_values = {
         'checkbox_url_variables':       checkbox_url_variables,
         'current_page_number':          page,
         'election_list':                election_list,

--- a/templates/politician/politician_list.html
+++ b/templates/politician/politician_list.html
@@ -121,6 +121,18 @@
              {% if exclude_politician_analysis_done %}checked{% endif %} /> Exclude Analyzed
     </label>
 </form>
+<!-- Pagination Section -->
+{% if not hide_pagination %}
+<span class="float-right">
+    {% if previous_page_url %}
+        <a href="{{ previous_page_url }}">Previous page</a> |
+    {% endif %}
+    Page {{ current_page_number|add:1 }}
+    {% if next_page_url %}
+        | <a href="{{ next_page_url }}">Next page</a>
+    {% endif %}
+</span>
+{% endif %}
 
 {% if politician_list %}
     <table class="table">
@@ -142,7 +154,7 @@
       </thead>
     {% for politician in politician_list %}
         <tr>
-            <td>{{ forloop.counter }}</td>
+            <td>{{ forloop.counter|add:start_index }}</td>
             <td{% if politician.profile_image_background_color %}
                     style="padding-left: 0; padding-right: 0;"
                 {% endif %}>
@@ -248,6 +260,18 @@
         </tr>
     {% endfor %}
     </table>
+    <!-- Pagination Section -->
+{% if not hide_pagination %}
+<span class="float-right">
+    {% if previous_page_url %}
+        <a href="{{ previous_page_url }}">Previous page</a> |
+    {% endif %}
+    Page {{ current_page_number|add:1 }}
+    {% if next_page_url %}
+        | <a href="{{ next_page_url }}">Next page</a>
+    {% endif %}
+</span>
+{% endif %}
 
     <p></p>
 {% else %}

--- a/templates/politician/politician_list.html
+++ b/templates/politician/politician_list.html
@@ -51,6 +51,9 @@
 
 <form name="state_code_form" method="get" action="{% url 'politician:politician_list' %}">
     {% csrf_token %}
+    <input type="hidden" name="politician_search" value="{{ politician_search|default_if_none:'' }}" />
+    <input type="hidden" name="show_all" value="{{ show_all|default_if_none:0 }}" />
+    <input type="hidden" name="exclude_politician_analysis_done" value="{{ exclude_politician_analysis_done|default_if_none:0 }}" />
 
     {% if state_code != "" %}
     <a href="#" onclick="showAllStates(); return false;">
@@ -58,15 +61,14 @@
     {% endif %}
 
     {% if state_list %}
-        <select id="state_code_id" name="state_code">
-            <option value="">
-                -- Filter by State Served --</option>
+    <select id="state_code_id" name="state_code" onchange="this.form.submit()">
+        <option value="" {% if not state_code %}selected{% endif %}>-- Select a State --</option>
         {% for key, state in state_list %}
-            <option value="{{ key }}"
-                    {% if key|lower == state_code|lower %} selected="selected"{% endif %}>
-                {{ state }}</option>
+        <option value="{{ key }}" {% if key|lower == state_code|lower %}selected{% endif %}>
+            {{ state }}
+        </option>
         {% endfor %}
-        </select>
+    </select>
     {% endif %}{# End of if state_list #}
 
     {% if politician_search %}
@@ -125,11 +127,11 @@
 {% if not hide_pagination %}
 <span class="float-right">
     {% if previous_page_url %}
-        <a href="{{ previous_page_url }}">Previous page</a> |
+    <a href="{{ previous_page_url }}" onclick="displayLoadingBanner()">Previous page</a> |
     {% endif %}
     Page {{ current_page_number|add:1 }}
     {% if next_page_url %}
-        | <a href="{{ next_page_url }}">Next page</a>
+        | <a href="{{ next_page_url }}" onclick="displayLoadingBanner()">Next page</a>
     {% endif %}
 </span>
 {% endif %}
@@ -264,11 +266,11 @@
 {% if not hide_pagination %}
 <span class="float-right">
     {% if previous_page_url %}
-        <a href="{{ previous_page_url }}">Previous page</a> |
+    <a href="{{ previous_page_url }}" onclick="displayLoadingBanner()">Previous page</a>
     {% endif %}
     Page {{ current_page_number|add:1 }}
     {% if next_page_url %}
-        | <a href="{{ next_page_url }}">Next page</a>
+        | <a href="{{ next_page_url }}" onclick="displayLoadingBanner()">Next page</a>
     {% endif %}
 </span>
 {% endif %}
@@ -283,7 +285,12 @@
 
 <script>
     function displayLoadingBanner() {
-        $('#FilterPopupMessage').show();
+        const banner = document.getElementById('FilterPopupMessage');
+        if (banner) {
+            banner.style.display = 'block';
+        } else {
+            console.error('FilterPopupMessage element not found.');
+        }
     }
 
     function clearSearch() {
@@ -360,5 +367,6 @@
     });
 
 </script>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 
 {% endblock %}

--- a/templates/politician/politician_list.html
+++ b/templates/politician/politician_list.html
@@ -50,6 +50,7 @@
     </ul>
 
 <form name="state_code_form" method="get" action="{% url 'politician:politician_list' %}">
+    <input type="hidden" name="page" id="page_input" value="{{ current_page_number }}">
     {% csrf_token %}
     {% if state_code != "" %}
     <a href="#" onclick="showAllStates(); return false;">
@@ -304,56 +305,67 @@
     $(function() {
         $('#exclude_politician_analysis_done_id').change(function() {
             displayLoadingBanner();
+            $('#page_input').val("{{ current_page_number }}");  // Retain page number
             this.form.submit();
         });
 
         $('#hide_politicians_with_photos_id').change(function() {
             displayLoadingBanner();
+            $('#page_input').val("{{ current_page_number }}");  // Retain page number
             this.form.submit();
         });
 
         $('#organization_manual_intervention_needed_id').change(function() {
             displayLoadingBanner();
+            $('#page_input').val("{{ current_page_number }}");  // Retain page number
             this.form.submit();
         });
 
         $('#show_all_id').change(function() {
             displayLoadingBanner();
+            $('#page_input').val("{{ current_page_number }}");  // Retain page number
             this.form.submit();
         });
 
         $('#show_battleground_id').change(function() {
             displayLoadingBanner();
+            $('#page_input').val("{{ current_page_number }}");  // Retain page number
             this.form.submit();
         });
 
         $('#show_politicians_with_email_id').change(function() {
             displayLoadingBanner();
+            $('#page_input').val("{{ current_page_number }}");  // Retain page number
             this.form.submit();
         });
 
         $('#show_related_candidates_id').change(function() {
             displayLoadingBanner();
+            $('#page_input').val("{{ current_page_number }}");  // Retain page number
             this.form.submit();
         });
 
         $('#show_ocd_id_state_mismatch_id').change(function() {
             displayLoadingBanner();
+            $('#page_input').val("{{ current_page_number }}");  // Retain page number
             this.form.submit();
         });
 
         $('#state_code_id').change(function() {
             displayLoadingBanner();
+            $('#page_input').val("{{ current_page_number }}");  // Retain page number
             this.form.submit();
         });
 
         $('#politician_search_submit').click(function() {
             displayLoadingBanner();
+            $('#page_input').val("{{ current_page_number }}");  // Retain page number
             this.form.submit();
         });
 
         $('#was_candidate_recently_id').change(function() {
             displayLoadingBanner();
+            $('#page_input').val("{{ current_page_number }}");  // Retain page number
             this.form.submit();
         });
 

--- a/templates/politician/politician_list.html
+++ b/templates/politician/politician_list.html
@@ -51,10 +51,6 @@
 
 <form name="state_code_form" method="get" action="{% url 'politician:politician_list' %}">
     {% csrf_token %}
-    <input type="hidden" name="politician_search" value="{{ politician_search|default_if_none:'' }}" />
-    <input type="hidden" name="show_all" value="{{ show_all|default_if_none:0 }}" />
-    <input type="hidden" name="exclude_politician_analysis_done" value="{{ exclude_politician_analysis_done|default_if_none:0 }}" />
-
     {% if state_code != "" %}
     <a href="#" onclick="showAllStates(); return false;">
         show all states</a>
@@ -367,6 +363,5 @@
     });
 
 </script>
-<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 
 {% endblock %}


### PR DESCRIPTION
1)Implemented backend logic to support pagination with total_count, items_per_page, start_index, and end_index.
2) Added previous_page_url and next_page_url for navigation.
3) Conditionally hid pagination UI when items fit on a single page.
4)Updated the frontend to display "Previous" and "Next" links with the current page number.
