### PR TITLE
[WV-2188] Added Fast Loading with presigned urls and db password

### DIFF
--- a/config/environment_variables-template.json
+++ b/config/environment_variables-template.json
@@ -7,6 +7,7 @@
   "CAMPAIGNS_ROOT_URL":             "http://localhost:3000",
   "CHALLENGES_ROOT_URL":            "http://localhost:3000",
   "TIME_ZONE":                      "US/Pacific",
+  "SERVER_IS_SOURCE_OF_TRUTH":      false,
   "SERVER_IN_DEBUG_MODE":           true,
 
   "_comment":                       "read/write database settings for local.py",

--- a/retrieve_tables/controllers_local.py
+++ b/retrieve_tables/controllers_local.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import subprocess
 import time
 
 import psycopg2
@@ -21,11 +22,6 @@ logger = wevote_functions.admin.get_logger(__name__)
 global_stats = {}
 dummy_unique_id = 10000000
 LOCAL_TMP_PATH = '/tmp/'
-AWS_ACCESS_KEY_ID = get_environment_variable("AWS_ACCESS_KEY_ID")
-AWS_SECRET_ACCESS_KEY = get_environment_variable("AWS_SECRET_ACCESS_KEY")
-AWS_REGION_NAME = get_environment_variable("AWS_REGION_NAME")
-AWS_STORAGE_BUCKET_NAME = get_environment_variable("AWS_STORAGE_BUCKET_NAME")
-AWS_STORAGE_SERVICE = "s3"
 
 
 def update_fast_load_db(host, voter_api_device_id, table_name, additional_records):
@@ -62,6 +58,8 @@ def retrieve_sql_files_from_master_server(request):
     voter_api_device_id = get_voter_api_device_id(request)
 
     try:
+        if connected_to_aws():
+            raise Exception('Can connect to AWS on Local Server, not allowed to Fast Load for risk of data loss.')
         # hack, call master from local...
         # results = backup_one_table_to_s3_controller('id', 'ballot_ballotitem')
         # ballot_ballotitem has 40,999,358 records in December 2024 and takes about 69 seconds to dump and 10 more to
@@ -77,7 +75,6 @@ def retrieve_sql_files_from_master_server(request):
         global_stats['step'] = 0
         global_stats['elapsed'] = 0
         global_stats['global_t0'] = time.time()
-
 
         for table_name in allowable_tables:
             global_stats['table_name_text'] = ('<b>Saving</b>&nbsp;&nbsp;<i>' + table_name +
@@ -117,17 +114,16 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         'success': False
     }
 
+    tf = tempfile.NamedTemporaryFile(mode='r+b')
     try:
         diff_t0 = int((time.time() - global_stats['global_t0']))
         print(f"About to download {table_name} from S3 at {diff_t0} seconds")
-        tf = tempfile.NamedTemporaryFile(mode='r+b')
         with requests.get(aws_s3_file_url, stream=True) as response:
             response.raise_for_status()
             # Process in 1MB chunks
             for chunk in response.iter_content(chunk_size=(1024*1024)):
                 if chunk:
                     tf.write(chunk)
-        tf.close()
 
         print("Downloaded", tf.name)
         diff_t0 = int(time.time() - global_stats['global_t0'])
@@ -143,6 +139,7 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         db_user = get_environment_variable('DATABASE_USER')
         db_host = get_environment_variable('DATABASE_HOST')
         db_port = get_environment_variable('DATABASE_PORT')
+        db_pass = get_environment_variable('DATABASE_PASSWORD')
 
         diff_t0 = int(time.time() - global_stats['global_t0'])
         print(f"About to TRUNCATE {table_name} at {diff_t0} seconds")
@@ -160,16 +157,28 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         diff_t0 = int((time.time() - global_stats['global_t0']))
         print(f"About to pg_restore from tempfile at {diff_t0} seconds")
 
-        command_str = f"pg_restore -v --data-only --disable-triggers -U {db_user} "
-        if positive_value_exists(db_host):
-            command_str += f"-h {db_host} "
-        if positive_value_exists(db_port):
-            command_str += f"-p {db_port} "
-        command_str += f"-d {db_name} -t {table_name} "
-        command_str += f"\"{tf.name}\""
-        # print(command_str)
+        command_list = ['pg_restore',
+                        '-v', 
+                        '--data-only', 
+                        '--disable-triggers',
+                        '--no-password',
+                        '-U', db_user]
+        command_list.extend(['-h', db_host] if positive_value_exists(db_host) else [])
+        command_list.extend(['-p', db_port] if positive_value_exists(db_port) else [])
+        command_list.extend(['-d', db_name,
+                            '-t', table_name,
+                            tf.name])
 
-        os.system(command_str)
+        # Get password and set environment. If no password, don't set the environment variable.
+        # Pssing 'None' to the environment variable will cause the command to fail.
+        env = os.environ.copy()
+        if db_pass:
+            env['PGPASSWORD'] = db_pass
+
+        table_restore_result = subprocess.run(command_list, env=env, capture_output=True, text=True)
+        # Any return code other than 0 is an error
+        if table_restore_result.returncode != 0:
+            raise RuntimeError(f"pg_restore failed: {table_restore_result.stderr}")
 
         diff_t0 = int((time.time() - global_stats['global_t0']))
         print(f"Restore completed at {diff_t0} seconds")
