### PR TITLE
Increase the maximum size of the data uploads to 20MB

### DIFF
--- a/WeVoteServerCheatSheet.md
+++ b/WeVoteServerCheatSheet.md
@@ -10,7 +10,7 @@ Didn't find a wevote directory
 `(3.11.8) stevepodell@Steves-MBP-M1-Dec2021 log % sudo mkdir wevote`
 Make the directory 
 `(3.11.8) stevepodell@Steves-MBP-M1-Dec2021 log % sudo chown stevepodell:staff wevote`
-Give it access to yourself at your (non sudo) privilege level.  Be sure to substitue your Mac user name for 'stevepodell'
+Give it access to yourself at your (non sudo) privilege level.  Be sure to substitute your Mac user name for 'stevepodell'
 
 #### Stopping postgres loaded by brew, and not setup as a daemon
 ```

--- a/config/base.py
+++ b/config/base.py
@@ -353,7 +353,7 @@ CSRF_TRUSTED_ORIGINS = [
     'http://localhost:8000', 'https://localhost:8000',
     'http://wevotedeveloper.com', 'https://wevotedeveloper.com',
 ]
-DATA_UPLOAD_MAX_MEMORY_SIZE = 6000000
+DATA_UPLOAD_MAX_MEMORY_SIZE = 20000000          # This does not seem to have any effect  June 24, 2025
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 4096
 
 CORS_ORIGIN_WHITELIST = (

--- a/config/settings.py
+++ b/config/settings.py
@@ -12,6 +12,9 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.8/ref/settings/
 """
 
+# June 24, 2025 -- The django/http is looking specifically in the settings.py file for this parameter
+DATA_UPLOAD_MAX_MEMORY_SIZE = 20000000
+
 try:
     # If the WeVoteServer/config/production.py file exists, use it
     from config.production import *


### PR DESCRIPTION
The DATA_UPLOAD_MAX_MEMORY_SIZE value in base.py does not seem to make any difference, since the lib/python3.11/site-packages/django/http/request.py file is looking specifically in the settings.py file for this parameter.