### PR TITLE
Fixed problem preventing emails from being sent with HTML formatting. Updated WeVote physical address and changed "We Vote" to "WeVote" in email templates. Replaced "dead_politician" with "stale_politician".

### DIFF
--- a/challenge/views_admin.py
+++ b/challenge/views_admin.py
@@ -877,10 +877,10 @@ def challenge_list_view(request):
     # Maintenance script section START
     # ################################################
 
-    clean_challenges_with_dead_politician_we_vote_id = True
+    clean_challenges_with_stale_politician_we_vote_id = True
     # If a Challenge entry has a politician_we_vote_id which no longer exists, remove the seo_friendly_path
     #  so that entry doesn't block the use of that seo_friendly_path
-    if clean_challenges_with_dead_politician_we_vote_id:
+    if clean_challenges_with_stale_politician_we_vote_id:
         number_to_update = 5000  # Set to 5,000 at a time
         politician_we_vote_id_list = []
         total_to_update_after = 0
@@ -933,7 +933,7 @@ def challenge_list_view(request):
             except Exception as e:
                 messages.add_message(
                     request, messages.ERROR,
-                    "ERROR with clean_challenges_with_dead_politician_we_vote_id: {e} "
+                    "ERROR with clean_challenges_with_stale_politician_we_vote_id: {e} "
                     "politician_we_vote_ids_not_found_list: {politician_we_vote_ids_not_found_list}"
                     "".format(e=e,
                               politician_we_vote_ids_not_found_list=politician_we_vote_ids_not_found_list))

--- a/email_outbound/models.py
+++ b/email_outbound/models.py
@@ -1126,7 +1126,7 @@ class EmailManager(models.Manager):
                 message.content = Content(
                     MimeType.text,
                     email_scheduled.message_text)
-            else:
+            if email_scheduled.message_html:
                 message.content = Content(
                     MimeType.html,
                     email_scheduled.message_html)

--- a/templates/email_outbound/email_templates/campaignx_friend_has_supported.html
+++ b/templates/email_outbound/email_templates/campaignx_friend_has_supported.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/campaignx_friend_has_supported.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">{# Later we replace "Your   friend" with the sender name. #}
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -123,7 +123,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Campaigns Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from WeVote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />WeVote, Attention: Campaigns Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/campaignx_friend_has_supported.txt
+++ b/templates/email_outbound/email_templates/campaignx_friend_has_supported.txt
@@ -19,11 +19,11 @@ Click to see: {{ campaignx_url }}
 Please support these candidates too! Every vote counts, and many elections are won by a small number of voters.
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Campaigns Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Campaigns Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/campaignx_news_item.html
+++ b/templates/email_outbound/email_templates/campaignx_news_item.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/campaignx_news_item.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -173,7 +173,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:22px;color:#424242;line-height:24px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a> via the nonpartisan website WeVote.US. We Vote did not create this campaign, is not responsible for its content, and does not support or oppose any political candidate or party. If you don&#039;t want to receive emails from this campaign, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:22px;color:#424242;line-height:24px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a> via the nonpartisan website WeVote.US. WeVote did not create this campaign, is not responsible for its content, and does not support or oppose any political candidate or party. If you don&#039;t want to receive emails from this campaign, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.</td>
                   </tr>
                 </table>
               </td>
@@ -187,7 +187,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:22px;color:#424242;line-height:24px;">We Vote<br />Attention: Campaigns Team<br />1423 Broadway PMB 158,<br />Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:22px;color:#424242;line-height:24px;">We Vote<br />Attention: Campaigns Team<br />1440 Broadway Ste 200, #158,<br />Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/campaignx_news_item.txt
+++ b/templates/email_outbound/email_templates/campaignx_news_item.txt
@@ -21,10 +21,10 @@ Click to see or share: {{ campaignx_news_item_url }}
 ========================================
 You supported this campaign{% if speaker_voter_name %} from {{ speaker_voter_name }}{% endif %}{% if date_supported %} on {{ date_supported }}{% endif %}.
 
-This message was sent to {{ recipient_voter_email }} via the nonpartisan website WeVote.US. We Vote did not create this campaign, is not responsible for its content, and does not support or oppose any political candidate or party. If you don't want to receive emails from this campaign, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }} via the nonpartisan website WeVote.US. WeVote did not create this campaign, is not responsible for its content, and does not support or oppose any political candidate or party. If you don't want to receive emails from this campaign, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
 
