### PR TITLE
[Issue #WV-2164] Add create email campaign and edit saved campaigns functionality

### DIFF
--- a/email_outbound/urls.py
+++ b/email_outbound/urls.py
@@ -19,4 +19,5 @@ urlpatterns = [
     re_path(r'^email_template_list/$', views_admin.email_template_list_view, name='email_template_list'),
     re_path(r'^email_template_list_process/$', views_admin.email_template_list_process_view,
             name='email_template_list_process'),
+    re_path(r'^template_content/$', views_admin.email_template_content_view, name='email_template_content'),
 ]

--- a/email_outbound/views_admin.py
+++ b/email_outbound/views_admin.py
@@ -8,13 +8,13 @@ from urllib.parse import urlencode
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import Q
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 
 from admin_tools.views import redirect_to_sign_in_page
-from email_outbound.models import EmailTemplate, EmailTemplateFolder
+from email_outbound.models import EmailCampaign, EmailTemplate, EmailTemplateFolder, EmailCampaignRecipient
 from voter.models import voter_has_authority
 import wevote_functions.admin
 from wevote_functions.functions import positive_value_exists
@@ -56,8 +56,6 @@ def email_campaign_edit_process_view(request):
     email_campaign_id = request.POST.get('email_campaign_id', '')
     google_civic_election_id = request.POST.get('google_civic_election_id', 0)
     state_code = request.POST.get('state_code', '')
-
-    from email_outbound.models import EmailCampaign, EmailCampaignRecipient
     
     # Create or update campaign
     if email_campaign_id:
@@ -134,7 +132,6 @@ def email_campaign_edit_view(request):
     campaign_recipients = []
     if campaign_id:
         try:
-            from email_outbound.models import EmailCampaign, EmailCampaignRecipient
             email_campaign = EmailCampaign.objects.get(id=campaign_id)
             
             # Load recipients for this campaign
@@ -155,7 +152,6 @@ def email_campaign_edit_view(request):
             pass
     
     # Get list of saved campaigns
-    from email_outbound.models import EmailCampaign
     saved_campaigns = EmailCampaign.objects.filter(deleted=False).order_by('-id')[:10]
 
     # Step 1: Get folders that are not deleted
@@ -550,9 +546,6 @@ def email_template_content_view(request):
     """
     API endpoint to fetch template content
     """
-    from django.http import JsonResponse
-    from email_outbound.models import EmailTemplate
-    
     template_id = request.GET.get('template_id', '')
     
     try:

--- a/email_outbound/views_admin.py
+++ b/email_outbound/views_admin.py
@@ -51,6 +51,8 @@ def email_campaign_edit_process_view(request):
     campaign_title = request.POST.get('campaign_title', '').strip()
     email_template_id = request.POST.get('email_template_id', 0)
     recipient_ids = request.POST.get('recipient_ids', '')
+    email_subject = request.POST.get('email_subject', '').strip()
+    email_body = request.POST.get('email_body', '')
     email_campaign_id = request.POST.get('email_campaign_id', '')
     google_civic_election_id = request.POST.get('google_civic_election_id', 0)
     state_code = request.POST.get('state_code', '')
@@ -63,6 +65,8 @@ def email_campaign_edit_process_view(request):
             campaign = EmailCampaign.objects.get(id=email_campaign_id)
             campaign.email_campaign_name = campaign_title
             campaign.email_template_id = email_template_id
+            campaign.email_subject_template_raw = email_subject
+            campaign.email_body_template_raw = email_body
             campaign.save()
             
             # Clear existing recipients for this campaign
@@ -72,12 +76,16 @@ def email_campaign_edit_process_view(request):
             campaign = EmailCampaign.objects.create(
                 email_campaign_name=campaign_title,
                 email_template_id=email_template_id,
+                email_subject_template_raw=email_subject,
+                email_body_template_raw=email_body,
             )
             messages.add_message(request, messages.SUCCESS, 'Email campaign created.')
     else:
         campaign = EmailCampaign.objects.create(
             email_campaign_name=campaign_title,
             email_template_id=email_template_id,
+            email_subject_template_raw=email_subject,
+            email_body_template_raw=email_body,
         )
         messages.add_message(request, messages.SUCCESS, 'Email campaign created.')
     
@@ -535,3 +543,27 @@ def email_template_list_view(request):
     }
     # messages.add_message(request, messages.INFO, '')
     return render(request, "email_outbound/email_template_list.html", context)