@@ -179,6 +188,7 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         logger.error("Problem occurred in pg_restore step: ", e)
         results['success'] = False,
         results['error string'] = str(e)
+    tf.close()
 
     return results
 
@@ -266,3 +276,22 @@ def fetch_data_from_api(url, params, max_retries=1000, timeout=8):
 
     raise Exception("API request failed after maximum retries")
 
+
+def connected_to_aws():
+    import boto3
+    AWS_ACCESS_KEY_ID = get_environment_variable("AWS_ACCESS_KEY_ID")
+    AWS_SECRET_ACCESS_KEY = get_environment_variable("AWS_SECRET_ACCESS_KEY")
+    AWS_REGION_NAME = get_environment_variable("AWS_REGION_NAME")
+
+    sts_client = boto3.client(
+        "sts",
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        region_name=AWS_REGION_NAME
+    )
+
+    try:
+        sts_client.get_caller_identity()
+        return True
+    except:
+        return False

--- a/retrieve_tables/controllers_local.py
+++ b/retrieve_tables/controllers_local.py
@@ -10,12 +10,12 @@ import time
 import psycopg2
 import requests
 import sqlalchemy as sa
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseServerError
 
 import wevote_functions.admin
 from config.base import get_environment_variable
 from retrieve_tables.retrieve_common import allowable_tables
-from wevote_functions.functions import get_voter_api_device_id, positive_value_exists
+from wevote_functions.functions import get_voter_api_device_id, positive_value_exists, server_is_source_of_truth
 
 logger = wevote_functions.admin.get_logger(__name__)
 
@@ -58,8 +58,6 @@ def retrieve_sql_files_from_master_server(request):
     voter_api_device_id = get_voter_api_device_id(request)
 
     try:
-        if connected_to_aws():
-            raise Exception('Can connect to AWS on Local Server, not allowed to Fast Load for risk of data loss.')
         # hack, call master from local...
         # results = backup_one_table_to_s3_controller('id', 'ballot_ballotitem')
         # ballot_ballotitem has 40,999,358 records in December 2024 and takes about 69 seconds to dump and 10 more to
@@ -67,6 +65,9 @@ def retrieve_sql_files_from_master_server(request):
         # in a day
         # Example: https://wevote-images.s3.amazonaws.com/backup-ballot_ballotitem-2024-12-06T13:25:13.backup
         # This same backup file takes 21 seconds to download to a local tempfile, and then 3 seconds to pg_restore
+
+        if server_is_source_of_truth():
+            raise Exception('Server may be a source of truth. Not allowed to Fast Load to maintain data integrity.')
 
         num_tables = len(allowable_tables)
         print(f"Fast loading {num_tables} tables")
@@ -77,6 +78,7 @@ def retrieve_sql_files_from_master_server(request):
         global_stats['global_t0'] = time.time()
 
         for table_name in allowable_tables:
+            global_stats['table_size'] = ''
             global_stats['table_name_text'] = ('<b>Saving</b>&nbsp;&nbsp;<i>' + table_name +
                                           '</i>&nbsp;&nbsp;to s3 from the <b>master</b> server')
             global_stats['table_name'] = table_name
@@ -104,6 +106,7 @@ def retrieve_sql_files_from_master_server(request):
     except Exception as e:
         results['status'] = 'Error ' + str(e)
         logger.error(f"Error retrieving {str(e)}")
+        return HttpResponseServerError(json.dumps(results), content_type='application/json')
 
     return HttpResponse(json.dumps(results), content_type='application/json')
 
@@ -119,11 +122,15 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         diff_t0 = int((time.time() - global_stats['global_t0']))
         print(f"About to download {table_name} from S3 at {diff_t0} seconds")
         with requests.get(aws_s3_file_url, stream=True) as response:
+            global_stats['table_size'] = int(response.headers.get('Content-Length'))
             response.raise_for_status()
             # Process in 1MB chunks
             for chunk in response.iter_content(chunk_size=(1024*1024)):
                 if chunk:
                     tf.write(chunk)
+        
+        if tf.tell() != global_stats['table_size']:
+            raise Exception(f"Downloaded {int(tf.tell()/1024)} Kb, expected {int(global_stats['table_size']/1024)} Kb")
 
         print("Downloaded", tf.name)
         diff_t0 = int(time.time() - global_stats['global_t0'])
@@ -151,11 +158,12 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         return results
 
     try:
-        truncate_table_psycopg2(table_name)
-        # drop_table(engine, table_name)
+        table_truncated = truncate_table_psycopg2(table_name)
+        if isinstance(table_truncated, Exception):
+            raise Exception(f"Truncate table {table_name} failed: {table_truncated}")
 
         diff_t0 = int((time.time() - global_stats['global_t0']))