-We Vote
+WeVote
 Attention: Campaigns Team
-1423 Broadway PMB 158,
+1440 Broadway Ste 200, #158,
 Oakland, CA 94612

--- a/templates/email_outbound/email_templates/campaignx_super_share_item.html
+++ b/templates/email_outbound/email_templates/campaignx_super_share_item.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/campaignx_super_share_item.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">{# Later we replace "Your   friend" with the sender name. #}
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -189,7 +189,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_email_address }}" style="color:#3b5998;text-decoration:none;">{{ recipient_email_address }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Campaigns Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_email_address }}" style="color:#3b5998;text-decoration:none;">{{ recipient_email_address }}</a>. If you don&#039;t want to receive emails from WeVote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Campaigns Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/campaignx_super_share_item.txt
+++ b/templates/email_outbound/email_templates/campaignx_super_share_item.txt
@@ -24,11 +24,11 @@ See Home Page
 ========================================
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_email_address }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_email_address }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Campaigns Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Campaigns Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/campaignx_supporter_initial_response.html
+++ b/templates/email_outbound/email_templates/campaignx_supporter_initial_response.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/campaignx_supporter_initial_response.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">{# Later we replace "Your   friend" with the sender name. #}
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -148,7 +148,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:22px;color:#424242;line-height:24px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Campaigns Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:22px;color:#424242;line-height:24px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from WeVote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />WeVote, Attention: Campaigns Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/campaignx_supporter_initial_response.txt
+++ b/templates/email_outbound/email_templates/campaignx_supporter_initial_response.txt
@@ -22,11 +22,11 @@ Click to share: {{ campaignx_share_campaign_url }}
 
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Campaigns Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Campaigns Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/friend_accepted_invitation.html
+++ b/templates/email_outbound/email_templates/friend_accepted_invitation.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/friend_accepted_invitation.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -43,7 +43,7 @@
                     <td height="28" style="line-height:28px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:20px;line-height:24px;color:#141823;"><a href="{{ see_your_friend_list_url }}" style="color:#3b5998;text-decoration:none;">{% if sender_name %}{{ sender_name }}{% else %}Your friend{% endif %}</a>{% if sender_email_address %} ({{ sender_email_address }}){% endif %} has accepted your invitation to be friends on We Vote.</span></td>
+                    <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:20px;line-height:24px;color:#141823;"><a href="{{ see_your_friend_list_url }}" style="color:#3b5998;text-decoration:none;">{% if sender_name %}{{ sender_name }}{% else %}Your friend{% endif %}</a>{% if sender_email_address %} ({{ sender_email_address }}){% endif %} has accepted your invitation to be friends on WeVote.</span></td>
                   </tr>
                   <tr style="">
                     <td height="14" style="line-height:14px;">&nbsp;</td>
@@ -160,7 +160,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from WeVote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/friend_accepted_invitation.txt
+++ b/templates/email_outbound/email_templates/friend_accepted_invitation.txt
@@ -5,7 +5,7 @@ Hello {{ recipient_name }},
 Hello,
 {% endif %}
 
-{% if sender_name %}{{ sender_name }}{% else %}Your friend{% endif %}{% if sender_email_address %} ({{ sender_email_address }}){% endif %} has accepted your invitation to be friends on We Vote.
+{% if sender_name %}{{ sender_name }}{% else %}Your friend{% endif %}{% if sender_email_address %} ({{ sender_email_address }}){% endif %} has accepted your invitation to be friends on WeVote.
 {% if invitation_message %}
 "{{ invitation_message }}"{% endif %}
 
@@ -15,11 +15,11 @@ See All Of Your Friends
 
 {% endif %}
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe.
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe.
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/friend_invitation.html
+++ b/templates/email_outbound/email_templates/friend_invitation.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/friend_invitation.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">{# Later we replace "Your   friend" with the sender name. #}
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -48,7 +48,7 @@
                     <td height="28" style="line-height:28px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:20px;line-height:24px;color:#141823;"><a href="{{ see_all_friend_requests_url }}" style="color:#3b5998;text-decoration:none;">{% if sender_name %}{{ sender_name }}{% else %}Your   friend{% endif %}</a>{% if sender_email_address %} ({{ sender_email_address }}){% elif sms_phone_number %} ({{ sms_phone_number }}){% endif %} wants to be friends with you on We Vote. Voting is better with friends!</span></td>
