### PR TITLE
Fix candidate search 502 timeout and exclude sub-snapshots from Speed Statistics totals

### DIFF
--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -707,8 +707,7 @@ def candidate_list_view(request):
     # Now retrieve the candidate_list from the filtered_candidate_we_vote_id_list
     t0 = time()
     try:
-        filters = Q()
-        excludes = Q()
+        candidate_query = CandidateCampaign.objects.using('readonly').all()
 
         t0_A = time()
         if positive_value_exists(google_civic_election_id_list_generated) \
@@ -716,28 +715,31 @@ def candidate_list_view(request):
                 or positive_value_exists(show_this_year_of_candidates_restriction):
             datetime_now = localtime(now()).date()  # We Vote uses Pacific Time for TIME_ZONE
             current_year = datetime_now.year
-            # # We could include all candidates in this year
-            # candidate_query = candidate_query.filter(
-            #     Q(we_vote_id__in=filtered_candidate_we_vote_id_list) |
-            #     Q(candidate_year=current_year)
-            # )
-            # We currently only add the year when searching
-            if positive_value_exists(candidate_search):
-                filters &= (Q(we_vote_id__in=filtered_candidate_we_vote_id_list) | Q(candidate_year=current_year))
+
+            if filtered_candidate_we_vote_id_list:
+                # We currently only add the year when searching
+                if positive_value_exists(candidate_search):
+                    candidate_query = candidate_query.filter(
+                        Q(we_vote_id__in=filtered_candidate_we_vote_id_list) |
+                        Q(candidate_year=current_year))
+                else:
+                    candidate_query = candidate_query.filter(
+                        we_vote_id__in=filtered_candidate_we_vote_id_list)
             else:
-                filters &= Q(we_vote_id__in=filtered_candidate_we_vote_id_list)
+                if not show_all_elections:
+                    candidate_query = candidate_query.none()
 
         if positive_value_exists(exclude_candidate_analysis_done):
-            excludes |= Q(candidate_analysis_done=True)
+            candidate_query = candidate_query.exclude(candidate_analysis_done=True)
         if positive_value_exists(no_supporters):
-            excludes |= Q(supporters_count__gt=0)
+            candidate_query = candidate_query.exclude(supporters_count__gt=0)
         if positive_value_exists(state_code):
-            filters &= Q(state_code__iexact=state_code)
+            candidate_query = candidate_query.filter(state_code__iexact=state_code)
 
         t1_A = time()
         performance_list.append({
             'name': 'Subsnapshot_FilterSetup',
-            'description': 'Build Q() "filters" and "excludes" before main search query',
+            'description': 'Build filters and excludes before main search query',
             'time_difference': t1_A - t0_A,
         })
 
@@ -759,7 +761,7 @@ def candidate_list_view(request):
                 word_filter = Q()
                 for field in search_fields:
                     word_filter |= Q(**{f"{field}__icontains": word})
