### PR TITLE
[WV-2188] Generate presigned URL on master and pass pull from URl on Local

### DIFF
--- a/retrieve_tables/controllers_local.py
+++ b/retrieve_tables/controllers_local.py
@@ -123,7 +123,8 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         tf = tempfile.NamedTemporaryFile(mode='r+b')
         with requests.get(aws_s3_file_url, stream=True) as response:
             response.raise_for_status()
-            for chunk in response.iter_content(chunk_size=100000):
+            # Process in 1MB chunks
+            for chunk in response.iter_content(chunk_size=(1000*1000)):
                 if chunk:
                     tf.write(chunk)
         tf.close()

--- a/retrieve_tables/controllers_local.py
+++ b/retrieve_tables/controllers_local.py
@@ -112,26 +112,22 @@ def retrieve_sql_files_from_master_server(request):
 
 
 def restore_one_file_to_local_server(aws_s3_file_url, table_name):
-    import boto3
     import tempfile
     results = {
         'success': False
     }
 
     try:
-        # s3 = boto3.client('s3')
-        session = boto3.session.Session(region_name=AWS_REGION_NAME,
-                                        aws_access_key_id=AWS_ACCESS_KEY_ID,
-                                        aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
-        s3 = session.resource(AWS_STORAGE_SERVICE)
-
-        head, tail = os.path.split(aws_s3_file_url)
-
         diff_t0 = int((time.time() - global_stats['global_t0']))
         print(f"About to download {table_name} from S3 at {diff_t0} seconds")
         tf = tempfile.NamedTemporaryFile(mode='r+b')
-        # print(f"AWS_STORAGE_BUCKET_NAME: {AWS_STORAGE_BUCKET_NAME}, tail: {tail}, tf.name: {tf.name}")
-        s3.Bucket(AWS_STORAGE_BUCKET_NAME).download_file(tail, tf.name)
+        with requests.get(aws_s3_file_url, stream=True) as response:
+            response.raise_for_status()
+            for chunk in response.iter_content(chunk_size=100000):
+                if chunk:
+                    tf.write(chunk)
+        tf.close()
+
         print("Downloaded", tf.name)
         diff_t0 = int(time.time() - global_stats['global_t0'])
         print(f"Done with download from S3 at {diff_t0} seconds")

--- a/retrieve_tables/controllers_master.py
+++ b/retrieve_tables/controllers_master.py
@@ -401,8 +401,13 @@ def backup_one_table_to_s3_controller(voter_api_device_id, table_name):
 
             s3.Bucket(AWS_STORAGE_BUCKET_NAME).upload_file(
                 results['temp_file_name'], tail, ExtraArgs={'Expires': date_tomorrow, 'ContentType': 'text/html'})
-            aws_s3_file_url = "https://{bucket_name}.s3.amazonaws.com/{file_location}" \
-                              "".format(bucket_name=AWS_STORAGE_BUCKET_NAME, file_location=tail)
+
+            aws_s3_file_url = s3.meta.client.generate_presigned_url(
+                                ClientMethod='get_object',
+                                Params={'Bucket': AWS_STORAGE_BUCKET_NAME, 'Key': tail},
+                                ExpiresIn=date_tomorrow,
+                            )
+
             ts = '{:.2f} seconds'.format(time.time() - t0)
             results['tmp_file_to_s3_completed'] = str(ts)
 


### PR DESCRIPTION
Feature Doc Here: https://docs.google.com/document/d/147RajQvdTI33vLeuT3-SXEoIdV0Vbav_7ynwcEwrVf0/edit?usp=sharing

Previously, the Fast Load process required local AWS credentials to download a database backup file stored in an S3 bucket on the master server. To eliminate this dependency, the master server now generates a presigned URL using generate_presigned_url, which allows secure access to the backup file without local credentials. The local environment has been updated to use Python’s requests library to download the file directly, removing the need to run within an AWS-authenticated instance.

Test Plan:
A test plan need to be devised that best protects data. This PR will be modified to address testing.