### PR TITLE
WV-707 Add New Candidate Process doesn't have a way to Add if there are potential matches

### DIFF
--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -1895,8 +1895,7 @@ def candidate_new_search_process_view(request):
         if not required_variables_found:
             messages.add_message(request, messages.ERROR,
                                  'No politician found. Please make sure you have entered '
-                                 '1) Candidate Name with State, or '
-                                 '2) Twitter Handle with State')
+                                 'candidate name with state')
         else:
             messages.add_message(request, messages.INFO, 'No politicians found that match your search.')
 

--- a/templates/candidate/candidate_new_search.html
+++ b/templates/candidate/candidate_new_search.html
@@ -197,7 +197,7 @@ th, td {
        {% if not name_and_state_found %}disabled style="background-color: grey; cursor: not-allowed;"{% endif %} />
 {% if not name_and_state_found %}
     <span style="color: red; margin-left: 10px;">To create new candidate, please make sure you have entered 
-        1) Candidate Name with State, or 2) Twitter Handle with State</span>
+        candidate name with state</span>
 {% endif %}
 </p>
 </form>

--- a/templates/candidate/candidate_new_search.html
+++ b/templates/candidate/candidate_new_search.html
@@ -192,8 +192,12 @@ th, td {
       cancel</a>
 {% endif %}
 <input name="submit_text" type="submit" value="Search" />
-{% if name_and_state_found and not politician_list_found %}
-<input name="create_new_candidate" type="submit" value="Create New Candidate" class="btn-primary" />
+<input name="create_new_candidate" type="submit" value="Create New Candidate" 
+       class="btn-primary" 
+       {% if not name_and_state_found %}disabled style="background-color: grey; cursor: not-allowed;"{% endif %} />
+{% if not name_and_state_found %}
+    <span style="color: red; margin-left: 10px;">To create new candidate, please make sure you have entered 
+        1) Candidate Name with State, or 2) Twitter Handle with State</span>
 {% endif %}
 </p>
 </form>


### PR DESCRIPTION
The create new candidate button is always shown and disable/greyed out if requirements are not met which are also shown right alongside the button as long it is disabled. The option is also disabled if when Twitter handle and state code are inputted and the candidate already exists.