-                filters &= word_filter
+                candidate_query = candidate_query.filter(word_filter)
 
         t1_B = time()
         performance_list.append({
@@ -772,23 +774,23 @@ def candidate_list_view(request):
         if positive_value_exists(hide_candidates_with_links):
             # Show candidates that do NOT have links: Twitter, Instagram, Facebook, Web, Ballotpedia
             # If you make changes here, please also search for 'hide_candidates_with_links' in election/views_admin.py
-            filters &= (
-                    (Q(ballotpedia_candidate_url__isnull=True) | Q(ballotpedia_candidate_url=""))
-                    & (Q(candidate_twitter_handle__isnull=True) | Q(candidate_twitter_handle="")
-                       | Q(twitter_handle_updates_failing=True))
-                    & (Q(candidate_url__isnull=True) | Q(candidate_url=""))
-                    & (Q(facebook_url__isnull=True) | Q(facebook_url="") | Q(facebook_url_is_broken=True))
-                    & (Q(instagram_handle__isnull=True) | Q(instagram_handle=""))
-            )
+            candidate_query = candidate_query.filter(
+                (Q(ballotpedia_candidate_url__isnull=True) | Q(ballotpedia_candidate_url=""))
+                & (Q(candidate_twitter_handle__isnull=True) | Q(candidate_twitter_handle="")
+                   | Q(twitter_handle_updates_failing=True))
+                & (Q(candidate_url__isnull=True) | Q(candidate_url=""))
+                & (Q(facebook_url__isnull=True) | Q(facebook_url="") | Q(facebook_url_is_broken=True))
+                & (Q(instagram_handle__isnull=True) | Q(instagram_handle="")))
 
         if positive_value_exists(federal_or_state):
             # Show candidates that with a race_office_level of 'Federal' or 'State'
-            filters &= (Q(race_office_level="Federal") | Q(race_office_level="State"))
+            candidate_query = candidate_query.filter(
+                Q(race_office_level="Federal") | Q(race_office_level="State"))
         if positive_value_exists(hide_candidates_with_photos):
             # Show candidates that do NOT have photos
-            filters &= (Q(we_vote_hosted_profile_image_url_medium__isnull=True) |
-                        Q(we_vote_hosted_profile_image_url_medium=""))
-
+            candidate_query = candidate_query.filter(
+                Q(we_vote_hosted_profile_image_url_medium__isnull=True) |
+                Q(we_vote_hosted_profile_image_url_medium=""))
         t1_C = time()
         performance_list.append({
             'name': 'Subsnapshot_LinkFederalStatePhotoFilters',
@@ -799,33 +801,36 @@ def candidate_list_view(request):
         t0_D = time()
         if positive_value_exists(show_candidates_with_best_twitter_options):
             # Show candidates with TwitterLinkPossibilities of greater than 60
-            filters &= (Q(candidate_twitter_handle__isnull=True) | Q(candidate_twitter_handle=""))
+            candidate_query = candidate_query.filter(
+                Q(candidate_twitter_handle__isnull=True) | Q(candidate_twitter_handle=""))
             try:
                 twitter_list = list(
-                    TwitterLinkPossibility.objects.filter(likelihood_score__gte=60, not_a_match=False)
+                    TwitterLinkPossibility.objects.using('readonly')
+                    .filter(likelihood_score__gte=60, not_a_match=False)
                     .values_list('candidate_campaign_we_vote_id', flat=True)
-                    .distinct()
-                )
+                    .distinct())
                 if twitter_list:
-                    filters &= Q(we_vote_id__in=twitter_list)
+                    candidate_query = candidate_query.filter(we_vote_id__in=twitter_list)
             except Exception as e:
                 pass
         elif positive_value_exists(show_candidates_with_twitter_options):
             # Show candidates that we have Twitter search results for
             try:
-                filters &= (Q(candidate_twitter_handle__isnull=True) | Q(candidate_twitter_handle=""))
+                candidate_query = candidate_query.filter(
+                    Q(candidate_twitter_handle__isnull=True) | Q(candidate_twitter_handle=""))
                 twitter_possibility_list = list(
-                    TwitterLinkPossibility.objects.filter(not_a_match=False)
+                    TwitterLinkPossibility.objects.using('readonly')
+                    .filter(not_a_match=False)
                     .values_list('candidate_campaign_we_vote_id', flat=True)
-                    .distinct()
-                )
+                    .distinct())
                 if twitter_possibility_list:
-                    filters &= Q(we_vote_id__in=twitter_possibility_list)
+                    candidate_query = candidate_query.filter(we_vote_id__in=twitter_possibility_list)
             except Exception as e:
                 pass
         elif positive_value_exists(show_candidates_without_twitter):
             # Don't show candidates that already have Twitter handles
-            filters &= (Q(candidate_twitter_handle__isnull=True) | Q(candidate_twitter_handle=""))
+            candidate_query = candidate_query.filter(
+                Q(candidate_twitter_handle__isnull=True) | Q(candidate_twitter_handle=""))
 
         t1_D = time()
         performance_list.append({
@@ -835,18 +840,13 @@ def candidate_list_view(request):
         })
 
         if positive_value_exists(show_candidates_with_claimed_profile):
-            filters &= (Q(is_claimed_profile=True))
+            candidate_query = candidate_query.filter(is_claimed_profile=True)
 
         t0_E = time()
-        if not filters and not excludes and not show_all_elections:
-            candidate_query = CandidateCampaign.objects.none()
-        else:
-            candidate_query = (CandidateCampaign.objects.using('readonly').filter(filters).exclude(excludes)
-                               .order_by('candidate_name'))
-
         if positive_value_exists(show_candidates_with_email):
-            candidate_query = candidate_query.annotate(candidate_email_length=Length('candidate_email'))
-            candidate_query = candidate_query.filter(candidate_email_length__gt=2)
+            candidate_query = candidate_query.annotate(
+                candidate_email_length=Length('candidate_email')
+            ).filter(candidate_email_length__gt=2)
 
         if sort_by == "twitter":
             candidate_query = candidate_query.annotate(has_twitter=(
@@ -876,7 +876,7 @@ def candidate_list_view(request):
             candidate_list = list(candidate_query)
             hide_pagination = True
         else:
-            # we add 1 extra candidate so we don't have to run .count() to check if we've reached the end...
+            # we add 1 extra candidate so we can see if there's a "next" page w/o having to run .count()
             candidate_count_end = candidate_count_start + number_to_show_per_page + 1
             candidate_slice = list(candidate_query[candidate_count_start:candidate_count_end])
 
@@ -886,7 +886,7 @@ def candidate_list_view(request):
             else:
                 next_page_url = None
                 candidate_list = candidate_slice
-            hide_pagination = len(candidate_query) <= number_to_show_per_page
+            hide_pagination = candidate_list_count <= number_to_show_per_page
 
         t1_F = time()
         performance_list.append({

--- a/templates/admin_tools/speed_statistics_banner.html
+++ b/templates/admin_tools/speed_statistics_banner.html
@@ -25,11 +25,25 @@
                 {% for stat in stats %}
                     <tr>
                         {% if stat.name %}
-                            <td>{{ stat.name }}</td>
-                            <td>{{ stat.time_difference|floatformat:4 }}</td>
-                            <td style="font-weight: 300; color: #666; text-align: left;">
-                                {{ stat.description }}
-                            </td>
+                            {% if "subsnapshot" in stat.name|lower %}
+                                {% with stat.name|cut:"Subsnapshot_" as short_name %}
+                                    <td style="color:#777; font-size:0.8em; line-height:1;">
+                                        Nested Snapshot: {{ short_name }}
+                                    </td>
+                                    <td style="color:#777; font-size:0.8em; line-height:1;">
+                                        {{ stat.time_difference|floatformat:4 }}
+                                    </td>
+                                    <td style="font-weight:100; color:#888; text-align:left; font-size:0.8em; line-height:1;">
+                                        {{ stat.description }}
+                                    </td>
+                                {% endwith %}
+                            {% else %}
+                                <td>{{ stat.name }}</td>
+                                <td>{{ stat.time_difference|floatformat:4 }}</td>
+                                <td style="font-weight:300; color:#666; text-align:left;">
+                                    {{ stat.description }}
+                                </td>
+                            {% endif %}
                         {% else %}
                             <td colspan="3">{{ stat }}</td>
                         {% endif %}

--- a/wevote_functions/templatetags/performance_tags.py
+++ b/wevote_functions/templatetags/performance_tags.py
@@ -10,6 +10,10 @@ register = template.Library()
 def performance_total(performance_dict):
     total = 0
     for time in performance_dict:
+        # Don't include sub-snapshots (nested snapshots) in the total
+        name = time.get('name', '') if isinstance(time, dict) else getattr(time, 'name', '')
+        if isinstance(name, str) and 'subsnapshot' in name.lower():
+            continue
         time_diff = time.get('time_difference') if isinstance(time, dict) else getattr(time, 'time_difference', 0)
         if time_diff:
             total += time_diff


### PR DESCRIPTION
Eliminated the 502 error caused by large candidate searches (~100k+ results) and reverted back from Q-object filtering back to direct query .filter() usage. Even the worst-case queries now complete in roughly 3 seconds on a fast machine.
Also improved nested snapshot display and excluded them from total runtime calcs

Before (buggy, 16s load time): 
<img width="2047" height="771" alt="image" src="https://github.com/user-attachments/assets/86baaf37-ee35-4346-a425-38013a9315df" />
After (fixed, 3s load time):
<img width="2046" height="680" alt="image" src="https://github.com/user-attachments/assets/f52dd5be-d21c-4ecf-9ada-647edf327cc0" />