+
+
+@login_required
+def email_template_content_view(request):
+    """
+    API endpoint to fetch template content
+    """
+    from django.http import JsonResponse
+    from email_outbound.models import EmailTemplate
+    
+    template_id = request.GET.get('template_id', '')
+    
+    try:
+        template = EmailTemplate.objects.get(id=template_id)
+        return JsonResponse({
+            'success': True,
+            'subject': template.subject or '',
+            'message': template.message or '',
+        })
+    except EmailTemplate.DoesNotExist:
+        return JsonResponse({
+            'success': False,
+            'error': 'Template not found'
+        }, status=404)

--- a/email_outbound/views_admin.py
+++ b/email_outbound/views_admin.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.db.models import Q
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
@@ -46,45 +47,160 @@ def email_campaign_edit_process_view(request):
 
     status = ""
 
-    email_template_name = request.POST.get('email_template_name', False)
-    if positive_value_exists(email_template_name):
-        email_template_name = email_template_name.strip()
+    # Get form data
+    campaign_title = request.POST.get('campaign_title', '').strip()
+    email_template_id = request.POST.get('email_template_id', 0)
+    recipient_ids = request.POST.get('recipient_ids', '')
+    email_campaign_id = request.POST.get('email_campaign_id', '')
     google_civic_election_id = request.POST.get('google_civic_election_id', 0)
-    state_code = request.POST.get('state_code', False)
+    state_code = request.POST.get('state_code', '')
 
-    # Since a pointer to performance_list was attached to performance_dict above, the performance_list
-    # data gets passed along within performance_dict. We pass this performance_dict
-    # with the name 'performance_process_dict' so it is clear this is from a "process" view.
-    performance_process_dict_encoded = urlencode({
-        'performance_process_dict': json.dumps(performance_dict)
-    })
-
-    messages.add_message(request, messages.INFO, 'EmailCampaign updated.')
-
-    redirect_url = reverse(
-        'email_outbound:email_campaign_list',
-        args=()) + "?google_civic_election_id=" + str(google_civic_election_id) + \
-        "&state_code=" + str(state_code) + "&" + performance_process_dict_encoded
+    from email_outbound.models import EmailCampaign, EmailCampaignRecipient
+    
+    # Create or update campaign
+    if email_campaign_id:
+        try:
+            campaign = EmailCampaign.objects.get(id=email_campaign_id)
+            campaign.email_campaign_name = campaign_title
+            campaign.email_template_id = email_template_id
+            campaign.save()
+            
+            # Clear existing recipients for this campaign
+            EmailCampaignRecipient.objects.filter(email_campaign_id=campaign.id).delete()
+            messages.add_message(request, messages.SUCCESS, 'Email campaign updated.')
+        except EmailCampaign.DoesNotExist:
+            campaign = EmailCampaign.objects.create(
+                email_campaign_name=campaign_title,
+                email_template_id=email_template_id,
+            )
+            messages.add_message(request, messages.SUCCESS, 'Email campaign created.')
+    else:
+        campaign = EmailCampaign.objects.create(
+            email_campaign_name=campaign_title,
+            email_template_id=email_template_id,
+        )
+        messages.add_message(request, messages.SUCCESS, 'Email campaign created.')
+    
+    # Save recipients
+    if recipient_ids:
+        recipient_list = recipient_ids.split(',')
+        for recipient_id in recipient_list:
+            recipient_id = recipient_id.strip()
+            if recipient_id:
+                # Check if it's an email (starts with 'email_') or a voter ID
+                if recipient_id.startswith('email_'):
+                    email_address = recipient_id.replace('email_', '')
+                    EmailCampaignRecipient.objects.create(
+                        email_campaign_id=campaign.id,
+                        recipient_name=email_address,
+                        voter_we_vote_id='',
+                    )
+                else:
+                    # It's a voter ID - you might want to look up the voter details
+                    EmailCampaignRecipient.objects.create(
+                        email_campaign_id=campaign.id,
+                        voter_we_vote_id=recipient_id,
+                    )
+    
+    # Redirect back to edit page with the campaign ID
+    redirect_url = reverse('email_outbound:email_campaign_edit') + \
+        "?id=" + str(campaign.id) + \
+        "&google_civic_election_id=" + str(google_civic_election_id) + \
+        "&state_code=" + str(state_code)
     return HttpResponseRedirect(redirect_url)
 
 
 @login_required
 def email_campaign_edit_view(request):
