### PR TITLE
[WV-2171] Added atomic transaction to 'Link Candidates' for loop

### DIFF
--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -12,6 +12,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.messages import get_messages
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
 from django.db.models import F, Q
 from django.db.models.functions import Length
 from django.http import HttpResponse
@@ -3610,29 +3611,31 @@ def politician_edit_process_view(request):
     # ##################################
     # Link Candidates to this Politician
     t0 = time()
-    for candidate in related_candidate_list:
-        if positive_value_exists(candidate.id):
-            variable_name = "link_candidate_" + str(candidate.id) + "_to_politician"
-            link_candidate = positive_value_exists(request.POST.get(variable_name, False))
-            if positive_value_exists(link_candidate) and positive_value_exists(politician_we_vote_id):
-                candidate.politician_id = politician_id
-                candidate.politician_we_vote_id = politician_we_vote_id
-                candidate.seo_friendly_path = politician_on_stage.seo_friendly_path
-                if not positive_value_exists(candidate.vote_usa_politician_id) and \
-                        positive_value_exists(vote_usa_politician_id):
-                    candidate.vote_usa_politician_id = vote_usa_politician_id
-                candidate.save()
-                # Now update positions
-                results = position_list_manager.update_politician_we_vote_id_in_all_positions(
-                    candidate_we_vote_id=candidate.we_vote_id,
-                    new_politician_id=politician_id,
-                    new_politician_we_vote_id=politician_we_vote_id)
+    # Transaction ensures all candidate saves and position_list_manager updates are committed together
+    with transaction.atomic():
+        for candidate in related_candidate_list:
+            if positive_value_exists(candidate.id):
+                variable_name = "link_candidate_" + str(candidate.id) + "_to_politician"
+                link_candidate = positive_value_exists(request.POST.get(variable_name, False))
+                if positive_value_exists(link_candidate) and positive_value_exists(politician_we_vote_id):
+                    candidate.politician_id = politician_id
+                    candidate.politician_we_vote_id = politician_we_vote_id
+                    candidate.seo_friendly_path = politician_on_stage.seo_friendly_path
+                    if not positive_value_exists(candidate.vote_usa_politician_id) and \
+                            positive_value_exists(vote_usa_politician_id):
+                        candidate.vote_usa_politician_id = vote_usa_politician_id
+                    candidate.save()
+                    # Now update positions
+                    results = position_list_manager.update_politician_we_vote_id_in_all_positions(
+                        candidate_we_vote_id=candidate.we_vote_id,
+                        new_politician_id=politician_id,
+                        new_politician_we_vote_id=politician_we_vote_id)
 
-                messages.add_message(request, messages.INFO,
-                                     'Candidate linked, number of positions changed: {number_changed}'
-                                     ''.format(number_changed=results['number_changed']))
-            else:
-                pass
+                    messages.add_message(request, messages.INFO,
+                                        'Candidate linked, number of positions changed: {number_changed}'
+                                        ''.format(number_changed=results['number_changed']))
+                else:
+                    pass
 
     performance_list.append({
         'name': 'Link Candidates',


### PR DESCRIPTION
Reference: [transaction.atomic() documentation](https://docs.djangoproject.com/en/5.2/topics/db/transactions/)

By wrapping `candidate.save()` and position_list_manager.update_politician_we_vote_id_in_all_positions() inside a `transaction.atomic()` block, each iteration of the loop will queue the database updates into a single transaction. This transaction will only be committed once the `for` loop completes, reducing the overhead compared to committing after every individual operation.

Adding this change has not caused any increase in test failures.

This approach is considered safe under the following assumptions:
1. The live back-end database is PostgreSQL, as it is in our local environment.
2. Both `Politician.save()` and `PoliticianListManager.update_politician_we_vote_id_in_all_positions() `have a low risk of failure. This is reasonable since their core save functionality is unchanged (only field values might be changed), and we haven't been adding explicit error handling.
3. If either function fails within the transaction, we would want all changes to be rolled back and an exception to be raised, preserving atomicity.