-        print(f"About to pg_restore from tempfile at {diff_t0} seconds")
+        print(f"About to sync data from tempfile at {diff_t0} seconds")
 
         command_list = ['pg_restore',
                         '-v', 
@@ -234,6 +242,7 @@ def truncate_table_psycopg2(table_name):
         # print(f"TRUNCATE TABLE {table_name} re {str(ret)}")
     except Exception as e:
         logger.error(f'FAILED_TABLE_TRUNCATE: {table_name} -- {str(e)}')
+        return e
 
 
 def drop_table(engine, table_name):
@@ -275,23 +284,3 @@ def fetch_data_from_api(url, params, max_retries=1000, timeout=8):
         time.sleep(2 ** attempt)  # Exponential backoff
 
     raise Exception("API request failed after maximum retries")
-
-
-def connected_to_aws():
-    import boto3
-    AWS_ACCESS_KEY_ID = get_environment_variable("AWS_ACCESS_KEY_ID")
-    AWS_SECRET_ACCESS_KEY = get_environment_variable("AWS_SECRET_ACCESS_KEY")
-    AWS_REGION_NAME = get_environment_variable("AWS_REGION_NAME")
-
-    sts_client = boto3.client(
-        "sts",
-        aws_access_key_id=AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-        region_name=AWS_REGION_NAME
-    )
-
-    try:
-        sts_client.get_caller_identity()
-        return True
-    except:
-        return False

--- a/templates/admin_tools/sync_data_with_master_dashboard.html
+++ b/templates/admin_tools/sync_data_with_master_dashboard.html
@@ -28,6 +28,7 @@
         <progress id="progress" value="0" max="100" style="display: none"></progress>
         <div id="table_count" style="padding-top: 10px"></div>
         <div id="current_table"></div>
+        <div id="current_table_size"></div>
         <div id="current_table_wordy"></div>
         <div id="total_time"></div>
         <div id="current_status"></div>
@@ -333,6 +334,7 @@ These imports are best run in order from top-to-bottom.
     const table_count = $("#table_count");
     const current_status = $("#current_status");
     const current_table = $("#current_table");
+    const current_table_size = $("#current_table_size");
     const current_table_wordy = $("#current_table_wordy");
     const elapsed_seconds = $("#elapsed_seconds");
     const total_time = $("#total_time");
@@ -374,6 +376,7 @@ These imports are best run in order from top-to-bottom.
             }
 
             current_table_wordy.html(`Current table: ${data.table_name_text}`);
+            current_table_size.html(`Table size: ${data.table_size === ''? 'Waiting for size...' : (data.table_size / (1024*1024)).toFixed(2) + ' MB'}`);
             current_table.html(data.table_name);
             table_count.text(`Table: ${data.count} of ${data.num_tables}`);
           },

--- a/wevote_functions/functions.py
+++ b/wevote_functions/functions.py
@@ -16,6 +16,7 @@ from django.core.validators import URLValidator
 from nameparser import HumanName
 from nameparser.config import CONSTANTS
 import wevote_functions.admin
+from config.base import get_environment_variable
 # from wevote_functions.functions_date import DATE_FORMAT_A_DBY_HMS_GMT
 CONSTANTS.string_format = "{title} {first} {middle} \"{nickname}\" {last} {suffix}"
 
@@ -2063,3 +2064,9 @@ def strip_html_tags(value):
         return django.utils.html.strip_tags(value)
     else:
         return ""
+
+
+def server_is_source_of_truth():
+    # If 'SERVER_IS_SOURCE_OF_TRUTH' is not False
+    # then the default value has been modified in the environment_variables.json file.
+    return get_environment_variable('SERVER_IS_SOURCE_OF_TRUTH') is not False


### PR DESCRIPTION
Added a `connected_to_aws()` function to verify whether a valid connection can be established with AWS using local credentials. The assumption is that if the local credentials are valid, the code is being executed on the Master server, since most volunteers do not have AWS credentials.

Moved the `tf = tempfile.NamedTemporaryFile(mode='r+b')` call outside of the try block to ensure the temporary file is always properly closed and deleted via `tf.close()`.

Refactored the `pg_restore` command into a list of commands passed to `subprocess.run()`. This approach helps ensure valid commands are passed and allows a database password to be included when required, while avoiding errors when no password is needed. A check for this logic is located at [LN 175].

If an error occurs (typically due to a missing password), it is handled in the exception block.

### Success Measures

Tested by running the Fast Load process and confirming successful synchronization of the local database.

Successful Fast Load after removing AWS credentials from Local
<img width="1571" height="479" alt="image" src="https://github.com/user-attachments/assets/3f1850ff-1664-41f9-9f1c-2a9a6b965af9" />


Candidate linkages working now for Ted Lieu:
<img width="1981" height="1092" alt="image" src="https://github.com/user-attachments/assets/cdfaa28d-d162-4734-8e4e-dac4a231ee93" />

Speeds Statistics behaving similar to Live environment:
<img width="1988" height="1985" alt="image" src="https://github.com/user-attachments/assets/62b8ab4e-5faf-4c95-b6ea-5b2d1e02302b" />