-    # admin, analytics_admin, partner_organization, political_data_manager, political_data_viewer, verified_volunteer
+    # Restrict access
     authority_required = {'political_data_manager', 'verified_volunteer'}
     if not voter_has_authority(request, authority_required):
         return redirect_to_sign_in_page(request, authority_required)
 
     google_civic_election_id = request.GET.get('google_civic_election_id', '')
     state_code = request.GET.get('state_code', '')
+    campaign_id = request.GET.get('id', '')
+    
+    # Load existing campaign if editing
+    email_campaign = None
+    campaign_recipients = []
+    if campaign_id:
+        try:
+            from email_outbound.models import EmailCampaign, EmailCampaignRecipient
+            email_campaign = EmailCampaign.objects.get(id=campaign_id)
+            
+            # Load recipients for this campaign
+            recipients = EmailCampaignRecipient.objects.filter(email_campaign_id=campaign_id)
+            campaign_recipients = []
+            for recipient in recipients:
+                if recipient.voter_we_vote_id:
+                    campaign_recipients.append({
+                        'id': recipient.voter_we_vote_id,
+                        'name': recipient.recipient_name or recipient.voter_we_vote_id,
+                    })
+                elif recipient.recipient_name:
+                    campaign_recipients.append({
+                        'id': 'email_' + recipient.recipient_name,
+                        'name': recipient.recipient_name,
+                    })
+        except EmailCampaign.DoesNotExist:
+            pass
+    
+    # Get list of saved campaigns
+    from email_outbound.models import EmailCampaign
+    saved_campaigns = EmailCampaign.objects.filter(deleted=False).order_by('-id')[:10]
 
+    # Step 1: Get folders that are not deleted
+    folder_queryset = EmailTemplateFolder.objects.filter(deleted=False, archived=False).order_by('email_template_name')
+
+    # Get all valid folder IDs
+    valid_folder_ids = list(folder_queryset.values_list('id', flat=True))
+
+    # Step 2: Build a list of folders, each with its templates
+    folder_list = []
+    for folder in folder_queryset:
+        templates_in_folder = EmailTemplate.objects.filter(
+            email_template_folder_id=folder.id,
+            deleted=False,
+            archived=False
+        ).order_by('email_template_name')
+
+        folder_list.append({
+            'id': folder.id,
+            'folder_name': folder.email_template_name,  # For template display
+            'templates': list(templates_in_folder.values('id', 'email_template_name')),
+        })
+
+    # Step 2b: Get templates without a folder (unfiled)
+    # This includes templates with folder_id=0, NULL, or referencing non-existent folders
+    unfiled_templates = EmailTemplate.objects.filter(
+        deleted=False,
+        archived=False
+    ).filter(
+        Q(email_template_folder_id__isnull=True) |
+        Q(email_template_folder_id=0) |
+        ~Q(email_template_folder_id__in=valid_folder_ids)
+    ).order_by('email_template_name')
+
+    # Always add unfiled section at the end (even if empty, so users know it exists)
+    folder_list.append({
+        'id': None,
+        'folder_name': 'Unfiled',
+        'templates': list(unfiled_templates.values('id', 'email_template_name')),
+    })
+
+    # Step 3: Pass data to template
+    import json
     template_values = {
-        # 'election':                                 election,
-        # 'election_list':                            election_list,
-        'google_civic_election_id':                 google_civic_election_id,
-        'state_code':                               state_code,
-        # 'state_list':                               sorted_state_list,
+        'folder_list': folder_list,
+        'folder_list_json': json.dumps(folder_list),
+        'google_civic_election_id': google_civic_election_id,
+        'state_code': state_code,
+        'email_campaign': email_campaign,
+        'saved_campaigns': saved_campaigns,
+        'campaign_recipients': json.dumps(campaign_recipients),
     }
