### PR TITLE
WV-861: Fix pagination — hide 'Previous page' on first page in footer

### DIFF
--- a/templates/politician/politician_list.html
+++ b/templates/politician/politician_list.html
@@ -263,7 +263,7 @@
     <!-- Pagination Section -->
 {% if not hide_pagination %}
 <span class="float-right">
-    {% if previous_page_url %}
+    {% if has_previous_page %}
     <a href="{{ previous_page_url }}" onclick="displayLoadingBanner()">Previous page</a>
     {% endif %}
     Page {{ current_page_number|add:1 }}


### PR DESCRIPTION
Updated the footer pagination in politician_list.html to use has_previous_page
instead of previous_page_url. Now, the Previous Page is only displayed correctly at the Top and Bottom.
