### PR TITLE
[WV-2158] Add "Twitter (click to sort)" link on Candidates page [TEAM REVIEW]

### DIFF
--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -446,6 +446,7 @@ def candidate_list_view(request):
     page = page if positive_value_exists(page) else 0  # Prevent negative pages
     run_scripts = positive_value_exists(request.GET.get('run_scripts', False))
     # run_scripts = True
+    sort_by = request.GET.get('sort_by', '')
     show_all = positive_value_exists(request.GET.get('show_all', False))
     show_all_elections = positive_value_exists(request.GET.get('show_all_elections', False))
     show_candidates_without_twitter = positive_value_exists(request.GET.get('show_candidates_without_twitter', False))
@@ -806,7 +807,18 @@ def candidate_list_view(request):
             candidate_query = candidate_query.filter(
                 Q(candidate_twitter_handle__isnull=True) | Q(candidate_twitter_handle=""))
 
-        candidate_query = candidate_query.order_by('candidate_name')
+        if sort_by == "twitter":
+            candidate_query = candidate_query.annotate(has_twitter=(
+                        Q(candidate_twitter_handle__isnull=False, candidate_twitter_handle__gt='') |
+                        Q(candidate_twitter_handle2__isnull=False, candidate_twitter_handle2__gt='') |
+                        Q(candidate_twitter_handle3__isnull=False, candidate_twitter_handle3__gt='')))
+            candidate_query = candidate_query.order_by(
+                '-has_twitter',
+                '-twitter_followers_count',
+                'candidate_name')
+        else:
+            candidate_query = candidate_query.order_by('candidate_name')
+
         candidate_list_count = candidate_query.count()
 
         candidate_count_start = 0
@@ -1342,6 +1354,7 @@ def candidate_list_view(request):
         'show_marquee_or_battleground':             show_marquee_or_battleground,
         'show_this_year_of_candidates':             show_this_year_of_candidates,
         'show_candidates_with_email':              show_candidates_with_email,
+        'sort_by':                                  sort_by,
         'state_code':                               state_code,
         'state_list':                               sorted_state_list,
         'total_twitter_handles':                    total_twitter_handles,

--- a/templates/candidate/candidate_list.html
+++ b/templates/candidate/candidate_list.html
@@ -29,6 +29,7 @@
     <input type="hidden" name="show_candidates_without_twitter" value="{{ show_candidates_without_twitter }}" />
     <input type="hidden" name="show_candidates_with_best_twitter_options" value="{{ show_candidates_with_best_twitter_options }}" />
     <input type="hidden" name="show_candidates_with_twitter_options" value="{{ show_candidates_with_twitter_options }}" />
+    <input type="hidden" name="sort_by" value="{{ sort_by }}" />
 {% if find_candidates_linked_to_multiple_offices %}<input type="hidden" name="find_candidates_linked_to_multiple_offices" value="1" />{% endif %}
 
     {% if election_list %}
@@ -380,6 +381,7 @@
     <input type="hidden" name="show_election_statistics" value="{{ show_election_statistics }}" />
     <input type="hidden" name="show_marquee_or_battleground" value="{{ show_marquee_or_battleground }}" />
     <input type="hidden" name="show_this_year_of_candidates" value="{{ show_this_year_of_candidates }}" />
+    <input type="hidden" name="sort_by" value="{{ sort_by }}">
 
     <input type="submit" value="Search for Candidate" />
 
@@ -461,13 +463,28 @@
             <tr>
                 <th>&nbsp;</th>
                 <th>&nbsp;</th>
-                <th>Candidate Name</th>
+                <th>
+                    <a href="?{{ request.GET.urlencode|cut:'&sort_by=twitter'|cut:'&sort_by=candidate' }}&sort_by=candidate">
+                    {% if sort_by == "candidate" %}<strong>Candidate Name</strong>{% else %}Candidate Name{% endif %}
+                    </a>
+                </th>
                 <th>State</th>
               {% if not google_civic_election_id %}
                 <th>Election</th>
               {% endif %}
                 <th>Office</th>
-                <th>Twitter Handle</th>
+                <th>
+                    {% if sort_by == "twitter" %}
+                        <a href="?{{ request.GET.urlencode|cut:'&sort_by=twitter' }}">
+                        Twitter <span class="glyphicon glyphicon-triangle-bottom"></span>
+                        </a>
+                    {% else %}
+                        <a href="?{{ request.GET.urlencode|cut:'&sort_by=candidate' }}&sort_by=twitter">
+
+                        Twitter (click to sort)
+                        </a>
+                    {% endif %}
+                </th>
                 <th>Google Search Results</th>
                 <th>Website / Facebook / Instagram / Email</th>
                 <th>IDs</th>


### PR DESCRIPTION
***WARNING***: I'm confident this may have a conflict with my PR for WV-2090. It's only one line, so it should be an easy fix. If that PR makes it through, I'll have to adjust this one.


Notes: Defaults to sorting by candidate name when candidates have the same amount of Twitter followers. Also, candidates with zero Twitter followers are always placed above candidates without Twitters.

Sort by Candidate:
<img width="1282" height="1088" alt="image" src="https://github.com/user-attachments/assets/f96b3ff3-c9a3-4d04-90f4-f342d4b8f285" />
Sort by Twitter:
<img width="1311" height="1059" alt="image" src="https://github.com/user-attachments/assets/53cd208d-0b9d-47a4-bd50-0e928a1efa34" />

