### PR TITLE
[WV-2309] LOCAL Address fast load empty tables

### DIFF
--- a/retrieve_tables/controllers_local.py
+++ b/retrieve_tables/controllers_local.py
@@ -128,9 +128,10 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
             for chunk in response.iter_content(chunk_size=(1024*1024)):
                 if chunk:
                     tf.write(chunk)
-        
+        # Force the python buffer to be written to the file            
+        tf.flush()
         if tf.tell() != global_stats['table_size']:
-            raise Exception(f"Downloaded {int(tf.tell()/1024)} Kb, expected {int(global_stats['table_size']/1024)} Kb")
+            raise Exception(f"Downloaded {int(os.path.getsize(tf.name)/1024)} Kb, expected {int(global_stats['table_size']/1024)} Kb")
 
         print("Downloaded", tf.name)
         diff_t0 = int(time.time() - global_stats['global_t0'])
@@ -139,6 +140,7 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         print("!!Problem occurred Downloading file:", e)
         results['success'] = False,
         results['error string'] = str(e)
+        tf.close()
         return results
 
     try:
@@ -155,6 +157,7 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         print("!!Problem occurred getting variables for db:", e)
         results['success'] = False,
         results['error string'] = str(e)
+        tf.close()
         return results
 
     try:

--- a/retrieve_tables/controllers_local.py
+++ b/retrieve_tables/controllers_local.py
@@ -131,7 +131,7 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         # Force the python buffer to be written to the file            
         tf.flush()
         if tf.tell() != global_stats['table_size']:
-            raise Exception(f"Downloaded {int(os.path.getsize(tf.name)/1024)} Kb, expected {int(global_stats['table_size']/1024)} Kb")
+            raise Exception(f"Downloaded {int(tf.tell()/1024)} Kb, expected {int(global_stats['table_size']/1024)} Kb")
 
         print("Downloaded", tf.name)
         diff_t0 = int(time.time() - global_stats['global_t0'])


### PR DESCRIPTION
This issue was cause by a quirk of a python `tempfile`, where if not enough data is written to it, the buffer wont be hit and the file will technically be empty. On larger files, once the buffer is hit it starts writing to the file. To address this, running `tf.flush()` forces the buffer to write to the file before it is passed into `pg restore`.