### PR TITLE
[Issue #WV-2163] Create email template and add template list

### DIFF
--- a/email_outbound/urls.py
+++ b/email_outbound/urls.py
@@ -17,4 +17,6 @@ urlpatterns = [
     re_path(r'^edit_template_folder_process/$', views_admin.email_template_folder_edit_process_view,
             name='email_template_folder_edit_process'),
     re_path(r'^email_template_list/$', views_admin.email_template_list_view, name='email_template_list'),
+    re_path(r'^email_template_list_process/$', views_admin.email_template_list_process_view,
+            name='email_template_list_process'),
 ]

--- a/email_outbound/views_admin.py
+++ b/email_outbound/views_admin.py
@@ -13,7 +13,7 @@ from django.shortcuts import render
 from django.urls import reverse
 
 from admin_tools.views import redirect_to_sign_in_page
-from email_outbound.models import EmailTemplateFolder
+from email_outbound.models import EmailTemplate, EmailTemplateFolder
 from voter.models import voter_has_authority
 import wevote_functions.admin
 from wevote_functions.functions import positive_value_exists
@@ -117,10 +117,21 @@ def email_template_edit_view(request):
 
     google_civic_election_id = request.GET.get('google_civic_election_id', '')
     state_code = request.GET.get('state_code', '')
+    email_template_id = request.GET.get('email_template_id', 0)
+
+    # Load existing template if editing
+    email_template = None
+    if positive_value_exists(email_template_id):
+        try:
+            email_template = EmailTemplate.objects.get(id=email_template_id)
+        except EmailTemplate.DoesNotExist:
+            email_template = None
 
     template_values = {
         # 'election':                                 election,
         # 'election_list':                            election_list,
+        'email_template':                           email_template,
+        'folder_list':                              EmailTemplateFolder.objects.filter(deleted=False).order_by('email_template_name'),
         'google_civic_election_id':                 google_civic_election_id,
         'state_code':                               state_code,
         # 'state_list':                               sorted_state_list,
@@ -153,11 +164,38 @@ def email_template_edit_process_view(request):
 
     status = ""
 
-    email_template_name = request.POST.get('email_template_name', False)
-    if positive_value_exists(email_template_name):
-        email_template_name = email_template_name.strip()
+    email_template_name = request.POST.get('email_template_name', '').strip()
+    subject = request.POST.get('subject', '').strip()
+    message = request.POST.get('message', '').strip()
+    folder_id = request.POST.get('folder', 0)
+
+    # if positive_value_exists(email_template_name):
+    #     email_template_name = email_template_name.strip()
     google_civic_election_id = request.POST.get('google_civic_election_id', 0)
-    state_code = request.POST.get('state_code', False)
+    state_code = request.POST.get('state_code', '')
+
+    try:
+        email_template, created = EmailTemplate.objects.get_or_create(
+            email_template_name=email_template_name,
+            defaults={
+                'subject': subject,
+                'message': message,
+                'email_template_folder_id': folder_id or 0,
+            }
+        )
+        if not created:
+            # Update existing one
+            email_template.subject = subject
+            email_template.message = message
+            email_template.email_template_folder_id = folder_id or 0
+            email_template.save()
+            status += "Existing template updated. "
+        else:
+            status += "New template created. "
+    except Exception as e:
+        status += f"Error saving template: {e}"
+
+    messages.add_message(request, messages.INFO, status)
 
     # Since a pointer to performance_list was attached to performance_dict above, the performance_list
     # data gets passed along within performance_dict. We pass this performance_dict
@@ -165,8 +203,6 @@ def email_template_edit_process_view(request):
     performance_process_dict_encoded = urlencode({
         'performance_process_dict': json.dumps(performance_dict)
     })
-
-    messages.add_message(request, messages.INFO, 'EmailTemplate updated.')
 
     redirect_url = reverse(
         'email_outbound:email_template_list',
@@ -310,6 +346,73 @@ def email_template_folder_edit_view(request):
 
 
 @login_required
+def email_template_list_process_view(request):
+    """
+    Process the email template list form (archive/delete operations)
+    :param request:
+    :return:
+    """
+    # The performance_dict variable contains list(s) of performance_snapshots.
+    performance_dict = {}
+    performance_list = []
+    performance_dict.update({
+        'email_template_list_process_view': performance_list,
+    })
+
+    # admin, analytics_admin, partner_organization, political_data_manager, political_data_viewer, verified_volunteer
+    authority_required = {'verified_volunteer'}
+    if not voter_has_authority(request, authority_required):
+        return redirect_to_sign_in_page(request, authority_required)
+
+    google_civic_election_id = request.POST.get('google_civic_election_id', 0)
+    state_code = request.POST.get('state_code', False)
+
+    # Update templates:
+    template_list = EmailTemplate.objects.filter(deleted=False)
+    for template in template_list:
+        # flag to check for changes
+        template_changed = False
+
+        # check if row exists
+        template_archived_variable_exists_name = \
+            "email_template_archived_" + str(template.id) + "_exists"
+        template_archived_variable_exists = \
+            request.POST.get(template_archived_variable_exists_name, None)
+
+        # get variables
+        template_archived_variable_name = \
+            "email_template_archived_" + str(template.id)
+        template_archived = \
+            positive_value_exists(request.POST.get(template_archived_variable_name, False))
+        template_deleted_variable_name = \
+            "email_template_deleted_" + str(template.id)
+        template_deleted = \
+            positive_value_exists(request.POST.get(template_deleted_variable_name, False))
+
+        # set variables only if row exists
+        if template_archived_variable_exists is not None:
+            template.archived = template_archived
+            template.deleted = template_deleted
+            template_changed = True
+
+        # save template if changed
+        if template_changed:
+            template.save()
+
+    messages.add_message(request, messages.INFO, 'Email templates updated.')
+
+    performance_process_dict_encoded = urlencode({
+        'performance_process_dict': json.dumps(performance_dict)
+    })
+
+    redirect_url = reverse(
+        'email_outbound:email_template_list',
+        args=()) + "?google_civic_election_id=" + str(google_civic_election_id) + \
+        "&state_code=" + str(state_code) + "&" + performance_process_dict_encoded
+    return HttpResponseRedirect(redirect_url)
+
+
+@login_required
 def email_template_list_view(request):
     # admin, analytics_admin, partner_organization, political_data_manager, political_data_viewer, verified_volunteer
     authority_required = {'political_data_manager', 'verified_volunteer'}
@@ -327,8 +430,10 @@ def email_template_list_view(request):
         # 'state_list':                               sorted_state_list,
         # Any data you want to show in the list, e.g. folders:
         'folders': EmailTemplateFolder.objects.filter(deleted=False).order_by('email_template_name'),
+        'templates': EmailTemplate.objects.filter(deleted=False).order_by('email_template_name'),
         # The process URL (used by the modal form)
         'process_url': reverse('email_outbound:email_template_folder_edit_process'),
+        'template_process_url': reverse('email_outbound:email_template_list_process'),
 
     }
     return render(request, 'email_outbound/email_template_list.html', template_values)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ django-cors-headers==4.3.1
 django-crispy-forms==1.12.0
 django-mathfilters==1.0.0
 django-sslserver-v2==1.0
+django-tinymce
 django-twitter-bootstrap==3.3.0
 django-user-agents==0.4.0
 djangorestframework==3.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-cors-headers==4.3.1
 django-crispy-forms==1.12.0
 django-mathfilters==1.0.0
 django-sslserver-v2==1.0
-django-tinymce
+django-tinymce==5.0.0
 django-twitter-bootstrap==3.3.0
 django-user-agents==0.4.0
 djangorestframework==3.15.2

--- a/templates/email_outbound/email_template_edit.html
+++ b/templates/email_outbound/email_template_edit.html
@@ -1,16 +1,150 @@
 {# templates/email_outbound/email_template_edit.html #}
 {% extends "template_base.html" %}
+{% load static %}
 
-{% block title %}Email Templates > New Email Template{% endblock %}
+{% block title %}Email Templates › New Email Template{% endblock %}
 
-{%  block content %}
-{% load template_filters %}
-{% load humanize %}
+{% block content %}
 {% include "admin_tools/loading_banner.html" %}
-    
-    <a href="{% url 'email_outbound:email_template_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-        < Back to Email Templates</a>
 
-<h1>Email Templates > New Email Template</h1>
+<a href="{% url 'email_outbound:email_template_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+    &lt; Back to Email Templates
+</a>
 
+<div class="container mt-5 p-4 bg-white rounded shadow-sm border" style="max-width: 800px;">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h4 class="mb-0">
+      <a href="{% url 'email_outbound:email_template_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" class="text-primary text-decoration-none">Email Templates</a> › {% if email_template %}Edit Email{% else %}New Email{% endif %}
+    </h4>
+    <div>
+      <a href="{% url 'email_outbound:email_template_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" class="btn btn-outline-secondary me-2">Cancel</a>
+      <button type="submit" form="email-template-form" class="btn btn-primary">Save</button>
+    </div>
+  </div>
+
+  <form id="email-template-form" method="post" action="{% url 'email_outbound:email_template_edit_process' %}">
+    {% csrf_token %}
+
+    <div class="mb-3">
+        <label for="email_template_name" class="form-label">Template Name <span class="text-danger">*</span></label>
+        <input type="text" id="email_template_name" name="email_template_name" class="form-control" value="{% if email_template %}{{ email_template.email_template_name }}{% endif %}" required>
+    </div>
+
+    <div class="mb-3">
+        <label for="subject" class="form-label">Subject <span class="text-danger">*</span></label>
+        <input type="text" id="subject" name="subject" class="form-control" value="{% if email_template %}{{ email_template.subject }}{% endif %}" required>
+    </div>
+
+    <div class="mb-3">
+        <label for="folder" class="form-label">Folder</label>
+        <select id="folder" name="folder" class="form-select">
+            <option value="">-- Choose folder --</option>
+            {% for folder in folder_list %}
+            <option value="{{ folder.id }}" {% if email_template and email_template.email_template_folder_id == folder.id %}selected{% endif %}>{{ folder.email_template_name }}</option>
+            {% endfor %}
+        </select>
+    </div>
+
+    <div class="mb-3">
+        <label for="message" class="form-label">Message <span class="text-danger">*</span></label>
+        <textarea id="message" name="message" class="form-control" rows="10">{% if email_template %}{{ email_template.message }}{% endif %}</textarea>
+    </div>
+
+    <input type="hidden" name="google_civic_election_id" value="{{ google_civic_election_id }}">
+    <input type="hidden" name="state_code" value="{{ state_code }}">
+  </form>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<!-- Use TinyMCE via CDN -->
+<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
+<script>
+  // Wait for DOM to be ready
+  document.addEventListener('DOMContentLoaded', function() {
+    // Remove TinyMCE instance if it exists
+    if (tinymce.get('message')) {
+      tinymce.get('message').remove();
+    }
+
+    tinymce.init({
+      selector: '#message',
+      menubar: true,
+      plugins: [
+        'advlist', 'autolink', 'lists', 'link', 'image', 'charmap', 'preview',
+        'anchor', 'searchreplace', 'visualblocks', 'code', 'fullscreen',
+        'insertdatetime', 'media', 'table', 'help', 'wordcount'
+      ],
+      toolbar: 'undo redo | blocks fontsize | ' +
+        'bold italic underline strikethrough | forecolor backcolor | ' +
+        'alignleft aligncenter alignright alignjustify | ' +
+        'outdent indent | bullist numlist | ' +
+        'link image media table | ' +
+        'removeformat code fullscreen help',
+      toolbar_mode: 'wrap',
+      height: 500,
+      branding: false,
+      promotion: false,
+
+      // Image upload settings
+      images_upload_handler: function (blobInfo, success, failure) {
+        // Convert image to base64 and embed
+        var reader = new FileReader();
+        reader.onload = function() {
+          success(reader.result);
+        };
+        reader.onerror = function() {
+          failure('Image upload failed');
+        };
+        reader.readAsDataURL(blobInfo.blob());
+      },
+
+      // File picker for images
+      file_picker_types: 'image',
+      file_picker_callback: function(callback, value, meta) {
+        if (meta.filetype === 'image') {
+          var input = document.createElement('input');
+          input.setAttribute('type', 'file');
+          input.setAttribute('accept', 'image/*');
+
+          input.onchange = function() {
+            var file = this.files[0];
+            var reader = new FileReader();
+
+            reader.onload = function() {
+              callback(reader.result, {
+                alt: file.name
+              });
+            };
+
+            reader.readAsDataURL(file);
+          };
+
+          input.click();
+        }
+      },
+
+      // Content styling
+      content_style: 'body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; font-size: 14px; line-height: 1.6; }',
+
+      // Additional features
+      link_default_target: '_blank',
+      link_assume_external_targets: true,
+
+      // Formatting options
+      block_formats: 'Paragraph=p; Heading 1=h1; Heading 2=h2; Heading 3=h3; Heading 4=h4; Heading 5=h5; Heading 6=h6; Preformatted=pre',
+      font_size_formats: '8pt 10pt 12pt 14pt 16pt 18pt 24pt 36pt',
+
+      // Allow all HTML elements and attributes for full flexibility
+      extended_valid_elements: '*[*]',
+      valid_children: '+body[style]',
+
+      setup: function(editor) {
+        editor.on('init', function() {
+          console.log('TinyMCE initialized successfully');
+        });
+      }
+    });
+  });
+</script>
 {% endblock %}

--- a/templates/email_outbound/email_template_list.html
+++ b/templates/email_outbound/email_template_list.html
@@ -28,6 +28,11 @@
              overflow: auto; text-align:left; padding:10px; border:1px solid #e5e7eb;
         }
 
+        .email_template_table {width:100%; border-collapse: collapse; margin-top: 2rem; }
+        .email_template_table th, .email_template_table td {
+             overflow: auto; text-align:left; padding:10px; border:1px solid #e5e7eb;
+        }
+
     </style>
     
     <a href="{% url 'email_outbound:email_campaign_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
@@ -35,15 +40,81 @@
 
     <h1>Email Templates</h1>
     {% if error_message %}<p><strong>{{ error_message }}</strong></p>{% endif %}
-   <div>
-       <a href="{% url 'email_outbound:email_template_edit' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-            Create Email Template</a>
-   </div>
+    <a id="createEmailTemplateButton"
+        class="btn btn-primary"
+        href="{% url 'email_outbound:email_template_edit' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+        Create Email Template
+    </a>
 
+   <form id="updateTemplateTable" class="template-table" method="post" action="{{ template_process_url }}" >
+        {% csrf_token %}
+        <input type="hidden" name="google_civic_election_id" value="{{ google_civic_election_id }}">
+        <input type="hidden" name="state_code" value="{{ state_code }}">
+
+        <!-- Table -->
+        <table class="email_template_table" id="template_table">
+            <thead>
+                <tr>
+                    <th>Template Name</th>
+                    <th>Subject</th>
+                    <th>Folder</th>
+                    <th>Archive Template</th>
+                    <th>Delete Template</th>
+                    <th>Edit Template</th>
+                </tr>
+            </thead>
+            <tbody id="templateTableBody">
+                {% for t in templates %}
+                <tr id="template_id_{{ t.id }}">
+                    <td>{{ t.email_template_name }}</td>
+                    <td>{{ t.subject }}</td>
+                    <td>
+                        {% for f in folders %}
+                            {% if f.id == t.email_template_folder_id %}
+                                {{ f.email_template_name }}
+                            {% endif %}
+                        {% endfor %}
+                    </td>
+                    <td>
+                        <input type="hidden" name="email_template_archived_{{ t.id }}_exists" value="1">
+                        <input
+                            type="checkbox"
+                            name="email_template_archived_{{ t.id }}"
+                            id="email_template_archived_{{ t.id }}_id"
+                            value="True"
+                            {% if t.archived %}
+                                checked="checked"
+                            {% endif %}
+                        />
+                    </td>
+                    <td>
+                        <input type="hidden" name="email_template_deleted_{{ t.id }}_exists" value="1">
+                        <input
+                            type="checkbox"
+                            name="email_template_deleted_{{ t.id }}"
+                            id="email_template_deleted_{{ t.id }}_id"
+                            value="True"
+                            {% if t.deleted %}
+                                checked="checked"
+                            {% endif %}
+                        />
+                    </td>
+                    <td>
+                        <a href="{% url 'email_outbound:email_template_edit' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}&email_template_id={{ t.id }}" class="btn btn-primary">
+                            Edit
+                        </a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <button type="submit" class="btn btn-primary wv-update-btn" id="updateTemplateTable">Update</button>
+    </form>
+
+    <h2>Email Template Folder List</h2>
     <button id="openCreateFolder" class="btn btn-primary">
         Create Folder
     </button>
-    <h2>Email Template Folder List</h2>
 
     <form id="updateFolderTable" class="folder-table" method="post" action="{{ process_url }}" >
         {% csrf_token %}


### PR DESCRIPTION
This PR addresses WV-2163: Build "Create Email Template" form (WeVoteServer). It adds a simple form to create email templates that is accessible at http://localhost:8000/email/edit_template/:
<img width="820" height="520" alt="Screenshot 2025-10-26 at 5 29 23 PM" src="https://github.com/user-attachments/assets/58d86138-6415-455d-ae43-050e6d93e399" />
It also adds a table containing the list of current email templates, with options to archive, delete or edit them at http://localhost:8000/email/email_template_list/:
<img width="1341" height="586" alt="Screenshot 2025-10-26 at 5 30 01 PM" src="https://github.com/user-attachments/assets/955eead4-a423-4dc0-a2a0-f1515e30ee15" />

I can enhance the message entering features in future PRs, including adding a format bar where users can insert files, hyperlinks, photos and format their text.