### PR TITLE
Downgrading selenium to Anu Priya's original version to solve this production server build problem:

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ zipp>=3.19.1             # not directly required, pinned by Snyk to avoid a vuln
 wordninja==2.0.0
 python-whois==0.9.4
 beautifulsoup4==4.12.3
-selenium==4.35.0
+selenium==4.25.0
 langdetect==1.0.9
 dnspython==2.8.0
 tldextract==5.1.2


### PR DESCRIPTION
Downgrading selenium to Anu Priya's original version to solve this production server build problem::

ERROR: Cannot install -r requirements.txt (line 19), -r requirements.txt (line 60) and -r requirements.txt (line 88) because these package versions have conflicting dependencies.

The conflict is caused by:
    elasticsearch 1.9.0 depends on urllib3<2.0 and >=1.8
    requests 2.32.2 depends on urllib3<3 and >=1.21.1
    selenium 4.35.0 depends on urllib3<3.0 and >=2.5.0