### PR TITLE
[WV-2171] address link candidates slowdown

### DIFF
--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -1680,8 +1680,8 @@ def candidate_new_search_process_view(request):
     politician_list_found = False
     if positive_value_exists(politician_list) and len(politician_list) > 0:
         politician_list_found = True
-        from politician.controllers import find_candidates_to_link_to_this_politician
-        related_candidate_list = find_candidates_to_link_to_this_politician(politician=politician_list[0])
+        from politician.controllers import queryset_find_candidates_to_link_to_this_politician
+        related_candidate_list = queryset_find_candidates_to_link_to_this_politician(politician=politician_list[0])
         for candidate in candidate_list:
             candidate_we_vote_id_list.append(candidate.we_vote_id)
         for candidate in related_candidate_list:

--- a/politician/controllers.py
+++ b/politician/controllers.py
@@ -528,7 +528,7 @@ def find_candidates_to_link_to_this_politician(politician=None):
         related_candidate_list = related_candidate_list.order_by('candidate_name')[:20]
     except Exception as e:
         related_candidate_list = []
-    return related_candidate_list
+    return list(related_candidate_list)
 
 
 def find_representatives_to_link_to_this_politician(politician=None):

--- a/politician/controllers.py
+++ b/politician/controllers.py
@@ -445,7 +445,7 @@ def find_campaignx_list_to_link_to_this_politician(politician=None):
     return related_list
 
 