+
     return render(request, 'email_outbound/email_campaign_edit.html', template_values)
 
 

--- a/templates/email_outbound/email_campaign_edit.html
+++ b/templates/email_outbound/email_campaign_edit.html
@@ -97,7 +97,7 @@
 
     <!-- Recipients Section -->
     <div class="mb-3">
-      <label class="form-label">Recipients</label>
+      <label class="form-label">Search Recipients</label>
       <div class="input-group mb-2">
         <input type="text" id="recipient_search" class="form-control" placeholder="Search by name or email...">
         <button type="button" class="btn btn-outline-secondary" id="search_btn">Add Recipient</button>
@@ -120,6 +120,25 @@
       </div>
       
       <input type="hidden" name="recipient_ids" id="recipient_ids_input" value="">
+    </div>
+
+    <!-- Subject Line -->
+    <div class="mb-3">
+      <label for="email_subject" class="form-label">Subject<span class="text-danger">*</span></label>
+      <input type="text" 
+             id="email_subject" 
+             name="email_subject" 
+             class="form-control" 
+             value="{% if email_campaign %}{{ email_campaign.email_subject_template_raw }}{% endif %}"
+             placeholder="Enter email subject"
+             required>
+    </div>
+
+    <!-- Email Preview/Editor -->
+    <div class="mb-3">
+      <label for="email_body" class="form-label">Email Preview</label>
+      <textarea id="email_body" name="email_body" class="form-control" rows="10">{% if email_campaign %}{{ email_campaign.email_body_template_raw }}{% endif %}</textarea>
+      <small class="text-muted">This will auto-populate when you select a template above. You can edit it before sending.</small>
     </div>
 
     <!-- Hidden Context Inputs -->
@@ -372,7 +391,51 @@
     
     // Monitor form changes
     document.getElementById('campaign_title').addEventListener('input', checkFormValidity);
