### PR TITLE
WV-2105: Accept email input to add campaign owner, managing email, voter, and organization objects appropriately

### DIFF
--- a/campaign/views_admin.py
+++ b/campaign/views_admin.py
@@ -11,6 +11,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.timezone import localtime, now
+import re
 
 import wevote_functions.admin
 from admin_tools.views import redirect_to_sign_in_page
@@ -25,6 +26,7 @@ from stripe_donations.models import StripeManager
 from volunteer_task.models import VOLUNTEER_ACTION_DUPLICATE_POLITICIAN_ANALYSIS, \
     VOLUNTEER_ACTION_POLITICIAN_DEDUPLICATION, VolunteerTaskManager
 from voter.models import fetch_voter_from_voter_device_link, voter_has_authority, VoterManager
+from email_outbound.models import EmailManager
 from wevote_functions.functions import convert_state_code_to_state_text, convert_to_int, \
     get_voter_api_device_id, positive_value_exists, STATE_CODE_MAP
 from wevote_functions.functions_date import generate_date_as_integer
@@ -235,8 +237,173 @@ def campaign_edit_owners_process_view(request):
     campaignx_owner_voter_we_vote_id = ''
 
     if positive_value_exists(incoming_campaignx_owner_we_vote_id):
-        # We allow either organization_we_vote_id or voter_we_vote_id
-        if 'org' in incoming_campaignx_owner_we_vote_id:
+        # We allow either organization_we_vote_id, voter_we_vote_id, or email
+
+        # check if incoming value is an email address
+        email_regex = r'^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}$'
+        if re.fullmatch(email_regex, incoming_campaignx_owner_we_vote_id):
+
+            # set email address
+            campaignx_owner_email = incoming_campaignx_owner_we_vote_id
+            incoming_email_manager = EmailManager()
+
+            # fetch email address object that is verified
+            results = incoming_email_manager.retrieve_primary_email_with_ownership_verified(
+                normalized_email_address=campaignx_owner_email,
+                read_only=False)
+
+            # check if email exists
+            if results['email_address_object_found']:
+                email_address_object = results['email_address_object']
+
+                # fetch voter related to email address
+                fetch_voter = False
+                voter_object_from_email = None
+
+                # check if email address object has valid voter we vote id and voter exists
+                temp_voter_we_vote_id = email_address_object.voter_we_vote_id
+                voter_fetch_results = voter_manager.retrieve_voter_by_we_vote_id(temp_voter_we_vote_id)
+
+                # if found set values
+                if temp_voter_we_vote_id and voter_fetch_results['voter_found']:
+                    fetch_voter = True
+                    voter_object_from_email = voter_fetch_results['voter']
+
+                # else, search for voter containing email
+                else:
+                    voter_fetch_results = voter_manager.retrieve_voter_by_email(email_address_object.normalized_email_address)
+
+                    # if found set values
+                    if voter_fetch_results['voter_found']:
+                        fetch_voter = True
+                        voter_object_from_email = voter_fetch_results['voter']
+                        temp_voter_we_vote_id = voter_object_from_email.we_vote_id
+
+                # check if voter related to email exists
+                if fetch_voter:
+
+                    # set voter id
+                    campaignx_owner_voter_we_vote_id = temp_voter_we_vote_id
+
+                    # set organization id
+                    campaignx_owner_organization_we_vote_id = \
+                        voter_manager.fetch_linked_organization_we_vote_id_by_voter_we_vote_id(
+                            campaignx_owner_voter_we_vote_id)
+
+                    # check if organization exists
+                    fetch_org_id_from_org_we_vote_id = organization_manager.fetch_organization_id(
+                        we_vote_id=campaignx_owner_organization_we_vote_id)
+
+                    # If no associated organization exists, create one
+                    if fetch_org_id_from_org_we_vote_id == 0:
+
+                        # create an organization
+                        create_organization_results = organization_manager.create_organization(
+                            organization_name=email_address_object.normalized_email_address,
+                            organization_email=email_address_object.normalized_email_address,
+                            # organization_type='I',
+                        )
+
+                        # if successfully created get organization object
+                        if create_organization_results['success']:
+                            organization_object_from_email = create_organization_results['organization']
+                            if organization_object_from_email.we_vote_id:
+
+                                # check and update voter name
+                                if not voter_object_from_email.first_name:
+                                    voter_first_name_update_results = voter_manager.update_voter_name_by_object(
+                                        voter=voter_object_from_email,
+                                        first_name="Voter-" + campaignx_owner_voter_we_vote_id)
+                                    if voter_first_name_update_results['success'] and \
+                                            voter_first_name_update_results['voter_updated']:
+                                        voter_object_from_email = voter_first_name_update_results['voter']
+
+                                # update voter with newly created organization id (needs voter to have name)
+                                voter_manager.alter_linked_organization_we_vote_id(voter=voter_object_from_email,
+                                                                                   linked_organization_we_vote_id=organization_object_from_email.we_vote_id)
+
+                                # set organization id
+                                campaignx_owner_organization_we_vote_id = organization_object_from_email.we_vote_id
+
+                    # update email object with voter we vote id
+                    email_address_object.voter_we_vote_id = campaignx_owner_voter_we_vote_id
+                    email_address_object.save()
+
+                    # set email address we vote id and verified status in found voter
+                    update_email_to_voter_results = voter_manager.update_voter_email_ownership_verified(voter=voter_object_from_email,
+                                                                        email_address_object=email_address_object)
+                    if not update_email_to_voter_results['success']:
+                        messages.add_message(request, messages.ERROR, 'issue with updating email to voter: '
+                                             + update_email_to_voter_results['status'])
+                # If no associated voter object exists, create one
+                else:
+
+                    voter_create_results = voter_manager.create_voter(
+                        email=email_address_object.normalized_email_address)
+
+                    # if successfully created get voter object
+                    if voter_create_results['voter_created']:
+                        voter_object_from_email = voter_create_results['voter']
+                        if voter_object_from_email.we_vote_id:
+
+                            # set voter id
+                            campaignx_owner_voter_we_vote_id = voter_object_from_email.we_vote_id
+
+                            # check if created voter has linked organization id
+                            if voter_object_from_email.linked_organization_we_vote_id:
+
+                                # set organization id
+                                campaignx_owner_organization_we_vote_id = voter_object_from_email.linked_organization_we_vote_id
+
+                            # check if organization exists
+                            fetch_org_id_from_org_we_vote_id = organization_manager.fetch_organization_id(
+                                we_vote_id=campaignx_owner_organization_we_vote_id)
+
+                            # If no associated organization exists, create one
+                            if fetch_org_id_from_org_we_vote_id == 0:
+
+                                # create an organization
+                                create_organization_results = organization_manager.create_organization(
+                                    organization_name=email_address_object.normalized_email_address,
+                                    organization_email=email_address_object.normalized_email_address,
+                                    # organization_type='I',
+                                )
+
+                                # if successfully created get organization object
+                                if create_organization_results['success']:
+                                    organization_object_from_email = create_organization_results['organization']
+                                    if organization_object_from_email.we_vote_id:
+
+                                        # check and update voter name
+                                        if not voter_object_from_email.first_name:
+                                            voter_first_name_update_results = voter_manager.update_voter_name_by_object(
+                                                voter=voter_object_from_email,
+                                                first_name="Voter-" + campaignx_owner_voter_we_vote_id)
+                                            if voter_first_name_update_results['success'] and \
+                                                    voter_first_name_update_results['voter_updated']:
+                                                voter_object_from_email = voter_first_name_update_results['voter']
+
+                                        # update voter with newly created organization id
+                                        voter_manager.alter_linked_organization_we_vote_id(
+                                            voter=voter_object_from_email,
+                                            linked_organization_we_vote_id=organization_object_from_email.we_vote_id)
+
+                                        # set organization id
+                                        campaignx_owner_organization_we_vote_id = organization_object_from_email.we_vote_id
+
+                            # update email object with voter we vote id
+                            email_address_object.voter_we_vote_id = campaignx_owner_voter_we_vote_id
+                            email_address_object.save()
+
+                            # set email address we vote id and verified status in found voter
+                            update_email_to_voter_results = voter_manager.update_voter_email_ownership_verified(
+                                voter=voter_object_from_email,
+                                email_address_object=email_address_object)
+                            if not update_email_to_voter_results['success']:
+                                messages.add_message(request, messages.ERROR, 'issue with updating email to voter: '
+                                                     + update_email_to_voter_results['status'])
+
+        elif 'org' in incoming_campaignx_owner_we_vote_id:
             campaignx_owner_organization_we_vote_id = incoming_campaignx_owner_we_vote_id
             campaignx_owner_voter_we_vote_id = \
                 voter_manager.fetch_voter_we_vote_id_by_linked_organization_we_vote_id(
@@ -245,6 +412,15 @@ def campaign_edit_owners_process_view(request):
             campaignx_owner_voter_we_vote_id = incoming_campaignx_owner_we_vote_id
             campaignx_owner_organization_we_vote_id = \
                 voter_manager.fetch_linked_organization_we_vote_id_by_voter_we_vote_id(campaignx_owner_voter_we_vote_id)
+
+        # makes sure wrong Voter or Organization IDs don't crash the site
+        if not campaignx_owner_organization_we_vote_id or \
+                campaignx_owner_organization_we_vote_id is None or \
+                not campaignx_owner_voter_we_vote_id or \
+                campaignx_owner_voter_we_vote_id is None:
+            messages.add_message(request, messages.ERROR, 'Voter or Organization does not exist')
+            campaignx_owner_organization_we_vote_id = ''
+            campaignx_owner_voter_we_vote_id = ''
 
     # Create new CampaignXOwner
     if positive_value_exists(campaignx_owner_organization_we_vote_id) or \


### PR DESCRIPTION
Summary:
Implementation for ticket [WV-2105](https://wevoteusa.atlassian.net/browse/WV-2105). 

Extended Campaign Owner creation to accept verified email addresses (in addition to We Vote IDs). The workflow now auto-resolves or creates the related Voter and Organization records as needed when adding campaign owner.

Functionality Implemented:

1. Detect and validate email input.
3. Lookup verified EmailAddress - reject if unverified or missing.
5. Resolve existing voter via voter_we_vote_id or email; create new voter if none exists.
7. Ensure linked organization exists—create one using the email as name if missing.
9. Auto-link voter - organization - email, then create CampaignXOwner.
11. Error message for all invalid states (to avoid crashes)

Scenarios Covered & Tested:

- Non email input → passes down after regex check
- Unverified / missing email → routes error message
- Verified email with voter + org present → campaign owner created
- Verified email with voter but missing/invalid org → new org created & linked
- - Caveat: Voter first name needed to updated linked_organization_we_vote_id field (if missing name given with format "Voter-{we_vote_id}") 
- Verified email missing voter link → voter found (by searching for voter with email) or created and linked properly
- Link email, voter and organizations appropriately

Outcome:
Consistent voter-org relationships and reliable Campaign Owner creation via verified emails.

[WV-2105]: https://wevoteusa.atlassian.net/browse/WV-2105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