### PR TITLE
[WV-2180] Added enum values to pass through Politician Edit url redirect

### DIFF
--- a/politician/enums.py
+++ b/politician/enums.py
@@ -1,0 +1,163 @@
+from enum import Enum
+
+class SpeedStatistics(Enum):
+    RET_POLITICIAN_FF_ERROR = {
+        "name": "Retrieve politician form fields",
+        "description": "These is done becase there was an error on the edit_process_view and the voter needs to try again",
+    }
+    RET_POLITICIAN_SEO = {
+        "name": "PoliticianSEOFriendlyPath",
+        "description": "Retrieve PoliticianSEOFriendlyPath objects for this politician",
+    }
+    RET_ORGS = {
+        "name": "Find organization(s) connected to this politician by politician_we_vote_id",
+        "description": "Retrieve Organization objects for this politician",
+    }
+    ATT_FOLLOW_ORG = {
+        "name": "Attach FollowOrganization information",
+        "description": "Attach organization_is_following_politician to the position",
+    }
+    RET_CANDIDATES = {
+        "name": "Find Candidate children of this politician",
+        "description": "Retrieve CandidateCampaign objects for this politician",
+    }
+    RET_DUPLICATE_POLITICIANS = {
+        "name": "Find possible duplicate politicians",
+        "description": "Retrieve Politician objects for this politician",
+    }
+    RET_REPS_LINKED = {
+        "name": "Find Representatives Linked to this Politician",
+        "description": "Retrieve Representative objects for this politician",
+    }
+    RET_REPS_TO_LINK = {
+        "name": "Find Representatives to Link to this Politician",
+        "description": "Retrieve Representative objects for this politician",
+    }
+    RET_CAMPAIGNX = {
+        "name": "Find Campaigns Linked to this Politician",
+        "description": "Retrieve CampaignX objects for this politician",
+    }
+    RET_POL_LINKED_CAMPAIGNX = {
+        "name": "PoliticianLinkedCampaignxWeVoteId",
+        "description": "Retrieve politician_linked_campaignx_we_vote_id",
+    }
+    RET_REC_POLITICIANS = {
+        "name": "Find Recommendations related to this Politician",
+        "description": "Retrieve RecommendedPoliticianLinkByPolitician objects for this politician",
+    }
+    POL_CHANGE_LOG = {
+        "name": "PoliticianChangeLogFilter",
+        "description": "Query PoliticianChangeLog and filter on politician_we_vote_id, order by log_datetime",
+    }
+    BG_COLOR = {
+        "name": "Background Color Generation",
+        "description": "Generate background color for politician profile image",
+    }
+    RET_POLITICIAN_FF = {
+        "name": "Retrieve politician form fields",
+        "description": "Retrieve form fields from Post request",
+    }
+    RET_EXISTING_POLITICIAN = {
+        "name": "Retrieve existing politician",
+        "description": "Retrieve existing politician from db",
+    }
+    RET_POLITICIAN_DUPS = {
+        "name": "Retrieve existing politician duplicates",
+        "description": "Retrieve existing politician duplicates from db",
+    }
+    SET_URL_VARS = {
+        "name": "Set url_variables",
+        "description": "Set url_variables for redirect",
+    }
+    CREATE_POLITICIAN = {
+        "name": "Create new politician",
+        "description": "Create new politician object and name and state code.",
+    }
+    UP_IMG = {
+        "name": "Process incoming uploaded photo if there is one",
+        "description": "Process incoming uploaded photo if there is one",
+    }
+    PROC_FIELDS = {
+        "name": "Process politician fields",
+        "description": "Processing all other fields in field",
+    }
+    PROC_TWITTER_URL_POLITICAL_PARTY = {
+        "name": "Process politician Twitter, url, political_party fields",
+        "description": "Process politician Twitter, url, political_party fields",
+    }
+    PROC_SEO_PATH = {
+        "name": "Process or generate SEO friendly path",
+        "description": "Process or generate SEO friendly path",
+    }
+    PROC_TIKTOK = {
+        "name": "Process tiktok_url field",
+        "description": "Process tiktok_url field",
+    }
+    PROC_TWITTER_FAILING = {
+        "name": "Process twitter_handle_updates_failing field",
+        "description": "Process twitter_handle_updates_failing field",
+    }
+    PROC_IDS = {
+        "name": "Process Ids",
+        "description": "Process vote_smart_id, politician_we_vote_id, vote_usa_politician_id, wikipedia_url, youtube_url fields if they exist",
+    }
+    SAVE_POLITICIAN = {
+        "name": "Save politician",
+        "description": "Save politician object",
+    }
+    PROC_BALLOTPEDIA = {
+        "name": "Process ballotpedia_politician_url field",
+        "description": "Process ballotpedia_politician_url field",
+    }
+    UP_CAMPAIGNX = {
+        "name": "Update CampaignX from politician",
+        "description": "Update linked CampaignX from politician if one is found",
+    }
+    UP_REPRESENTATIVE = {
+        "name": "Update Representative from politician",
+        "description": "Update linked Representative from politician if one is found",
+    }
+    RET_REP_MNGR_FAIL = {
+        "name": "Query Representative Manager",
+        "description": "Queried Representative Manager, but no Representative found for this politician.",
+    }
+    UP_PRLL_FIELDS = {
+        "name": "Update parallel fields",
+        "description": "Update parallel fields with years in related objects",
+    }
+    UNLNK_CANDIDATES = {
+        "name": "Unlink Candidates",
+        "description": "Unlink Candidates",
+    }
+    UNLNK_REPS = {
+        "name": "Unlink Representatives",
+        "description": "Unlink Representatives",
+    }
+    RET_CANDIDATES_TO_LINK = {
+        "name": "Find Candidates to Link",
+        "description": "Retrieve Candidates to Link",
+    }
+    LINK_CANDIDATES = {
+        "name": "Link Candidates",
+        "description": "Link Candidates",
+    }
+    LINK_REPS = {
+        "name": "Link Representatives",
+        "description": "Link Representatives",
+    }
+    UP_SEO = {
+        "name": "Update seo_friendly_path(s)",
+        "description": "Update linked CampainXs, Candidates, Representatives with seo_friendly_path",
+    }
+    UP_SUPS_COUNT = {
+        "name": "Update supporters_count",
+        "description": "Update supporters_count",
+    }
+    CHANGE_LOG_VOLUNTEER = {
+        "name": "Change log and volunteer scoring",
+        "description": "Change log and volunteer scoring",
+    }
+    UP_MSGS = {
+        "name": "Update needed messages",
+        "description": "Update needed messages",
+    }

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -1569,7 +1569,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
 
     performance_list.append({
         'enum_key': 'RET_POLITICIAN_FF_ERROR',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
     
     try:
@@ -1656,7 +1656,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         
         performance_list.append({
             'enum_key': 'RET_POLITICIAN_SEO',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         t0 = time()
@@ -1692,7 +1692,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         
         performance_list.append({
             'enum_key': 'RET_ORGS',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         # ##################################
@@ -1737,7 +1737,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         
         performance_list.append({
             'enum_key': 'ATT_FOLLOW_ORG',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         # ##################################
@@ -1774,7 +1774,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         
         performance_list.append({
             'enum_key': 'RET_CANDIDATES',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         # ##################################
@@ -1887,7 +1887,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
 
         performance_list.append({
             'enum_key': 'RET_DUPLICATE_POLITICIANS',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         # ##################################
@@ -1901,7 +1901,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         
         performance_list.append({
             'enum_key': 'RET_REPS_LINKED',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         # ##################################
@@ -1913,7 +1913,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
 
         performance_list.append({
             'enum_key': 'RET_REPS_TO_LINK',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         # ##################################
@@ -1929,7 +1929,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         
         performance_list.append({
             'enum_key': 'RET_CAMPAIGNX',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         t0 = time()
@@ -1943,7 +1943,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         
         performance_list.append({
             'enum_key': 'RET_POL_LINKED_CAMPAIGNX',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         # ##################################
@@ -1955,7 +1955,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
 
         performance_list.append({
             'enum_key': 'RET_CAMPAIGNX',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         # ##################################
@@ -1974,7 +1974,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         
         performance_list.append({
             'enum_key': 'RET_REC_POLITICIANS',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         politician_linked_campaignx_we_vote_id = ''
@@ -2002,7 +2002,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
 
         performance_list.append({
             'enum_key': 'POL_CHANGE_LOG',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         t0 = time()
@@ -2015,7 +2015,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
 
         performance_list.append({
             'enum_key': 'BG_COLOR',
-            'time_difference': time() - t0,
+            'time_difference': round(time() - t0, 4),
         })
 
         ##################################
@@ -2547,7 +2547,7 @@ def politician_edit_process_view(request):
 
     performance_list.append({
         'enum_key': 'RET_POLITICIAN_FF',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     from campaign.controllers import update_campaignx_from_politician
@@ -2572,7 +2572,7 @@ def politician_edit_process_view(request):
 
     performance_list.append({
         'enum_key': 'RET_EXISTING_POLITICIAN',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # Check to see if there is a duplicate politician already saved
@@ -2646,7 +2646,7 @@ def politician_edit_process_view(request):
     
     performance_list.append({
         'enum_key': 'RET_POLITICIAN_DUPS',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # We can use the same url_variables with any processing failures below
@@ -2691,7 +2691,7 @@ def politician_edit_process_view(request):
     
     performance_list.append({
         'enum_key': 'SET_URL_VARS',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     if not success:
@@ -2727,7 +2727,7 @@ def politician_edit_process_view(request):
 
                 performance_list.append({
                     'enum_key': 'CREATE_POLITICIAN',
-                    'time_difference': time() - t0,
+                    'time_difference': round(time() - t0, 4),
                 })
 
         if politician_on_stage_found:
@@ -2804,7 +2804,7 @@ def politician_edit_process_view(request):
 
             performance_list.append({
                 'enum_key': 'UP_IMG',
-                'time_difference': time() - t0,
+                'time_difference': round(time() - t0, 4),
             })
 
             # ###############################################
@@ -3000,7 +3000,7 @@ def politician_edit_process_view(request):
 
             performance_list.append({
                 'enum_key': 'PROC_FIELDS',
-                'time_difference': time() - t0,
+                'time_difference': round(time() - t0, 4),
             })
 
             if not positive_value_exists(politician_on_stage.organization_we_vote_id):
@@ -3025,7 +3025,7 @@ def politician_edit_process_view(request):
 
                 performance_list.append({
                     'enum_key': 'RET_ORGS',
-                    'time_difference': time() - t0,
+                    'time_difference': round(time() - t0, 4),
                 })
 
             if politician_contact_form_url is not False:
@@ -3223,7 +3223,7 @@ def politician_edit_process_view(request):
             
             performance_list.append({
                 'enum_key': 'PROC_TWITTER_URL_POLITICAL_PARTY',
-                'time_difference': time() - t0,
+                'time_difference': round(time() - t0, 4),
             })
 
 
@@ -3274,7 +3274,7 @@ def politician_edit_process_view(request):
 
             performance_list.append({
                 'enum_key': 'PROC_SEO_PATH',
-                'time_difference': time() - t0,
+                'time_difference': round(time() - t0, 4),
             })
 
             # #################################################
@@ -3297,7 +3297,7 @@ def politician_edit_process_view(request):
              
             performance_list.append({
                 'enum_key': 'PROC_TIKTOK',
-                'time_difference': time() - t0,
+                'time_difference': round(time() - t0, 4),
             })
 
             # if politician_on_stage.twitter_handle_updates_failing != twitter_handle_updates_failing:
@@ -3335,7 +3335,7 @@ def politician_edit_process_view(request):
 
             performance_list.append({
                 'enum_key': 'PROC_TWITTER_FAILING',
-                'time_difference': time() - t0,
+                'time_difference': round(time() - t0, 4),
             })
 
             # #################################################
@@ -3368,7 +3368,7 @@ def politician_edit_process_view(request):
 
             performance_list.append({
                 'enum_key': 'PROC_IDS',
-                'time_difference': time() - t0,
+                'time_difference': round(time() - t0, 4),
             })
 
             # #################################################
@@ -3381,7 +3381,7 @@ def politician_edit_process_view(request):
 
             performance_list.append({
                 'enum_key': 'SAVE_POLITICIAN',
-                'time_difference': time() - t0,
+                'time_difference': round(time() - t0, 4),
             })
 
             # #################################################
@@ -3401,7 +3401,7 @@ def politician_edit_process_view(request):
 
             performance_list.append({
                 'enum_key': 'PROC_BALLOTPEDIA',
-                'time_difference': time() - t0,
+                'time_difference': round(time() - t0, 4),
             })
 
             if positive_value_exists(politician_on_stage.linked_campaignx_we_vote_id):
@@ -3418,7 +3418,7 @@ def politician_edit_process_view(request):
 
                 performance_list.append({
                     'enum_key': 'UP_CAMPAIGNX',
-                    'time_difference': time() - t0,
+                    'time_difference': round(time() - t0, 4),
                 })
 
             # #################################################
@@ -3441,12 +3441,12 @@ def politician_edit_process_view(request):
                 
                 performance_list.append({
                     'enum_key': 'UP_REPRESENTATIVE',
-                    'time_difference': time() - t0,
+                    'time_difference': round(time() - t0, 4),
                 })
             else:
                 performance_list.append({
                     'enum_key': 'RET_REP_MNGR_FAIL',
-                    'time_difference': time() - t0,
+                    'time_difference': round(time() - t0, 4),
                 })
 
         else:
@@ -3461,7 +3461,7 @@ def politician_edit_process_view(request):
             
             performance_list.append({
                 'enum_key': 'SAVE_POLITICIAN',
-                'time_difference': time() - t0,
+                'time_difference': round(time() - t0, 4),
             })
 
     except Exception as e:
@@ -3485,7 +3485,7 @@ def politician_edit_process_view(request):
 
     performance_list.append({
         'enum_key': 'UP_PRLL_FIELDS',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # ##################################
@@ -3525,7 +3525,7 @@ def politician_edit_process_view(request):
 
     performance_list.append({
         'enum_key': 'UNLNK_CANDIDATES',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # ##################################
@@ -3557,7 +3557,7 @@ def politician_edit_process_view(request):
 
     performance_list.append({
         'enum_key': 'UNLNK_REPS',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # ##################################
@@ -3570,7 +3570,7 @@ def politician_edit_process_view(request):
 
     performance_list.append({
         'enum_key': 'RET_CANDIDATES_TO_LINK',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # ##################################
@@ -3604,7 +3604,7 @@ def politician_edit_process_view(request):
 
     performance_list.append({
         'enum_key': 'LINK_CANDIDATES',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # ##################################
@@ -3616,7 +3616,7 @@ def politician_edit_process_view(request):
     
     performance_list.append({
         'enum_key': 'RET_REPS_TO_LINK',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # ##################################
@@ -3637,7 +3637,7 @@ def politician_edit_process_view(request):
     
     performance_list.append({
         'enum_key': 'LINK_REPS',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # ##################################
@@ -3773,7 +3773,7 @@ def politician_edit_process_view(request):
 
     performance_list.append({
         'enum_key': 'UP_SEO',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # ####################################################################
@@ -3846,7 +3846,7 @@ def politician_edit_process_view(request):
 
     performance_list.append({
         'enum_key': 'UP_SUPS_COUNT',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # ##################################################
@@ -3920,7 +3920,7 @@ def politician_edit_process_view(request):
     
     performance_list.append({
         'enum_key': 'CHANGE_LOG_VOLUNTEER',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     t0 = time()
@@ -3934,7 +3934,7 @@ def politician_edit_process_view(request):
     
     performance_list.append({
         'enum_key': 'UP_MSGS',
-        'time_difference': time() - t0,
+        'time_difference': round(time() - t0, 4),
     })
 
     # Since a pointer to performance_list was attached to performance_dict above, the performance_list

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -69,6 +69,7 @@ TWITTER_API_ON = positive_value_exists(get_environment_variable("TWITTER_API_ON"
 WE_VOTE_SERVER_ROOT_URL = get_environment_variable("WE_VOTE_SERVER_ROOT_URL")
 WEB_APP_ROOT_URL = get_environment_variable("WEB_APP_ROOT_URL")
 from wevote_functions import functions_test_links
+from politician.enums import SpeedStatistics
 
 logger = wevote_functions.admin.get_logger(__name__)
 
@@ -1567,8 +1568,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
     politician_on_stage = Politician()
 
     performance_list.append({
-        'name': 'Retrieve politician form fields',
-        'description': 'These is done becase there was an error on the edit_process_view and the voter needs to try again',
+        'enum_key': 'RET_POLITICIAN_FF_ERROR',
         'time_difference': time() - t0,
     })
     
@@ -1655,8 +1655,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
                 status += 'ERROR_RETRIEVING_FROM_ORGANIZATION: ' + str(e) + ' '
         
         performance_list.append({
-            'name': 'PoliticianSEOFriendlyPath',
-            'description': 'Retrieve PoliticianSEOFriendlyPath objects for this politician',
+            'enum_key': 'RET_POLITICIAN_SEO',
             'time_difference': time() - t0,
         })
 
@@ -1692,16 +1691,9 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             organization_we_vote_id_linked_to_politician = politician_on_stage.organization_we_vote_id
         
         performance_list.append({
-            'name': 'Find organization(s) connected to this politician by politician_we_vote_id',
-            'description': 'Retrieve Organization objects for this politician',
+            'enum_key': 'RET_ORGS',
             'time_difference': time() - t0,
         })
-        # performance_snapshot = {
-        #     'name': 'Find organization(s) connected to this politician by politician_we_vote_id',
-        #     'description': 'Retrieve Organization objects for this politician',
-        #     'time_difference': t1 - t0,
-        # }
-        # performance_list.append(performance_snapshot)
 
         # ##################################
         # Attach FollowOrganization information
@@ -1744,8 +1736,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
                 politician_position.organization_is_following_politician = True
         
         performance_list.append({
-            'name': 'Attach FollowOrganization information',
-            'description': 'Attach organization_is_following_politician to the position',
+            'enum_key': 'ATT_FOLLOW_ORG',
             'time_difference': time() - t0,
         })
 
@@ -1782,8 +1773,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
                 linked_candidate_list = modified_linked_candidate_list
         
         performance_list.append({
-            'name': 'Find Candidate "children" of this politician',
-            'description': 'Retrieve CandidateCampaign objects for this politician',
+            'enum_key': 'RET_CANDIDATES',
             'time_difference': time() - t0,
         })
 
@@ -1896,8 +1886,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
                 pass
 
         performance_list.append({
-            'name': 'Find possible duplicate politicians',
-            'description': 'Retrieve Politician objects for this politician',
+            'enum_key': 'RET_DUPLICATE_POLITICIANS',
             'time_difference': time() - t0,
         })
 
@@ -1911,8 +1900,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             linked_representative_list = list(queryset)
         
         performance_list.append({
-            'name': 'Find Representatives Linked to this Politician',
-            'description': 'Retrieve Representative objects for this politician',
+            'enum_key': 'RET_REPS_LINKED',
             'time_difference': time() - t0,
         })
 
@@ -1924,8 +1912,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         related_representative_list = find_representatives_to_link_to_this_politician(politician=politician_on_stage)
 
         performance_list.append({
-            'name': 'Find Representatives to Link to this Politician',
-            'description': 'Retrieve Representative objects for this politician',
+            'enum_key': 'RET_REPS_TO_LINK',
             'time_difference': time() - t0,
         })
 
@@ -1941,8 +1928,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             linked_campaignx_list = list(queryset)
         
         performance_list.append({
-            'name': 'Find Campaigns Linked to this Politician',
-            'description': 'Retrieve CampaignX objects for this politician',
+            'enum_key': 'RET_CAMPAIGNX',
             'time_difference': time() - t0,
         })
 
@@ -1956,8 +1942,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             politician_linked_campaignx_we_vote_id = politician_on_stage.linked_campaignx_we_vote_id
         
         performance_list.append({
-            'name': 'PoliticianLinkedCampaignxWeVoteId',
-            'description': 'Retrieve politician_linked_campaignx_we_vote_id',
+            'enum_key': 'RET_POL_LINKED_CAMPAIGNX',
             'time_difference': time() - t0,
         })
 
@@ -1969,8 +1954,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         related_campaignx_list = find_campaignx_list_to_link_to_this_politician(politician=politician_on_stage)
 
         performance_list.append({
-            'name': 'Find Campaigns to Link to this Politician',
-            'description': 'Retrieve CampaignX objects for this politician',
+            'enum_key': 'RET_CAMPAIGNX',
             'time_difference': time() - t0,
         })
 
@@ -1989,8 +1973,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             recommended_politicians_list = Politician.objects.filter(we_vote_id__in=recommended_politician_we_vote_ids)
         
         performance_list.append({
-            'name': 'Find Recommendations related to this Politician',
-            'description': 'Retrieve RecommendedPoliticianLinkByPolitician objects for this politician',
+            'enum_key': 'RET_REC_POLITICIANS',
             'time_difference': time() - t0,
         })
 
@@ -2018,8 +2001,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         change_log_list = list(queryset)
 
         performance_list.append({
-            'name': 'PoliticianChangeLogFilter',
-            'description': 'Query PoliticianChangeLog and filter on politician_we_vote_id, order by log_datetime',
+            'enum_key': 'POL_CHANGE_LOG',
             'time_difference': time() - t0,
         })
 
@@ -2032,10 +2014,16 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
                 messages.add_message(request, messages.INFO, "Background color generated")
 
         performance_list.append({
-            'name': 'Background Color Generation',
-            'description': 'Background Color Generation',
+            'enum_key': 'BG_COLOR',
             'time_difference': time() - t0,
         })
+
+        ##################################
+        # Use performance_dict enum_key to add name and description
+        for _, performance_dict_list in performance_dict.items():
+            for performance_item in performance_dict_list:
+                performance_item.update(SpeedStatistics[performance_item['enum_key']].value)
+
 
         if 'localhost' in WEB_APP_ROOT_URL:
             web_app_root_url = 'https://localhost:3000'
@@ -2558,8 +2546,7 @@ def politician_edit_process_view(request):
     # is_battleground_race_ values taken in below
 
     performance_list.append({
-        'name': 'Retrieve politician form fields',
-        'description': 'Retrieve form fields from Post request',
+        'enum_key': 'RET_POLITICIAN_FF',
         'time_difference': time() - t0,
     })
 
@@ -2584,8 +2571,7 @@ def politician_edit_process_view(request):
             success = False
 
     performance_list.append({
-        'name': 'Retrieve existing politician',
-        'description': 'Retrieve existing politician from db',
+        'enum_key': 'RET_EXISTING_POLITICIAN',
         'time_difference': time() - t0,
     })
 
@@ -2659,8 +2645,7 @@ def politician_edit_process_view(request):
             success = False
     
     performance_list.append({
-        'name': 'Retrieve existing politician duplicates',
-        'description': 'Retrieve existing politician duplicates from db',
+        'enum_key': 'RET_POLITICIAN_DUPS',
         'time_difference': time() - t0,
     })
 
@@ -2705,8 +2690,7 @@ def politician_edit_process_view(request):
                     "&youtube_url=" + str(youtube_url)
     
     performance_list.append({
-        'name': 'Set url_variables',
-        'description': 'Set url_variables',
+        'enum_key': 'SET_URL_VARS',
         'time_difference': time() - t0,
     })
 
@@ -2742,8 +2726,7 @@ def politician_edit_process_view(request):
                 politician_on_stage_found = True
 
                 performance_list.append({
-                    'name': 'Create new politician',
-                    'description': 'Create new politician object and name and state code.',
+                    'enum_key': 'CREATE_POLITICIAN',
                     'time_difference': time() - t0,
                 })
 
@@ -2820,8 +2803,7 @@ def politician_edit_process_view(request):
                         # politician_on_stage.profile_image_background_color_needed = False
 
             performance_list.append({
-                'name': 'Process incoming uploaded photo',
-                'description': 'Process incoming uploaded photo if there is one',
+                'enum_key': 'UP_IMG',
                 'time_difference': time() - t0,
             })
 
@@ -3017,8 +2999,7 @@ def politician_edit_process_view(request):
                     status += 'ERROR_RETRIEVING_FROM_ORGANIZATION: ' + str(e) + ' '
 
             performance_list.append({
-                'name': 'Process politician fields',
-                'description': 'Processing all other fields in field',
+                'enum_key': 'PROC_FIELDS',
                 'time_difference': time() - t0,
             })
 
@@ -3043,8 +3024,7 @@ def politician_edit_process_view(request):
                     status += 'ERROR_RETRIEVING_ORGANIZATION_ATTACHED_TO_POLITICIAN: ' + str(e) + ' '
 
                 performance_list.append({
-                    'name': 'Find Linked Organization',
-                    'description': 'Find Organization that already thinks it is linked to this politician.',
+                    'enum_key': 'RET_ORGS',
                     'time_difference': time() - t0,
                 })
 
@@ -3242,8 +3222,7 @@ def politician_edit_process_view(request):
                 politician_on_stage.state_code = state_code
             
             performance_list.append({
-                'name': 'Process politician Twitter, url, political_party fields',
-                'description': 'Process politician Twitter, url, political_party fields',
+                'enum_key': 'PROC_TWITTER_URL_POLITICAL_PARTY',
                 'time_difference': time() - t0,
             })
 
@@ -3294,8 +3273,7 @@ def politician_edit_process_view(request):
                     status += seo_results['status'] + ' '
 
             performance_list.append({
-                'name': 'Process or generate SEO friendly path',
-                'description': 'Process or generate SEO friendly path',
+                'enum_key': 'PROC_SEO_PATH',
                 'time_difference': time() - t0,
             })
 
@@ -3318,8 +3296,7 @@ def politician_edit_process_view(request):
                 politician_on_stage.tiktok_url = tiktok_url
              
             performance_list.append({
-                'name': 'Process tiktok_url field',
-                'description': 'Process tiktok_url field',
+                'enum_key': 'PROC_TIKTOK',
                 'time_difference': time() - t0,
             })
 
@@ -3357,8 +3334,7 @@ def politician_edit_process_view(request):
             politician_on_stage.twitter_handle2_updates_failing = twitter_handle2_updates_failing
 
             performance_list.append({
-                'name': 'Process Twitter handle updates failing fields',
-                'description': 'Process Twitter handle updates failing fields',
+                'enum_key': 'PROC_TWITTER_FAILING',
                 'time_difference': time() - t0,
             })
 
@@ -3391,8 +3367,7 @@ def politician_edit_process_view(request):
                 politician_on_stage.youtube_url = youtube_url
 
             performance_list.append({
-                'name': 'Process Ids',
-                'description': 'Process vote_smart_id, politician_we_vote_id, vote_usa_politician_id, wikipedia_url, youtube_url fields if they exist',
+                'enum_key': 'PROC_IDS',
                 'time_difference': time() - t0,
             })
 
@@ -3405,8 +3380,7 @@ def politician_edit_process_view(request):
             politician_id = politician_on_stage.id
 
             performance_list.append({
-                'name': 'Save politician',
-                'description': 'Save politician object',
+                'enum_key': 'SAVE_POLITICIAN',
                 'time_difference': time() - t0,
             })
 
@@ -3426,8 +3400,7 @@ def politician_edit_process_view(request):
                     messages.add_message(request, messages.INFO, results['info_message_to_print'])
 
             performance_list.append({
-                'name': 'Process ballotpedia_politician_url field',
-                'description': 'Process ballotpedia_politician_url field',
+                'enum_key': 'PROC_BALLOTPEDIA',
                 'time_difference': time() - t0,
             })
 
@@ -3444,8 +3417,7 @@ def politician_edit_process_view(request):
                         campaignx.save()
 
                 performance_list.append({
-                    'name': 'Update CampaignX from politician',
-                    'description': 'Update linked CampaignX from politician if one is found',
+                    'enum_key': 'UP_CAMPAIGNX',
                     'time_difference': time() - t0,
                 })
 
@@ -3468,14 +3440,12 @@ def politician_edit_process_view(request):
                         representative.save()
                 
                 performance_list.append({
-                    'name': 'Update Representative from politician',
-                    'description': 'Update linked Representative from politician if one is found',
+                    'enum_key': 'UP_REPRESENTATIVE',
                     'time_difference': time() - t0,
                 })
             else:
                 performance_list.append({
-                    'name': 'Query Representative Manager',
-                    'description': 'Queried Representative Manager, but no Representative found for this politician.',
+                    'enum_key': 'RET_REP_MNGR_FAIL',
                     'time_difference': time() - t0,
                 })
 
@@ -3490,8 +3460,7 @@ def politician_edit_process_view(request):
                                             url_variables)
             
             performance_list.append({
-                'name': 'Save politician',
-                'description': 'Save politician object',
+                'enum_key': 'SAVE_POLITICIAN',
                 'time_difference': time() - t0,
             })
 
@@ -3515,8 +3484,7 @@ def politician_edit_process_view(request):
             messages.add_message(request, messages.ERROR, status)
 
     performance_list.append({
-        'name': 'Update parallel fields',
-        'description': 'Update parallel fields with years in related objects',
+        'enum_key': 'UP_PRLL_FIELDS',
         'time_difference': time() - t0,
     })
 
@@ -3556,8 +3524,7 @@ def politician_edit_process_view(request):
                 pass
 
     performance_list.append({
-        'name': 'Unlink Candidates',
-        'description': 'Unlink Candidates',
+        'enum_key': 'UNLNK_CANDIDATES',
         'time_difference': time() - t0,
     })
 
@@ -3589,8 +3556,7 @@ def politician_edit_process_view(request):
                 pass
 
     performance_list.append({
-        'name': 'Unlink Representatives',
-        'description': 'Unlink Representatives',
+        'enum_key': 'UNLNK_REPS',
         'time_difference': time() - t0,
     })
 
@@ -3603,8 +3569,7 @@ def politician_edit_process_view(request):
     related_candidate_list = find_candidates_to_link_to_this_politician(politician=politician_on_stage)
 
     performance_list.append({
-        'name': 'Find Candidates to Link',
-        'description': 'Find Candidates to Link',
+        'enum_key': 'RET_CANDIDATES_TO_LINK',
         'time_difference': time() - t0,
     })
 
@@ -3638,8 +3603,7 @@ def politician_edit_process_view(request):
                     pass
 
     performance_list.append({
-        'name': 'Link Candidates',
-        'description': 'Link Candidates',
+        'enum_key': 'LINK_CANDIDATES',
         'time_difference': time() - t0,
     })
 
@@ -3651,8 +3615,7 @@ def politician_edit_process_view(request):
     related_representative_list = find_representatives_to_link_to_this_politician(politician=politician_on_stage)
     
     performance_list.append({
-        'name': 'Find Representatives to Link',
-        'description': 'Find Representatives to Link',
+        'enum_key': 'RET_REPS_TO_LINK',
         'time_difference': time() - t0,
     })
 
@@ -3673,8 +3636,7 @@ def politician_edit_process_view(request):
                 representative.save()
     
     performance_list.append({
-        'name': 'Link Representatives',
-        'description': 'Link Representatives',
+        'enum_key': 'LINK_REPS',
         'time_difference': time() - t0,
     })
 
@@ -3810,8 +3772,7 @@ def politician_edit_process_view(request):
         pass
 
     performance_list.append({
-        'name': 'Update seo_friendly_path(s)',
-        'description': 'Update linked CampainXs, Candidates, Representatives with seo_friendly_path',
+        'enum_key': 'UP_SEO',
         'time_difference': time() - t0,
     })
 
@@ -3884,8 +3845,7 @@ def politician_edit_process_view(request):
                 update_message += results['update_message']
 
     performance_list.append({
-        'name': 'Update supporters_count',
-        'description': 'Update supporters_count',
+        'enum_key': 'UP_SUPS_COUNT',
         'time_difference': time() - t0,
     })
 
@@ -3959,8 +3919,7 @@ def politician_edit_process_view(request):
                               '{error} [type: {error_type}]'.format(error=e, error_type=type(e))
     
     performance_list.append({
-        'name': 'Change log and volunteer scoring',
-        'description': 'Change log and volunteer scoring',
+        'enum_key': 'CHANGE_LOG_VOLUNTEER',
         'time_difference': time() - t0,
     })
 
@@ -3974,8 +3933,7 @@ def politician_edit_process_view(request):
         messages.add_message(request, messages.INFO, info_message_to_print)
     
     performance_list.append({
-        'name': 'Update needed messages',
-        'description': 'Update needed messages',
+        'enum_key': 'UP_MSGS',
         'time_difference': time() - t0,
     })
 


### PR DESCRIPTION
Added `politician/enums.py/SpeedStatistics` enum so that we have shorter keys to pass through 
```
HttpResponseRedirect(reverse('politician:politician_edit', args=(
        politician_id,)) + url_variables + "&" + performance_process_dict_encoded)
```

This method of using redirect to pass through speed statistic names and descriptions was erroring since too many arguments in the `GET` request pushed it over the 4,094 character limit. Previously it was sending a `GET` request of ~5,600 characters, and this method of using an enum shrinks it down to ~3,600 characters.

Added `round()` to timestamps to decrease the character count a further ~400 characters to ~3,200 characters total.