-    templateSelect.addEventListener('change', checkFormValidity);
+    templateSelect.addEventListener('change', function() {
+      checkFormValidity();
+      loadTemplateContent();
+    });
+    
+    // Load template content when template is selected
+    function loadTemplateContent() {
+      const templateId = templateSelect.value;
+      if (!templateId) return;
+      
+      console.log('Loading template content for ID:', templateId);
+      
+      // Fetch template content
+      fetch('/email/template_content/?template_id=' + templateId, {
+        method: 'GET',
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        credentials: 'same-origin'
+      })
+        .then(response => {
+          console.log('Response status:', response.status);
+          if (!response.ok) {
+            throw new Error('HTTP error ' + response.status);
+          }
+          return response.json();
+        })
+        .then(data => {
+          console.log('Template data received:', data);
+          
+          if (data.subject) {
+            document.getElementById('email_subject').value = data.subject;
+          }
+          
+          if (data.message) {
+            // Set textarea value directly
+            document.getElementById('email_body').value = data.message;
+            console.log('Content set successfully');
+          }
+        })
+        .catch(error => {
+          console.error('Error loading template:', error);
+          alert('Failed to load template content. Please try again.');
+        });
+    }
     
     // Handle Send button
     document.getElementById('send-campaign-btn').addEventListener('click', function() {

--- a/templates/email_outbound/email_campaign_edit.html
+++ b/templates/email_outbound/email_campaign_edit.html
@@ -1,16 +1,426 @@
 {# templates/email_outbound/email_campaign_edit.html #}
 {% extends "template_base.html" %}
+{% load static %}
 
-{% block title %}Email Campaigns > New Email Campaign{% endblock %}
+{% block title %}Email Campaigns › New Campaign{% endblock %}
 
-{%  block content %}
-{% load template_filters %}
-{% load humanize %}
+{% block content %}
 {% include "admin_tools/loading_banner.html" %}
+
+<a href="{% url 'email_outbound:email_campaign_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
+    &lt; Back to Email Campaigns
+</a>
+
+<div class="container-fluid mt-4" style="max-width: 1400px;">
+  <div class="row">
+    <!-- Saved Campaigns List (Left Column) -->
+    <div class="col-md-4">
+      <div class="p-3 bg-light rounded border sticky-top" style="top: 20px; max-height: calc(100vh - 100px); overflow-y: auto;">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <h5 class="mb-0">📋 Saved Campaigns</h5>
+          <button type="button" class="btn btn-sm btn-success" onclick="createNewCampaign()" title="Create new campaign">
+            <strong>+ Create</strong>
+          </button>
+        </div>
+        
+        <div class="list-group" id="campaigns-list">
+          {% if saved_campaigns %}
+            {% for campaign in saved_campaigns %}
+            <div class="list-group-item campaign-item {% if email_campaign and email_campaign.id == campaign.id %}active{% endif %}"
+                 data-campaign-id="{{ campaign.id }}">
+              <div class="d-flex justify-content-between align-items-center">
+                <div style="flex: 1; min-width: 0;">
+                  <strong class="d-block text-truncate">{{ campaign.email_campaign_name }}</strong>
+                  <small class="text-muted">
+                    ID: #{{ campaign.id }}{% if campaign.emails_sent %} | <span class="badge badge-success">Sent</span>{% endif %}
+                  </small>
+                </div>
+                <button type="button" class="btn btn-sm btn-outline-primary ml-2" onclick="loadCampaign({{ campaign.id }})">
+                  Edit
+                </button>
+              </div>
+            </div>
+            {% endfor %}
+          {% else %}
+            <p class="text-muted text-center py-3">No saved campaigns yet.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
+    <!-- Campaign Form (Right Column) -->
+    <div class="col-md-8">
+<div class="p-4 bg-white rounded shadow-sm border">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h4 class="mb-0">
+      Email Campaigns › {% if email_campaign %}Edit Campaign{% else %}New Email Campaign{% endif %}
+    </h4>
+    <div>
+      <a href="{% url 'email_outbound:email_campaign_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" class="btn btn-outline-secondary me-2">Cancel</a>
+      <button type="submit" form="email-campaign-form" class="btn btn-primary me-2">Save</button>
+      <button type="button" id="send-campaign-btn" class="btn btn-success" disabled>Send</button>
+    </div>
+  </div>
+
+  <form id="email-campaign-form" method="post" action="{% url 'email_outbound:email_campaign_edit_process' %}">
+    {% csrf_token %}
+
+    <!-- Campaign Name -->
+    <div class="mb-3">
+        <label for="campaign_title" class="form-label">Campaign Name <span class="text-danger">*</span></label>
+        <input type="text"
+               id="campaign_title"
+               name="campaign_title"
+               class="form-control"
+               value="{% if email_campaign %}{{ email_campaign.email_campaign_name }}{% endif %}"
+               placeholder="Enter campaign name"
+               required>
+    </div>
+
+    <!-- Template Selection -->
+    <div class="mb-3">
+      <label for="folder_select" class="form-label">Template Folder</label>
+      <select id="folder_select" class="form-select mb-2">
+        <option value="">-- Select a folder --</option>
+        {% for folder in folder_list %}
+          <option value="{{ forloop.counter0 }}">
+            {% if folder.folder_name == "Unfiled" %}📋{% else %}📁{% endif %} {{ folder.folder_name }}
+          </option>
+        {% endfor %}
+      </select>
+      
+      <label for="template_select" class="form-label">Email Template <span class="text-danger">*</span></label>
+      <select id="template_select" name="email_template_id" class="form-select" required disabled>
+        <option value="">-- Select a folder first --</option>
+      </select>
+    </div>
+
+    <!-- Recipients Section -->
+    <div class="mb-3">
+      <label class="form-label">Recipients</label>
+      <div class="input-group mb-2">
+        <input type="text" id="recipient_search" class="form-control" placeholder="Search by name or email...">
+        <button type="button" class="btn btn-outline-secondary" id="search_btn">Add Recipient</button>
+      </div>
+      
+      <div id="search_results" class="border rounded p-2 mb-2" style="max-height: 300px; overflow-y: auto; display: none;">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <span class="text-muted small">Select recipients to add</span>
+          <button type="button" class="btn btn-sm btn-primary" id="add_selected_btn">Add Selected</button>
+        </div>
+        <div id="search_results_list"></div>
+      </div>
+      
+      <div class="border rounded p-3" style="min-height: 100px; background-color: #f8f9fa;">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <strong>Selected Recipients (<span id="recipient_count">0</span>)</strong>
+          <button type="button" class="btn btn-sm btn-outline-danger" id="clear_all_btn">Clear All</button>
+        </div>
+        <div id="selected_recipients"></div>
+      </div>
+      
+      <input type="hidden" name="recipient_ids" id="recipient_ids_input" value="">
+    </div>
+
+    <!-- Hidden Context Inputs -->
+    <input type="hidden" name="google_civic_election_id" value="{{ google_civic_election_id }}">
+    <input type="hidden" name="state_code" value="{{ state_code }}">
+    <input type="hidden" name="email_campaign_id" id="email_campaign_id" value="{% if email_campaign %}{{ email_campaign.id }}{% endif %}">
+    <input type="hidden" name="selected_template_id" value="{{ selected_template_id }}">
+  </form>
+</div>
+    </div><!-- end col-md-8 -->
+  </div><!-- end row -->
+</div><!-- end container-fluid -->
+{% endblock %}
+
+{% block extrabody %}
+<style>
+  .recipient-chip {
+    display: inline-block;
+    background-color: #007bff;
+    color: white;
+    padding: 5px 10px;
+    margin: 3px;
+    border-radius: 15px;
+    font-size: 0.9em;
+  }
+  .recipient-chip .remove-btn {
+    margin-left: 8px;
+    cursor: pointer;
+    font-weight: bold;
+  }
+  .search-result-item {
+    padding: 8px;
+    border-bottom: 1px solid #dee2e6;
+    cursor: pointer;
+  }
+  .search-result-item:hover {
+    background-color: #f8f9fa;
+  }
+  .search-result-item input[type="checkbox"] {
+    margin-right: 8px;
+  }
+  .campaign-item.active {
+    background-color: #007bff !important;
+    color: white;
+  }
+  .campaign-item.active .text-muted {
+    color: rgba(255, 255, 255, 0.8) !important;
+  }
+  .campaign-item.active .btn-outline-primary {
+    color: white;
+    border-color: white;
+    background-color: transparent;
+  }
+  .campaign-item.active .btn-outline-primary:hover {
+    background-color: white;
+    color: #007bff;
+  }
+</style>
+<script>
+  // Store folder data from Django template
+  const folderData = JSON.parse('{{ folder_list_json|escapejs }}');
+  const selectedRecipients = new Set();
+  
+  document.addEventListener('DOMContentLoaded', function() {
+    const folderSelect = document.getElementById('folder_select');
+    const templateSelect = document.getElementById('template_select');
+    const searchBtn = document.getElementById('search_btn');
+    const recipientSearch = document.getElementById('recipient_search');
+    const searchResults = document.getElementById('search_results');
+    const searchResultsList = document.getElementById('search_results_list');
+    const selectedRecipientsDiv = document.getElementById('selected_recipients');
+    const addSelectedBtn = document.getElementById('add_selected_btn');
+    const clearAllBtn = document.getElementById('clear_all_btn');
     
-    <a href="{% url 'email_outbound:email_campaign_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}">
-        < Back to Email Campaigns</a>
-
-<h1>Email Campaigns > New Email Campaign</h1>
-
+    // Handle folder selection
+    folderSelect.addEventListener('change', function() {
+      const folderIndex = this.value;
+      templateSelect.innerHTML = '<option value="">-- Select a template --</option>';
+      
+      if (folderIndex !== '') {
+        const folder = folderData[folderIndex];
+        if (folder.templates && folder.templates.length > 0) {
+          folder.templates.forEach(template => {
+            const option = document.createElement('option');
+            option.value = template.id;
+            option.textContent = template.email_template_name;
+            templateSelect.appendChild(option);
+          });
+          templateSelect.disabled = false;
+        } else {
+          templateSelect.innerHTML = '<option value="">-- No templates in this folder --</option>';
+          templateSelect.disabled = true;
+        }
+      } else {
+        templateSelect.disabled = true;
+      }
+    });
+    
+    // Handle recipient search
+    searchBtn.addEventListener('click', performSearch);
+    recipientSearch.addEventListener('keypress', function(e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        performSearch();
+      }
+    });
+    
+    function isValidEmail(email) {
+      return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    }
+    
+    function performSearch() {
+      const query = recipientSearch.value.trim();
+      if (query.length < 2) {
+        alert('Please enter at least 2 characters to search');
+        return;
+      }
+      
+      // If it's an email address, add it directly
+      if (isValidEmail(query)) {
+        addRecipientByEmail(query);
+        recipientSearch.value = '';
+        return;
+      }
+      
+      // Make AJAX call to search for voters
+      fetch(`/apis/v1/voterSearch/?search_term=${encodeURIComponent(query)}`)
+        .then(response => response.json())
+        .then(data => {
+          displaySearchResults(data.voters || []);
+        })
+        .catch(error => {
+          console.error('Search error:', error);
+          searchResultsList.innerHTML = '<p class="text-danger">Error searching for recipients</p>';
+        });
+    }
+    
+    function addRecipientByEmail(email) {
+      const emailId = 'email_' + email;
+      addRecipient(emailId, email);
+      updateRecipientInput();
+    }
+    
+    function displaySearchResults(voters) {
+      searchResultsList.innerHTML = '';
+      
+      if (voters.length === 0) {
+        searchResultsList.innerHTML = '<p class="text-muted">No voters found</p>';
+        searchResults.style.display = 'block';
+        return;
+      }
+      
+      voters.forEach(voter => {
+        const item = document.createElement('div');
+        item.className = 'search-result-item';
+        item.innerHTML = `
+          <input type="checkbox" id="voter_${voter.id}" value="${voter.id}" 
+                 ${selectedRecipients.has(voter.id) ? 'checked disabled' : ''}>
+          <label for="voter_${voter.id}" style="cursor: pointer;">
+            ${voter.first_name || ''} ${voter.last_name || ''} 
+            ${voter.email ? '(' + voter.email + ')' : ''}
+          </label>
+        `;
+        searchResultsList.appendChild(item);
+      });
+      
+      searchResults.style.display = 'block';
+    }
+    
+    // Handle adding selected recipients
+    addSelectedBtn.addEventListener('click', function() {
+      const checkboxes = searchResultsList.querySelectorAll('input[type="checkbox"]:checked:not(:disabled)');
+      checkboxes.forEach(checkbox => {
+        const voterId = parseInt(checkbox.value);
+        const label = checkbox.nextElementSibling.textContent.trim();
+        addRecipient(voterId, label);
+      });
+      updateRecipientInput();
+    });
+    
+    function addRecipient(id, name) {
+      if (selectedRecipients.has(id)) return;
+      
+      selectedRecipients.add(id);
+      
+      const chip = document.createElement('span');
+      chip.className = 'recipient-chip';
+      chip.dataset.recipientId = id;
+      const safeId = String(id).replace(/[@.]/g, '_');
+      chip.innerHTML = `${name}<span class="remove-btn" onclick="removeRecipient('${safeId}')">&times;</span>`;
+      
+      selectedRecipientsDiv.appendChild(chip);
+      updateRecipientCount();
+    }
+    
+    window.removeRecipient = function(safeId) {
+      // Find and remove the original ID from the set
+      for (let id of selectedRecipients) {
+        const testSafeId = String(id).replace(/[@.]/g, '_');
+        if (testSafeId === safeId) {
+          selectedRecipients.delete(id);
+          break;
+        }
+      }
+      const chip = selectedRecipientsDiv.querySelector(`[data-recipient-id="${safeId.replace(/_/g, '.')}"]`);
+      if (!chip) {
+        // Try finding by safe ID
+        const chips = selectedRecipientsDiv.querySelectorAll('.recipient-chip');
+        chips.forEach(c => {
+          const cId = String(c.dataset.recipientId).replace(/[@.]/g, '_');
+          if (cId === safeId) c.remove();
+        });
+      } else {
+        chip.remove();
+      }
+      updateRecipientCount();
+      updateRecipientInput();
+    }
+    
+    clearAllBtn.addEventListener('click', function() {
+      if (confirm('Remove all recipients?')) {
+        selectedRecipients.clear();
+        selectedRecipientsDiv.innerHTML = '';
+        updateRecipientCount();
+        updateRecipientInput();
+      }
+    });
+    
+    function updateRecipientCount() {
+      document.getElementById('recipient_count').textContent = selectedRecipients.size;
+    }
+    
+    function updateRecipientInput() {
+      document.getElementById('recipient_ids_input').value = Array.from(selectedRecipients).join(',');
+      checkFormValidity();
+    }
+    
+    function checkFormValidity() {
+      const campaignTitle = document.getElementById('campaign_title').value.trim();
+      const templateId = document.getElementById('template_select').value;
+      const hasRecipients = selectedRecipients.size > 0;
+      const sendBtn = document.getElementById('send-campaign-btn');
+      
+      if (campaignTitle && templateId && hasRecipients) {
+        sendBtn.disabled = false;
+      } else {
+        sendBtn.disabled = true;
+      }
+    }
+    
+    // Monitor form changes
+    document.getElementById('campaign_title').addEventListener('input', checkFormValidity);
+    templateSelect.addEventListener('change', checkFormValidity);
+    
+    // Handle Send button
+    document.getElementById('send-campaign-btn').addEventListener('click', function() {
+      if (confirm('Send this email campaign to ' + selectedRecipients.size + ' recipient(s)?')) {
+        alert('Send functionality will be implemented on the backend.');
+        // TODO: Implement actual send logic
+      }
+    });
+    
+    // Load existing campaign data if editing
+    {% if email_campaign %}
+      // Populate campaign title
+      document.getElementById('campaign_title').value = '{{ email_campaign.email_campaign_name|escapejs }}';
+      
+      // Set template if available
+      {% if email_campaign.email_template_id %}
+        // Find the folder containing this template
+        let templateId = {{ email_campaign.email_template_id }};
+        folderData.forEach((folder, index) => {
+          if (folder.templates.some(t => t.id === templateId)) {
+            folderSelect.value = index;
+            folderSelect.dispatchEvent(new Event('change'));
+            setTimeout(() => {
+              templateSelect.value = templateId;
+              checkFormValidity();
+            }, 100);
+          }
+        });
+      {% endif %}
+      
+      // Load recipients if available
+      const campaignRecipients = JSON.parse('{{ campaign_recipients|escapejs }}');
+      if (campaignRecipients && campaignRecipients.length > 0) {
+        campaignRecipients.forEach(recipient => {
+          addRecipient(recipient.id, recipient.name);
+        });
+        updateRecipientInput();
+      }
+    {% endif %}
+  });
+  
+  // Global functions for campaign management
+  window.createNewCampaign = function() {
+    window.location.href = '{% url "email_outbound:email_campaign_edit" %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}';
+  }
+  
+  window.loadCampaign = function(campaignId) {
+    window.location.href = '{% url "email_outbound:email_campaign_edit" %}?id=' + campaignId + '&google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}';
+  }
+</script>
 {% endblock %}


### PR DESCRIPTION
This PR addresses WV-2164 and adds changes that builds the UI for "Create Email Campaign". Specifically, it adds functionality to:

1. Create a new email campaign by selecting an email template that has been previously saved and adding recipients
2. Save an email campaign and edit it later

Note that the "send" functionality is not yet functional because we have not yet wired this to SendGrid.
See UI (http://localhost:8000/email/edit_campaign/) below:
<img width="1333" height="629" alt="Screenshot 2025-11-16 at 10 13 37 PM" src="https://github.com/user-attachments/assets/d953054f-f764-4c82-b110-cc6f97f826a6" />