-def find_candidates_to_link_to_this_politician(politician=None):
+def queryset_find_candidates_to_link_to_this_politician(politician=None):
     """
     Find Candidates to Link to this Politician
     Finding Candidates that *might* be "children" of this politician
@@ -528,7 +528,8 @@ def find_candidates_to_link_to_this_politician(politician=None):
         related_candidate_list = related_candidate_list.order_by('candidate_name')[:20]
     except Exception as e:
         related_candidate_list = []
-    return list(related_candidate_list)
+    
+    return related_candidate_list
 
 
 def find_representatives_to_link_to_this_politician(politician=None):

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -1787,8 +1787,8 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         # Find Candidates to Link to this Politician
         # Finding Candidates that *might* be "children" of this politician
         t0 = time()
-        from politician.controllers import find_candidates_to_link_to_this_politician
-        related_candidate_list = find_candidates_to_link_to_this_politician(politician=politician_on_stage)
+        # from politician.controllers import queryset_find_candidates_to_link_to_this_politician
+        # related_candidate_list = queryset_find_candidates_to_link_to_this_politician(politician=politician_on_stage)
 
         # Find possible duplicate politicians
         duplicate_politician_list = []
@@ -2202,7 +2202,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             },
             'rating_list':                  rating_list,
             'related_campaignx_list':       related_campaignx_list,
-            'related_candidate_list':       related_candidate_list,
+            # 'related_candidate_list':       related_candidate_list,
             'related_representative_list':  related_representative_list,
             'state_code':                   state_code,
             'state_code_dict':
@@ -3592,50 +3592,50 @@ def politician_edit_process_view(request):
     # ##################################
     # Find Candidates to Link to this Politician
     # Finding Candidates that *might* be "children" of this politician
-    t0 = time()
-    from politician.controllers import find_candidates_to_link_to_this_politician
+    # t0 = time()
+    # from politician.controllers import queryset_find_candidates_to_link_to_this_politician
 
-    # Note, this returns a queryset which is evaluated when converted to a list
-    related_candidate_list = find_candidates_to_link_to_this_politician(politician=politician_on_stage)
+    # # Note, this returns a queryset which is evaluated when converted to a list
+    # related_candidate_list = queryset_find_candidates_to_link_to_this_politician(politician=politician_on_stage)
 
-    performance_list.append({
-        'enum_key': 'RET_CANDIDATES_TO_LINK',
-        'time_difference': round(time() - t0, 4),
-    })
+    # performance_list.append({
+    #     'enum_key': 'RET_CANDIDATES_TO_LINK',
+    #     'time_difference': round(time() - t0, 4),
+    # })
 
-    # ##################################
-    # Link Candidates to this Politician
-    t0 = time()
-    # Transaction ensures all candidate saves and position_list_manager updates are committed together
-    with transaction.atomic():
-        for candidate in related_candidate_list:
-            if positive_value_exists(candidate.id):
-                variable_name = "link_candidate_" + str(candidate.id) + "_to_politician"
-                link_candidate = positive_value_exists(request.POST.get(variable_name, False))
-                if positive_value_exists(link_candidate) and positive_value_exists(politician_we_vote_id):
-                    candidate.politician_id = politician_id
-                    candidate.politician_we_vote_id = politician_we_vote_id
-                    candidate.seo_friendly_path = politician_on_stage.seo_friendly_path
-                    if not positive_value_exists(candidate.vote_usa_politician_id) and \
-                            positive_value_exists(vote_usa_politician_id):
-                        candidate.vote_usa_politician_id = vote_usa_politician_id
-                    candidate.save()
-                    # Now update positions
-                    results = position_list_manager.update_politician_we_vote_id_in_all_positions(
-                        candidate_we_vote_id=candidate.we_vote_id,
-                        new_politician_id=politician_id,
-                        new_politician_we_vote_id=politician_we_vote_id)
+    # # ##################################
+    # # Link Candidates to this Politician
+    # t0 = time()
+    # # Transaction ensures all candidate saves and position_list_manager updates are committed together
+    # with transaction.atomic():
+    #     for candidate in related_candidate_list:
+    #         if positive_value_exists(candidate.id):
+    #             variable_name = "link_candidate_" + str(candidate.id) + "_to_politician"
+    #             link_candidate = positive_value_exists(request.POST.get(variable_name, False))
+    #             if positive_value_exists(link_candidate) and positive_value_exists(politician_we_vote_id):
+    #                 candidate.politician_id = politician_id
+    #                 candidate.politician_we_vote_id = politician_we_vote_id
+    #                 candidate.seo_friendly_path = politician_on_stage.seo_friendly_path
+    #                 if not positive_value_exists(candidate.vote_usa_politician_id) and \
+    #                         positive_value_exists(vote_usa_politician_id):
+    #                     candidate.vote_usa_politician_id = vote_usa_politician_id
+    #                 candidate.save()
+    #                 # Now update positions
+    #                 results = position_list_manager.update_politician_we_vote_id_in_all_positions(
+    #                     candidate_we_vote_id=candidate.we_vote_id,
+    #                     new_politician_id=politician_id,
+    #                     new_politician_we_vote_id=politician_we_vote_id)
 
-                    messages.add_message(request, messages.INFO,
-                                        'Candidate linked, number of positions changed: {number_changed}'
-                                        ''.format(number_changed=results['number_changed']))
-                else:
-                    pass
+    #                 messages.add_message(request, messages.INFO,
+    #                                     'Candidate linked, number of positions changed: {number_changed}'
+    #                                     ''.format(number_changed=results['number_changed']))
+    #             else:
+    #                 pass
 
-    performance_list.append({
-        'enum_key': 'LINK_CANDIDATES',
-        'time_difference': round(time() - t0, 4),
-    })
+    # performance_list.append({
+    #     'enum_key': 'LINK_CANDIDATES',
+    #     'time_difference': round(time() - t0, 4),
+    # })
 
     # ##################################
     # Find Representatives to Link to this Politician

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -3595,6 +3595,7 @@ def politician_edit_process_view(request):
     t0 = time()
     from politician.controllers import find_candidates_to_link_to_this_politician
 
+    # Note, this returns a queryset which is evaluated when converted to a list
     related_candidate_list = find_candidates_to_link_to_this_politician(politician=politician_on_stage)
 
     performance_list.append({


### PR DESCRIPTION
Commenting out usage of `queryset_find_candidates_to_link_to_this_politician` (previously `find_candidates_to_link_to_this_politician`) until data scrubbing and/or indexing can be resolved.

Also appending `queryset_` to the name to clarify what is returned. 

New ticket to resolve this issue: https://wevoteusa.atlassian.net/browse/WV-2296
