### PR TITLE
[WV-2188][quick-fix] create fastload table presigned url

### DIFF
--- a/retrieve_tables/controllers_local.py
+++ b/retrieve_tables/controllers_local.py
@@ -124,7 +124,7 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         with requests.get(aws_s3_file_url, stream=True) as response:
             response.raise_for_status()
             # Process in 1MB chunks
-            for chunk in response.iter_content(chunk_size=(1000*1000)):
+            for chunk in response.iter_content(chunk_size=(1024*1024)):
                 if chunk:
                     tf.write(chunk)
         tf.close()

--- a/retrieve_tables/controllers_master.py
+++ b/retrieve_tables/controllers_master.py
@@ -395,6 +395,7 @@ def backup_one_table_to_s3_controller(voter_api_device_id, table_name):
             head, tail = os.path.split(results['temp_file_name'])
 
             date_tomorrow = datetime.now() + timedelta(days=2)
+            date_tomorrow_seconds = timedelta(days=2).total_seconds()
 
             ts = '{:.2f} seconds'.format(time.time() - t0)
             print(f"About to upload to S3 at {ts} seconds")
@@ -405,7 +406,7 @@ def backup_one_table_to_s3_controller(voter_api_device_id, table_name):
             aws_s3_file_url = s3.meta.client.generate_presigned_url(
                                 ClientMethod='get_object',
                                 Params={'Bucket': AWS_STORAGE_BUCKET_NAME, 'Key': tail},
-                                ExpiresIn=date_tomorrow,
+                                ExpiresIn=date_tomorrow_seconds,
                             )
 
             ts = '{:.2f} seconds'.format(time.time() - t0)


### PR DESCRIPTION
Changed the presign URL to have expiration in seconds using `datetime.total_seconds()`. Using a Datetime object was causing an error.
Tested by using Local AWS credentials to create a presigned_url using an existing file:
<img width="656" height="397" alt="image" src="https://github.com/user-attachments/assets/1d8db1bf-8a2c-4927-a232-564afd790866" />
Checked URL for proper expiration:
<img width="886" height="241" alt="image" src="https://github.com/user-attachments/assets/ae8000c8-690f-4025-a296-ca12ad60c514" />