+                    <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:20px;line-height:24px;color:#141823;"><a href="{{ see_all_friend_requests_url }}" style="color:#3b5998;text-decoration:none;">{% if sender_name %}{{ sender_name }}{% else %}Your   friend{% endif %}</a>{% if sender_email_address %} ({{ sender_email_address }}){% elif sms_phone_number %} ({{ sms_phone_number }}){% endif %} wants to be friends with you on WeVote. Voting is better with friends!</span></td>
                   </tr>
                   <tr style="">
                     <td height="14" style="line-height:14px;">&nbsp;</td>
@@ -178,7 +178,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from WeVote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/friend_invitation.txt
+++ b/templates/email_outbound/email_templates/friend_invitation.txt
@@ -17,16 +17,16 @@ Hello {{ recipient_name }},
 Hello,
 {% endif %}
 
-{% if sender_name %}{{ sender_name }}{% else %}Your   friend{% endif %}{% if sender_email_address %} ({{ sender_email_address }}){% elif sms_phone_number %} ({{ sms_phone_number }}){% endif %} wants to be friends with you on We Vote, a simple way to plan your entire ballot. If you confirm, each of you will see what the other supports or opposes.
+{% if sender_name %}{{ sender_name }}{% else %}Your   friend{% endif %}{% if sender_email_address %} ({{ sender_email_address }}){% elif sms_phone_number %} ({{ sms_phone_number }}){% endif %} wants to be friends with you on WeVote, a simple way to plan your entire ballot. If you confirm, each of you will see what the other supports or opposes.
 {% if invitation_message %}
 "{{ invitation_message }}"{% endif %}
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/generic_email.txt
+++ b/templates/email_outbound/email_templates/generic_email.txt
@@ -17,14 +17,14 @@ Hello {{ recipient_name }},
 Hello,
 {% endif %}
 
