### PR TITLE
WV-876 Add instructions for Analysis checkbox on Candidate and Politician pages [TEAM REVIEW]

### DIFF
--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -790,7 +790,8 @@ th, td {
                   placeholder="Note about candidate..."></textarea>
         <input type="checkbox" name="candidate_analysis_done" id="candidate_analysis_done_id" value="1"
                 {% if candidate.candidate_analysis_done %}checked{% endif %} />
-        <label for="candidate_analysis_done_id" style="font-weight: normal !important;">Candidate Analysis Complete{% if candidate.candidate_analysis_done %}. <span style="color: darkgray">One of our team has researched this candidate and could not find more information.</span>{% endif %}</label>
+        <label for="candidate_analysis_done_id" style="font-weight: normal !important;">Candidate Analysis Complete. <span style="color: darkgray">One of our team has researched this candidate and could not find more information.</span>
+        </label>
     </div>
 </div>
 

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -585,7 +585,8 @@
                   placeholder="Note about politician..."></textarea>
         <input type="checkbox" name="politician_analysis_done" id="politician_analysis_done_id" value="1"
                 {% if politician.politician_analysis_done %}checked{% endif %} />
-        <label for="politician_analysis_done_id" style="font-weight: normal !important;">Politician Analysis Complete{% if politician.politician_analysis_done %}. <span style="color: darkgray">One of our team has researched this politician and could not find more information.</span>{% endif %}</label>
+        <label for="politician_analysis_done_id" style="font-weight: normal !important;">Politician Analysis Complete. <span style="color: darkgray">One of our team has researched this politician and could not find more information.</span>
+        </label>
     </div>
 </div>
 


### PR DESCRIPTION
Add instructions for the "Analysis" checkbox on the Candidate and Politician  pages. Removed the if/endif statement to make the "information" visible regardless of whether the checkbox is checked and whether the candidate/ politician are updated.