-{% if sender_name %}{{sender_name}}{% else %}{{sender_email_address}{% endif %} wants to be friends with you on We Vote.
+{% if sender_name %}{{sender_name}}{% else %}{{sender_email_address}{% endif %} wants to be friends with you on WeVote.
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/link_to_sign_in.html
+++ b/templates/email_outbound/email_templates/link_to_sign_in.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/link_to_sign_in.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -14,7 +14,7 @@
               <td height="20" style="line-height:20px;" colspan="3">&nbsp;</td>
             </tr>
             <tr>
-              <td height="1" colspan="3" style="line-height:1px;"><span style="color:#FFFFFF;display:none !important;font-size:1px;">Click to sign in to We Vote</span></td>
+              <td height="1" colspan="3" style="line-height:1px;"><span style="color:#FFFFFF;display:none !important;font-size:1px;">Click to sign in to WeVote</span></td>
             </tr>
             <tr>
               <td width="15" style="display:block;width:15px;">&nbsp;&nbsp;&nbsp;</td>
@@ -42,7 +42,7 @@
                   </tr>
                   <tr>
                     <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:20px;line-height:24px;color:#141823;">
-                        Please <a href="{{ link_to_sign_in }}" style="color:#3b5998;text-decoration:none;">sign in to We Vote</a>
+                        Please <a href="{{ link_to_sign_in }}" style="color:#3b5998;text-decoration:none;">sign in to WeVote</a>
                         so you can save your ballot and invite your friends. If the button does not work, please copy and paste this link into a browser: {{ link_to_sign_in }}</span></td>
                   </tr>
                   <tr style="">
@@ -94,7 +94,7 @@
                         You can notify us that there was a problem by forwarding this email to info@WeVote.US.<br />
                     <br />
                     Thank you,<br />
-                    The We Vote Team</span></td>
+                    The WeVote Team</span></td>
                   </tr>
                   <tr style="">
                     <td height="14" style="line-height:14px;">&nbsp;</td>
@@ -115,8 +115,8 @@
                   </tr>
                   <tr>
                     <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>.
-                        If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />
-                        We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                        If you don&#039;t want to receive emails from WeVote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />
+                        WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/link_to_sign_in.txt
+++ b/templates/email_outbound/email_templates/link_to_sign_in.txt
@@ -1,16 +1,16 @@
 Hello,
 
-Please follow the link below to sign into We Vote.
+Please follow the link below to sign into WeVote.
 {{ link_to_sign_in }}
 
-If you did not request this link to We Vote, please do not follow the link. You can notify us that there was a problem by forwarding this email to info@WeVote.US.
+If you did not request this link to WeVote, please do not follow the link. You can notify us that there was a problem by forwarding this email to info@WeVote.US.
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/message_to_friend.html
+++ b/templates/email_outbound/email_templates/message_to_friend.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/message_to_friend.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">{# Later we replace "Your   friend" with the sender name. #}
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -162,7 +162,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from WeVote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/message_to_friend.txt
+++ b/templates/email_outbound/email_templates/message_to_friend.txt
@@ -17,11 +17,11 @@ Hello,
 "{{ message_to_friend }}"{% endif %}
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/notice_friend_endorsements.html
+++ b/templates/email_outbound/email_templates/notice_friend_endorsements.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/notice_friend_endorsements.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">{# Later we replace "Your   friend" with the sender name. #}
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -173,7 +173,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/notice_friend_endorsements.txt
+++ b/templates/email_outbound/email_templates/notice_friend_endorsements.txt
@@ -22,11 +22,11 @@ Hello,
 "{{ invitation_message }}"{% endif %}
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/notice_voter_daily_summary.html
+++ b/templates/email_outbound/email_templates/notice_voter_daily_summary.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/notice_voter_daily_summary.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">{# Later we replace "Your   friend" with the sender name. #}
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -181,7 +181,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/notice_voter_daily_summary.txt
+++ b/templates/email_outbound/email_templates/notice_voter_daily_summary.txt
@@ -26,11 +26,11 @@ Hello,
 {% endfor %}
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/remind_contact.html
+++ b/templates/email_outbound/email_templates/remind_contact.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/remind_contact.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">{# Later we replace "Your   friend" with the sender name. #}
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -125,13 +125,13 @@
                     <td height="21" style="line-height:21px;">&nbsp;</td>
                   </tr>
                   <tr>
-                      <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:20px;line-height:24px;color:#141823;">Not sure who to vote for? <a href="{{ ready_page_url_using_shared_item_code }}" style="color:#0834CD;display:block;">View your ballot on We Vote</a></span></td>
+                      <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:20px;line-height:24px;color:#141823;">Not sure who to vote for? <a href="{{ ready_page_url_using_shared_item_code }}" style="color:#0834CD;display:block;">View your ballot on WeVote</a></span></td>
                   </tr>
                   <tr style="">
                     <td height="21" style="line-height:21px;">&nbsp;</td>
                   </tr>
                   <tr>
-                      <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:20px;line-height:24px;color:#141823;"><a href="{{ we_vote_url }}" style="color:#0834CD;display:block;">What is We Vote?</a></span></td>
+                      <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:20px;line-height:24px;color:#141823;"><a href="{{ we_vote_url }}" style="color:#0834CD;display:block;">What is WeVote?</a></span></td>
                   </tr>
                   <tr style="">
                     <td height="14" style="line-height:14px;">&nbsp;</td>
@@ -151,7 +151,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/remind_contact.txt
+++ b/templates/email_outbound/email_templates/remind_contact.txt
@@ -4,7 +4,7 @@ View your ballot: {{ url_with_shared_item_code }}
 
 {% endif %}
 {% if we_vote_url %}
-What is We Vote? {{ we_vote_url }}
+What is WeVote? {{ we_vote_url }}
 
 {% endif %}
 ========================================
@@ -20,11 +20,11 @@ Hello,
 "{{ invitation_message }}"{% endif %}
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/send_ballot_to_friends.html
+++ b/templates/email_outbound/email_templates/send_ballot_to_friends.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/send_ballot_to_friends.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -43,7 +43,7 @@
                     <td height="28" style="line-height:28px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;line-height:21px;color:#141823;"><a href="{{ ballot_link }}" style="color:#3b5998;text-decoration:none;">{% if sender_name %}{{ sender_name }}{% else %}{{ sender_email_address }}{% endif %}</a> has invited you to view your ballot on We Vote. This is the view they recommend:</span></td>
+                    <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;line-height:21px;color:#141823;"><a href="{{ ballot_link }}" style="color:#3b5998;text-decoration:none;">{% if sender_name %}{{ sender_name }}{% else %}{{ sender_email_address }}{% endif %}</a> has invited you to view your ballot on WeVote. This is the view they recommend:</span></td>
                   </tr>
                   <tr style="">
                     <td height="7" style="line-height:7px;">&nbsp;</td>
@@ -66,7 +66,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:11px;color:#424242;line-height:16px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:11px;color:#424242;line-height:16px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from WeVote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/send_ballot_to_friends.txt
+++ b/templates/email_outbound/email_templates/send_ballot_to_friends.txt
@@ -5,18 +5,18 @@ Hello,
 {% endif %}
 
 {% if sender_name %}{{ sender_name }}{% else %}{{ sender_email_address }}{% endif %} has invited you to view
-your ballot on We Vote. This is the view they recommend:
+your ballot on WeVote. This is the view they recommend:
 "{{ ballot_link }}"
 
 {% if invitation_message %}
 "{{ invitation_message }}"{% endif %}
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/send_ballot_to_self.html
+++ b/templates/email_outbound/email_templates/send_ballot_to_self.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/send_ballot_to_self.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -49,7 +49,7 @@
                     <td height="14" style="line-height:14px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;line-height:21px;color:#141823;">This is a link to the ballot you were viewing on We Vote. Please feel free to forward to friends!</span></td>
+                    <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;line-height:21px;color:#141823;">This is a link to the ballot you were viewing on WeVote. Please feel free to forward to friends!</span></td>
                   </tr>
                   <tr>
                     <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;line-height:21px;color:#141823;"><a href="{{ ballot_link }}" style="color:#3b5998;text-decoration:none;">{{ ballot_link }}</a></span></td>
@@ -69,7 +69,7 @@
                     <td height="16" style="line-height:16px;">&nbsp;</td>
                   </tr>
                   <tr>
-                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:11px;color:#424242;line-height:16px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                    <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:11px;color:#424242;line-height:16px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>. If you don&#039;t want to receive emails from WeVote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/send_ballot_to_self.txt
+++ b/templates/email_outbound/email_templates/send_ballot_to_self.txt
@@ -4,18 +4,18 @@ Hello {{ sender_name }},
 Hello,
 {% endif %}
 
-This is a link to the ballot you were viewing on We Vote. Please feel free to forward to friends!
+This is a link to the ballot you were viewing on WeVote. Please feel free to forward to friends!
 "{{ ballot_link }}"
 
 {% if invitation_message %}
 "{{ invitation_message }}"{% endif %}
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/sign_in_code_email.html
+++ b/templates/email_outbound/email_templates/sign_in_code_email.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/link_to_sign_in.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -42,7 +42,7 @@
                   </tr>
                   <tr>
                     <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:20px;line-height:24px;color:#141823;">
-                        To sign into We Vote, please enter the following code on the page (in your browser, or in the We Vote App) where you requested your sign in code: {{ secret_numerical_code }}</span></td>
+                        To sign into WeVote, please enter the following code on the page (in your browser, or in the WeVote App) where you requested your sign in code: {{ secret_numerical_code }}</span></td>
                   </tr>
                   <tr style="">
                     <td height="14" style="line-height:14px;">&nbsp;</td>
@@ -92,7 +92,7 @@
                       If you did not visit www.WeVote.US, you can notify us by forwarding this email to info@WeVote.US.<br />
                     <br />
                     Thank you,<br />
-                    The We Vote Team</span></td>
+                    The WeVote Team</span></td>
                   </tr>
                   <tr style="">
                     <td height="14" style="line-height:14px;">&nbsp;</td>
@@ -113,8 +113,8 @@
                   </tr>
                   <tr>
                     <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>.
-                        If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />
-                        We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                        If you don&#039;t want to receive emails from WeVote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />
+                        WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/sign_in_code_email.txt
+++ b/templates/email_outbound/email_templates/sign_in_code_email.txt
@@ -1,16 +1,16 @@
 Hello,
 
-To sign into We Vote, please enter the following code on the page where you requested your sign in code:
+To sign into WeVote, please enter the following code on the page where you requested your sign in code:
 {{ secret_numerical_code }}
 
-If you did not request this link to We Vote, please do not follow the link. You can notify us that there was a problem by forwarding this email to info@WeVote.US.
+If you did not request this link to WeVote, please do not follow the link. You can notify us that there was a problem by forwarding this email to info@WeVote.US.
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612

--- a/templates/email_outbound/email_templates/verify_email_address.html
+++ b/templates/email_outbound/email_templates/verify_email_address.html
@@ -1,7 +1,7 @@
 {# email_outbound/email_templates/verify_email_address.html #}<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional //EN">
 <html lang="en">
   <head>
-    <title>We Vote</title>
+    <title>WeVote</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>@media all and (max-width: 480px){*[class].ib_t{min-width:100% !important}*[class].ib_row{display:block !important}*[class].ib_ext{display:block !important;padding:10px 0 5px 0;vertical-align:top !important;width:100% !important}*[class].ib_img,*[class].ib_mid{vertical-align:top !important}*[class].mb_blk{display:block !important;padding-bottom:10px;width:100% !important}*[class].mb_hide{display:none !important}*[class].mb_inl{display:inline !important}}.mb_text h1,.mb_text h2,.mb_text h3,.mb_text h4,.mb_text h5,.mb_text h6{line-height:normal}</style>
   </head>
@@ -14,7 +14,7 @@
               <td height="20" style="line-height:20px;" colspan="3">&nbsp;</td>
             </tr>
             <tr>
-              <td height="1" colspan="3" style="line-height:1px;"><span style="color:#FFFFFF;display:none !important;font-size:1px;">Verify your email so you can invite your friends to We Vote</span></td>
+              <td height="1" colspan="3" style="line-height:1px;"><span style="color:#FFFFFF;display:none !important;font-size:1px;">Verify your email so you can invite your friends to WeVote</span></td>
             </tr>
             <tr>
               <td width="15" style="display:block;width:15px;">&nbsp;&nbsp;&nbsp;</td>
@@ -43,7 +43,7 @@
                   <tr>
                     <td style=""><span class="mb_text" style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:20px;line-height:24px;color:#141823;">
                         Please <a href="{{ verify_email_link }}" style="color:#3b5998;text-decoration:none;">verify your email</a>
-                        so you can save your ballot and invite your friends to We Vote. If the Verify Email button does not work, please copy and paste this link into a browser: {{ verify_email_link }}</td>
+                        so you can save your ballot and invite your friends to WeVote. If the Verify Email button does not work, please copy and paste this link into a browser: {{ verify_email_link }}</td>
                   </tr>
                   <tr style="">
                     <td height="14" style="line-height:14px;">&nbsp;</td>
@@ -93,7 +93,7 @@
                         You can notify us that there was a problem by forwarding this email to info@WeVote.US.<br />
                     <br />
                     Thank you,<br />
-                    The We Vote Team</span></td>
+                    The WeVote Team</span></td>
                   </tr>
                   <tr style="">
                     <td height="14" style="line-height:14px;">&nbsp;</td>
@@ -114,8 +114,8 @@
                   </tr>
                   <tr>
                     <td style="font-family:Helvetica Neue,Helvetica,Lucida Grande,tahoma,verdana,arial,sans-serif;font-size:16px;color:#424242;line-height:20px;">This message was sent to <a href="mailto:{{ recipient_voter_email }}" style="color:#3b5998;text-decoration:none;">{{ recipient_voter_email }}</a>.
-                        If you don&#039;t want to receive emails from We Vote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />
-                        We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612</td>
+                        If you don&#039;t want to receive emails from WeVote, please <a href="{{ recipient_unsubscribe_url }}" style="color:#3b5998;text-decoration:none;">unsubscribe</a>.<br />
+                        WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612</td>
                   </tr>
                 </table>
               </td>

--- a/templates/email_outbound/email_templates/verify_email_address.txt
+++ b/templates/email_outbound/email_templates/verify_email_address.txt
@@ -1,16 +1,16 @@
 Hello,
 
-Please follow the link below to verify your email so you can save your ballot and invite your friends to We Vote.
+Please follow the link below to verify your email so you can save your ballot and invite your friends to WeVote.
 {{ verify_email_link }}
 
-If you did not sign up for We Vote, please do not follow the link. You can notify us that there was a problem by forwarding this email to info@WeVote.US.
+If you did not sign up for WeVote, please do not follow the link. You can notify us that there was a problem by forwarding this email to info@WeVote.US.
 
 Thank you,
-The We Vote Team
+The WeVote Team
 
 
 
 ========================================
-This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from We Vote, please follow the link below to unsubscribe:
+This message was sent to {{ recipient_voter_email }}. If you don't want to receive emails from WeVote, please follow the link below to unsubscribe:
 {{ recipient_unsubscribe_url }}
-We Vote, Attention: Community Team, 1423 Broadway PMB 158, Oakland, CA 94612
+WeVote, Attention: Community Team, 1440 Broadway Ste 200, #158, Oakland, CA 94612


### PR DESCRIPTION
Fixed problem preventing emails from being sent with HTML formatting. Updated WeVote physical address and changed "We Vote" to "WeVote" in email templates. Replaced "dead_politician" with "stale_politician".