### PR TITLE
Created mechanism to start over deduplication for a state if manual merging has happened by a WeVoter. Removed "Find candidates to link to a Politician" from every "Edit Politician" page load because of how slow it is. Now you can click a button start the check.

### DIFF
--- a/candidate/controllers_data_cleaning.py
+++ b/candidate/controllers_data_cleaning.py
@@ -2,6 +2,7 @@
 # Brought to you by We Vote. Be good.
 # -*- coding: UTF-8 -*-
 from datetime import datetime
+import pytz
 
 from django.db.models import Q
 from config.base import get_environment_variable
@@ -12,10 +13,12 @@ from import_export_batches.controllers_data_cleaning import full_deduplication_f
 from politician.models import PoliticianManager
 import wevote_functions.admin
 from wevote_functions.functions import convert_to_int, positive_value_exists
-from wevote_functions.functions_date import convert_we_vote_date_string_to_date_as_integer, \
+from wevote_functions.functions_date import convert_date_to_date_as_integer, \
+    convert_we_vote_date_string_to_date_as_integer, \
     generate_localized_datetime_from_obj, get_current_year_as_integer
 from .controllers import find_duplicate_candidate, merge_if_duplicate_candidates
-from .models import CandidateCampaign, CandidateListManager, CandidateManager, CandidatesArePossibleDuplicates
+from .models import CandidateCampaign, CandidateListManager, CandidateManager, CandidatesArePossibleDuplicates, \
+    DeduplicationNeededForStateToday
 
 logger = wevote_functions.admin.get_logger(__name__)
 
@@ -582,28 +585,50 @@ def populate_contest_office_data(
     return results
 
 
-def batch_process_deduplication_scripts_candidate():
+def batch_process_deduplication_scripts_candidate():  # DEDUPLICATION_SCRIPTS_CANDIDATE
     all_states_deduplication_complete = False
     status = ':||: '
     success = True
 
     # ##################
-    #
+    # Every day, we go through all states and run a duplication check so we end up with a list of Candidates
+    #  that might be duplicates. Every time this script runs, we check one more state.
     results = full_deduplication_for_next_state(is_for_candidates=True)
     if positive_value_exists(results['status']):
         status += results['status'] + " :||: "
         all_states_deduplication_complete = results['all_states_deduplication_complete']
 
     # ##################
-    # Check to see if there are any states with that have new politicians that haven't been checked for duplicates
-    # if all_states_deduplication_complete:
-    #     results = find_states_that_need_new_deduplication()
-    #     if positive_value_exists(results['success']):
-    #         state_code_list = results['state_code_list']
-    #         if state_code_list and len(state_code_list) > 0:
-    #             pass
-    #     if positive_value_exists(results['status']):
-    #         status += results['status'] + " :||: "
+    # After all states have been checked once per day for duplicates, we check to see if there have been any
+    #  manual deduplication in any states. If so, run the full_deduplication_for_next_state again for that state
+    #  the next time batch_process_deduplication_scripts_candidate is run.
+    if all_states_deduplication_complete:
+        results = find_states_that_need_new_candidate_deduplication()
+        if positive_value_exists(results['success']):
+            state_code_list = results['state_code_list']
+            if state_code_list and len(state_code_list) > 0:
+                # Update the DeduplicationNeededForStateToday entry for today with the
+                #  states that need to be deduplicated again.
+                try:
+                    pacific_tz = pytz.timezone('US/Pacific')
+                    date_now = now().astimezone(pacific_tz)
+                    date_now_as_integer = convert_date_to_date_as_integer(date_now)
+                    deduplication_needed_for_state_today, created = \
+                        DeduplicationNeededForStateToday.objects.get_or_create(
+                            date_now_as_integer=date_now_as_integer,
+                        )
+                    # Set the deduplication_needed flag to True for each state in the list
+                    for state_code in state_code_list:
+                        field_name = f"{state_code.lower()}_deduplication_needed"
+                        setattr(deduplication_needed_for_state_today, field_name, True)
+
+                    deduplication_needed_for_state_today.save()
+                    status += f"UPDATED_DeduplicationNeededForStateToday for states: {', '.join(state_code_list)} "
+                except Exception as e:
+                    status += "FAILED_TO_UPDATE_DeduplicationNeededForStateToday: {e} ".format(e=e)
+                    success = False
+        if positive_value_exists(results['status']):
+            status += results['status'] + " :||: "
 
     results = {
         'status': status,
@@ -674,7 +699,8 @@ def candidate_deduplication_for_one_state(candidate_year=0, state_code=''):
         queryset = CandidatesArePossibleDuplicates.objects.filter(
             state_code__iexact=state_code,
         )
-        queryset.delete()
+        number_deleted, unused = queryset.delete()
+        status += f"[Deleted {number_deleted:,} PoliticiansArePossibleDuplicates entries for state {state_code}] "
     except Exception as e:
         status += "ERROR_DELETING_POSSIBLE_DUPLICATES: {e} ".format(e=e)
         success = False
@@ -696,6 +722,15 @@ def candidate_deduplication_for_one_state(candidate_year=0, state_code=''):
                 status += f"DUPLICATE_CHECK_COMPLETE_FOR-{len(we_vote_ids_to_update)}-CANDIDATES "
             except Exception as e:
                 status += f"COULD_NOT_UPDATE_DUPLICATE_CHECK_LAST_COMPLETED: {e} "
+        if merge_results['reset_duplicate_check_last_completed_we_vote_id_list']:
+            try:
+                we_vote_ids_to_update = merge_results['reset_duplicate_check_last_completed_we_vote_id_list']
+                if len(we_vote_ids_to_update) > 0:
+                    CandidateCampaign.objects.filter(we_vote_id__in=we_vote_ids_to_update)\
+                        .update(duplicate_check_last_completed=None)
+                    status += f"RESET_DUPLICATE_CHECK_FOR-{len(we_vote_ids_to_update)}-CANDIDATES "
+            except Exception as e:
+                status += f"COULD_NOT_RESET_DUPLICATE_CHECK_LAST_COMPLETED: {e} "
 
     results = {
         'status': status,
@@ -711,12 +746,14 @@ def find_and_merge_duplicate_candidates(
     duplicate_check_complete_candidate_we_vote_id_list = []
     candidates_merged_found = False
     candidates_merged_list = []
+    reset_duplicate_check_last_completed_we_vote_id_list = []
     status = ""
     success = True
     error_results = {
         "duplicate_check_complete_candidate_we_vote_id_list": duplicate_check_complete_candidate_we_vote_id_list,
         "candidates_merged_found": candidates_merged_found,
         "candidates_merged_list": candidates_merged_list,
+        "reset_duplicate_check_last_completed_we_vote_id_list": reset_duplicate_check_last_completed_we_vote_id_list,
         "status": status,
         "success": False,
     }
@@ -791,13 +828,18 @@ def find_and_merge_duplicate_candidates(
             if we_vote_candidate.we_vote_id in exclude_candidate_we_vote_id_list:
                 continue
             # Start ignore list with entries already reviewed
-            ignore_candidate_id_list = exclude_candidate_we_vote_id_list
+            ignore_candidate_id_list = exclude_candidate_we_vote_id_list.copy()
             # Add current entry to ignore list
             ignore_candidate_id_list.append(we_vote_candidate.we_vote_id)
             # Now check for others we have already labeled as "not a duplicate"
-            not_a_duplicate_list = candidate_manager.fetch_candidates_are_not_duplicates_list_we_vote_ids(
-                we_vote_candidate.we_vote_id)
-            ignore_candidate_id_list += not_a_duplicate_list
+            duplicates_results = \
+                candidate_manager.retrieve_candidates_are_not_duplicates_list(we_vote_candidate.we_vote_id)
+            if duplicates_results['success']:
+                not_a_duplicate_list = duplicates_results['candidates_are_not_duplicates_list_we_vote_ids']
+                # Add current entry to ignore list
+                ignore_candidate_id_list += not_a_duplicate_list
+            else:
+                status += f"COULD_NOT_RETRIEVE_CANDIDATES_ARE_NOT_DUPLICATES: {duplicates_results['status']} "
 
             results = find_duplicate_candidate(we_vote_candidate, ignore_candidate_id_list, read_only=True)
 
@@ -830,9 +872,14 @@ def find_and_merge_duplicate_candidates(
                     )
                     candidates_merged_list.append(candidate)
                     candidates_merged_found = True
+                    if candidate.we_vote_id not in reset_duplicate_check_last_completed_we_vote_id_list:
+                        reset_duplicate_check_last_completed_we_vote_id_list.append(candidate.we_vote_id)
                 else:
                     # Add an entry showing that this is a possible match
-                    status += f"[Candidate {we_vote_candidate.candidate_name} has possible match.] "
+                    status += (
+                        f"[Candidate {we_vote_candidate.candidate_name} "
+                        f"({we_vote_candidate.we_vote_id}) has possible match.] "
+                    )
                     state_code_local = state_code
                     if not positive_value_exists(state_code_local):
                         if positive_value_exists(we_vote_candidate.state_code):
@@ -846,6 +893,12 @@ def find_and_merge_duplicate_candidates(
                     )
                     if candidate_option2_for_template.we_vote_id not in exclude_candidate_we_vote_id_list:
                         exclude_candidate_we_vote_id_list.append(candidate_option2_for_template.we_vote_id)
+                    if we_vote_candidate.we_vote_id not in reset_duplicate_check_last_completed_we_vote_id_list:
+                        reset_duplicate_check_last_completed_we_vote_id_list.append(we_vote_candidate.we_vote_id)
+                    if candidate_option2_for_template.we_vote_id not in \
+                            reset_duplicate_check_last_completed_we_vote_id_list:
+                        reset_duplicate_check_last_completed_we_vote_id_list.append(
+                            candidate_option2_for_template.we_vote_id)
             else:
                 # No matches found
                 CandidatesArePossibleDuplicates.objects.create(
@@ -859,12 +912,78 @@ def find_and_merge_duplicate_candidates(
         # Fall through to exit function
 
     return {
-            "duplicate_check_complete_candidate_we_vote_id_list": duplicate_check_complete_candidate_we_vote_id_list,
-            "candidates_merged_found": candidates_merged_found,
-            "candidates_merged_list": candidates_merged_list,
-            "status": status,
-            "success": success,
-        }
+        "duplicate_check_complete_candidate_we_vote_id_list": duplicate_check_complete_candidate_we_vote_id_list,
+        "candidates_merged_found": candidates_merged_found,
+        "candidates_merged_list": candidates_merged_list,
+        "reset_duplicate_check_last_completed_we_vote_id_list": reset_duplicate_check_last_completed_we_vote_id_list,
+        "status": status,
+        "success": success,
+    }
+
+
+def find_states_that_need_new_candidate_deduplication():
+    """
+    Check to see if there are any states with that have new candidates that haven't been checked for duplicates
+    """
+    state_codes_for_deduplication = [
+        "ak", "al", "ar", "az", "ca", "co", "ct", "dc", "de", "fl", "ga", "hi", "ia", "id", "il", "in", "ks",
+        "ky", "la", "ma", "md", "me", "mi", "mn", "mo", "ms", "mt", "na", "nc", "nd", "ne", "nh", "nj", "nm",
+        "nv", "ny", "oh", "ok", "or", "pa", "pr", "ri", "sc", "sd", "tn", "tx", "ut", "va", "vt", "wa", "wi",
+        "wv", "wy"
+    ]
+    state_code_list = []
+    status = ''
+    success = True
+
+    # Return all candidates from any state in state_codes_for_deduplication
+    #  that have a null duplicate_check_last_completed value
+    # We want to identify new candidates that haven't been deduplicated yet
+    current_year_as_integer = get_current_year_as_integer()
+    candidate_query = CandidateCampaign.objects.using('readonly').filter(
+        candidate_year=current_year_as_integer,
+        state_code__in=state_codes_for_deduplication,
+        duplicate_check_last_completed__isnull=True,
+    )
+    # Extract a list of candidate we_vote_id values from the candidate_query organized by state_code
+    candidate_list = list(candidate_query)
+    candidates_by_state_code = {}
+    for candidate in candidate_list:
+        if candidate.state_code not in candidates_by_state_code:
+            candidates_by_state_code[candidate.state_code] = []
+        candidates_by_state_code[candidate.state_code].append(candidate.we_vote_id)
+
+    # Now cycle through each state in state_codes_for_deduplication and make sure
+    # that none of the we_vote_id values in candidates_by_state_code appear in PoliticiansArePossibleDuplicates
+    for state_code in candidates_by_state_code:
+        candidate_we_vote_id_list = candidates_by_state_code[state_code]
+        candidate_we_vote_id_remaining_list = candidate_we_vote_id_list.copy()
+        candidate_duplicate_check_query = CandidatesArePossibleDuplicates.objects.using('readonly').filter(
+            (
+                Q(candidate1_we_vote_id__in=candidate_we_vote_id_list) &
+                Q(candidate2_we_vote_id__isnull=False)
+            ) | (
+                Q(candidate2_we_vote_id__in=candidate_we_vote_id_list) &
+                Q(candidate1_we_vote_id__isnull=False)
+            )
+        )
+        candidate_duplicate_check_list = list(candidate_duplicate_check_query)
+        # Cycle through candidate_duplicate_check_list and remove one-by-one the values in candidate_we_vote_id_list.
+        #  If there are values left, then we can run the deduplication process for the state again
+        for candidate_duplicate_check in candidate_duplicate_check_list:
+            if candidate_duplicate_check.candidate1_we_vote_id in candidate_we_vote_id_remaining_list:
+                candidate_we_vote_id_remaining_list.remove(candidate_duplicate_check.candidate1_we_vote_id)
+            if candidate_duplicate_check.candidate2_we_vote_id in candidate_we_vote_id_remaining_list:
+                candidate_we_vote_id_remaining_list.remove(candidate_duplicate_check.candidate2_we_vote_id)
+
+        if len(candidate_we_vote_id_remaining_list) > 0:
+            # We need to run the deduplication process for this state again
+            state_code_list.append(state_code)
+
+    return {
+        "state_code_list": state_code_list,
+        "status": status,
+        "success": success,
+    }
 
 
 def seo_friendly_path_updates(

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -4299,6 +4299,18 @@ def candidate_merge_process_view(request):
     if positive_value_exists(skip):
         results = candidate_manager.update_or_create_candidates_are_not_duplicates(
             candidate1_we_vote_id, candidate2_we_vote_id)
+        if results['success']:
+            queryset = CandidatesArePossibleDuplicates.objects.filter(
+                candidate1_we_vote_id=candidate1_we_vote_id,
+                candidate2_we_vote_id=candidate2_we_vote_id,
+            )
+            queryset.delete()
+
+            we_vote_ids_to_update = [candidate1_we_vote_id, candidate2_we_vote_id]
+            CandidateCampaign.objects.filter(we_vote_id__in=we_vote_ids_to_update) \
+                .update(duplicate_check_last_completed=None)
+            status += f"DUPLICATE_CHECK_COMPLETE_SET_FOR-{len(we_vote_ids_to_update)}-CANDIDATES "
+
         if results['new_candidates_are_not_duplicates_created']:
             if positive_value_exists(voter_we_vote_id):
                 try:
@@ -4361,6 +4373,12 @@ def candidate_merge_process_view(request):
         candidate = merge_results['candidate']
         messages.add_message(request, messages.INFO, "Candidate '{candidate_name}' merged."
                                                      "".format(candidate_name=candidate.candidate_name))
+
+        # Now set the flag so this politician gets checked against other politicians for duplicates
+        CandidateCampaign.objects.filter(we_vote_id=candidate.we_vote_id) \
+            .update(duplicate_check_last_completed=None)
+        status += f"RESET_DUPLICATE_CHECK_FOR-{candidate.we_vote_id}-CANDIDATE "
+
         if positive_value_exists(voter_we_vote_id):
             try:
                 # Give the volunteer who entered this credit

--- a/import_export_batches/controllers_data_cleaning.py
+++ b/import_export_batches/controllers_data_cleaning.py
@@ -61,9 +61,11 @@ def full_deduplication_for_next_state(is_for_candidates=False):
             from candidate.controllers_data_cleaning import candidate_deduplication_for_one_state
             state_results = candidate_deduplication_for_one_state(
                 candidate_year=current_year, state_code=next_state_code)
+            status += state_results['status']
         else:
             from politician.controllers_data_cleaning import politician_deduplication_for_one_state
             state_results = politician_deduplication_for_one_state(state_code=next_state_code)
+            status += state_results['status']
         if state_results['success']:
             try:
                 setattr(deduplication_needed, f"{next_state_code}_deduplication_needed", False)

--- a/politician/controllers.py
+++ b/politician/controllers.py
@@ -455,10 +455,11 @@ def find_candidates_to_link_to_this_politician(politician=None):
     """
     if not hasattr(politician, 'we_vote_id'):
         return []
+    related_candidate_list = []
     from candidate.models import CandidateCampaign
     try:
-        related_candidate_list = CandidateCampaign.objects.using('readonly').all()
-        related_candidate_list = related_candidate_list.exclude(
+        queryset = CandidateCampaign.objects.using('readonly').all()
+        queryset = queryset.exclude(
             politician_we_vote_id=politician.we_vote_id)
 
         filters = []
@@ -523,9 +524,10 @@ def find_candidates_to_link_to_this_politician(politician=None):
             for item in filters:
                 final_filters |= item
 
-            related_candidate_list = related_candidate_list.filter(final_filters)
+            queryset = queryset.filter(final_filters)
 
-        related_candidate_list = related_candidate_list.order_by('candidate_name')[:20]
+        queryset = queryset.order_by('candidate_name')[:20]
+        related_candidate_list = list(queryset)
     except Exception as e:
         related_candidate_list = []
     return related_candidate_list

--- a/politician/controllers_data_cleaning.py
+++ b/politician/controllers_data_cleaning.py
@@ -3,7 +3,7 @@
 # -*- coding: UTF-8 -*-
 
 from datetime import datetime, timedelta
-from django.db.models import Q
+from django.db.models import Count, Q
 from django.utils.timezone import now
 import pytz
 
@@ -25,26 +25,48 @@ WEB_APP_ROOT_URL = get_environment_variable("WEB_APP_ROOT_URL")
 logger = wevote_functions.admin.get_logger(__name__)
 
 
-def batch_process_deduplication_scripts_politician():
+def batch_process_deduplication_scripts_politician():  # DEDUPLICATION_SCRIPTS_POLITICIAN
     all_states_deduplication_complete = False
     status = ':||: '
     success = True
 
     # ##################
-    #
+    # Every day, we go through all states and run a duplication check so we end up with a list of Politicians
+    #  that might be duplicates. Every time this script runs, we check one more state.
     results = full_deduplication_for_next_state()
     if positive_value_exists(results['status']):
         status += results['status'] + " :||: "
         all_states_deduplication_complete = results['all_states_deduplication_complete']
 
     # ##################
-    # Check to see if there are any states with that have new politicians that haven't been checked for duplicates
+    # After all states have been checked once per day for duplicates, we check to see if there have been any
+    #  manual deduplication in any states. If so, run the full_deduplication_for_next_state again for that state
+    #  the next time batch_process_deduplication_scripts_politician is run.
     if all_states_deduplication_complete:
-        results = find_states_that_need_new_deduplication()
+        results = find_states_that_need_new_politician_deduplication()
         if positive_value_exists(results['success']):
             state_code_list = results['state_code_list']
             if state_code_list and len(state_code_list) > 0:
-                pass
+                # Update the DeduplicationNeededForStateToday entry for today with the
+                # states that need to be deduplicated again.
+                try:
+                    pacific_tz = pytz.timezone('US/Pacific')
+                    date_now = now().astimezone(pacific_tz)
+                    date_now_as_integer = convert_date_to_date_as_integer(date_now)
+                    deduplication_needed_for_state_today, created = \
+                        DeduplicationNeededForStateToday.objects.get_or_create(
+                            date_now_as_integer=date_now_as_integer,
+                        )
+                    # Set the deduplication_needed flag to True for each state in the list
+                    for state_code in state_code_list:
+                        field_name = f"{state_code.lower()}_deduplication_needed"
+                        setattr(deduplication_needed_for_state_today, field_name, True)
+
+                    deduplication_needed_for_state_today.save()
+                    status += f"UPDATED_DeduplicationNeededForStateToday for states: {', '.join(state_code_list)} "
+                except Exception as e:
+                    status += "FAILED_TO_UPDATE_DeduplicationNeededForStateToday: {e} ".format(e=e)
+                    success = False
         if positive_value_exists(results['status']):
             status += results['status'] + " :||: "
 
@@ -243,7 +265,8 @@ def politician_deduplication_for_one_state(state_code=''):
         queryset = PoliticiansArePossibleDuplicates.objects.filter(
             state_code__iexact=state_code,
         )
-        queryset.delete()
+        number_deleted, unused = queryset.delete()
+        status += f"[Deleted {number_deleted:,} PoliticiansArePossibleDuplicates entries for state {state_code}] "
     except Exception as e:
         status += "ERROR_DELETING_POSSIBLE_DUPLICATES: {e} ".format(e=e)
         success = False
@@ -258,11 +281,21 @@ def politician_deduplication_for_one_state(state_code=''):
         if merge_results['duplicate_check_complete_politician_we_vote_id_list']:
             try:
                 we_vote_ids_to_update = merge_results['duplicate_check_complete_politician_we_vote_id_list']
-                Politician.objects.filter(we_vote_id__in=we_vote_ids_to_update)\
-                    .update(duplicate_check_last_completed=now())
-                status += f"DUPLICATE_CHECK_COMPLETE_FOR-{len(we_vote_ids_to_update)}-POLITICIANS "
+                if len(we_vote_ids_to_update) > 0:
+                    Politician.objects.filter(we_vote_id__in=we_vote_ids_to_update)\
+                        .update(duplicate_check_last_completed=now())
+                    status += f"DUPLICATE_CHECK_COMPLETE_FOR-{len(we_vote_ids_to_update)}-POLITICIANS "
             except Exception as e:
                 status += f"COULD_NOT_UPDATE_DUPLICATE_CHECK_LAST_COMPLETED: {e} "
+        if merge_results['reset_duplicate_check_last_completed_we_vote_id_list']:
+            try:
+                we_vote_ids_to_update = merge_results['reset_duplicate_check_last_completed_we_vote_id_list']
+                if len(we_vote_ids_to_update) > 0:
+                    Politician.objects.filter(we_vote_id__in=we_vote_ids_to_update)\
+                        .update(duplicate_check_last_completed=None)
+                    status += f"RESET_DUPLICATE_CHECK_FOR-{len(we_vote_ids_to_update)}-POLITICIANS "
+            except Exception as e:
+                status += f"COULD_NOT_RESET_DUPLICATE_CHECK_LAST_COMPLETED: {e} "
 
     results = {
         'status': status,
@@ -276,12 +309,14 @@ def find_and_merge_duplicate_politicians(state_code=''):
     politician_manager = PoliticianManager()
     politicians_merged_found = False
     politicians_merged_list = []
+    reset_duplicate_check_last_completed_we_vote_id_list = []
     status = ""
     success = True
     error_results = {
         "duplicate_check_complete_politician_we_vote_id_list": [],
         "politicians_merged_found": politicians_merged_found,
         "politicians_merged_list": politicians_merged_list,
+        "reset_duplicate_check_last_completed_we_vote_id_list": reset_duplicate_check_last_completed_we_vote_id_list,
         "status": status,
         "success": False,
     }
@@ -308,7 +343,8 @@ def find_and_merge_duplicate_politicians(state_code=''):
     # Retrieve list of politicians to compare
     try:
         politician_query = Politician.objects.using('readonly').all()
-        politician_query = politician_query.exclude(we_vote_id__in=exclude_politician_we_vote_id_list)
+        if exclude_politician_we_vote_id_list and len(exclude_politician_we_vote_id_list) > 0:
+            politician_query = politician_query.exclude(we_vote_id__in=exclude_politician_we_vote_id_list)
         if positive_value_exists(state_code):
             politician_query = politician_query.filter(state_code__iexact=state_code)
         politician_list = list(politician_query)
@@ -324,17 +360,19 @@ def find_and_merge_duplicate_politicians(state_code=''):
             if we_vote_politician.we_vote_id in exclude_politician_we_vote_id_list:
                 continue
             # Start ignore list with entries already reviewed
-            ignore_politician_id_list = exclude_politician_we_vote_id_list
+            ignore_politician_id_list = exclude_politician_we_vote_id_list.copy()
             # Add current entry to ignore list
             ignore_politician_id_list.append(we_vote_politician.we_vote_id)
-            # Now check for others we have already labeled as "not a duplicate"
-            not_a_duplicate_list = politician_manager.fetch_politicians_are_not_duplicates_list_we_vote_ids(
-                we_vote_politician.we_vote_id)
-            ignore_politician_id_list += not_a_duplicate_list
+            # Now check for others we have already labeled as "not a duplicate" of this particular politician
+            duplicates_results = \
+                politician_manager.retrieve_politicians_are_not_duplicates_list(we_vote_politician.we_vote_id)
+            if duplicates_results['success']:
+                not_a_duplicate_list = duplicates_results['politicians_are_not_duplicates_list_we_vote_ids']
+                # Add current entry to ignore list
+                ignore_politician_id_list += not_a_duplicate_list
+            else:
+                status += f"COULD_NOT_RETRIEVE_POLITICIANS_ARE_NOT_DUPLICATES: {duplicates_results['status']} "
 
-            stop_processing = ['wv87pol74053', 'wv87pol28538']
-            if we_vote_politician.we_vote_id in stop_processing:
-                status += f"STOP_PROCESSING_POLITICIAN: {we_vote_politician.we_vote_id} "
             results = find_duplicate_politician(we_vote_politician, ignore_politician_id_list, read_only=True)
 
             # If we find politicians to merge, store them for review
@@ -366,9 +404,14 @@ def find_and_merge_duplicate_politicians(state_code=''):
                     )
                     politicians_merged_list.append(politician)
                     politicians_merged_found = True
+                    if politician.we_vote_id not in reset_duplicate_check_last_completed_we_vote_id_list:
+                        reset_duplicate_check_last_completed_we_vote_id_list.append(politician.we_vote_id)
                 else:
                     # Add an entry showing that this is a possible match
-                    status += f"[Politician {we_vote_politician.politician_name} has possible match.] "
+                    status += (
+                        f"[Politician {we_vote_politician.politician_name} "
+                        f"({we_vote_politician.we_vote_id}) has possible match.] "
+                    )
                     PoliticiansArePossibleDuplicates.objects.create(
                         politician1_we_vote_id=we_vote_politician.we_vote_id,
                         politician2_we_vote_id=politician_option2_for_template.we_vote_id,
@@ -376,6 +419,12 @@ def find_and_merge_duplicate_politicians(state_code=''):
                     )
                     if politician_option2_for_template.we_vote_id not in exclude_politician_we_vote_id_list:
                         exclude_politician_we_vote_id_list.append(politician_option2_for_template.we_vote_id)
+                    if we_vote_politician.we_vote_id not in reset_duplicate_check_last_completed_we_vote_id_list:
+                        reset_duplicate_check_last_completed_we_vote_id_list.append(we_vote_politician.we_vote_id)
+                    if politician_option2_for_template.we_vote_id not in \
+                            reset_duplicate_check_last_completed_we_vote_id_list:
+                        reset_duplicate_check_last_completed_we_vote_id_list.append(
+                            politician_option2_for_template.we_vote_id)
             else:
                 # No matches found
                 PoliticiansArePossibleDuplicates.objects.create(
@@ -383,7 +432,8 @@ def find_and_merge_duplicate_politicians(state_code=''):
                     politician2_we_vote_id=None,
                     state_code=state_code,
                 )
-                duplicate_check_complete_politician_we_vote_id_list.append(we_vote_politician.we_vote_id)
+                if we_vote_politician.we_vote_id not in duplicate_check_complete_politician_we_vote_id_list:
+                    duplicate_check_complete_politician_we_vote_id_list.append(we_vote_politician.we_vote_id)
     except Exception as e:
         status += f"CRASHED_IN_POLITICIAN_LIST_LOOP: {str(e)} "
         # Fall through to exit function
@@ -392,15 +442,67 @@ def find_and_merge_duplicate_politicians(state_code=''):
         "duplicate_check_complete_politician_we_vote_id_list": duplicate_check_complete_politician_we_vote_id_list,
         "politicians_merged_found": politicians_merged_found,
         "politicians_merged_list": politicians_merged_list,
+        "reset_duplicate_check_last_completed_we_vote_id_list": reset_duplicate_check_last_completed_we_vote_id_list,
         "status": status,
         "success": success,
     }
 
 
-def find_states_that_need_new_deduplication():
+def find_states_that_need_new_politician_deduplication():
+    """
+    Check to see if there are any states with that have new politicians that haven't been checked for duplicates
+    """
+    state_codes_for_deduplication = [
+        "ak", "al", "ar", "az", "ca", "co", "ct", "dc", "de", "fl", "ga", "hi", "ia", "id", "il", "in", "ks",
+        "ky", "la", "ma", "md", "me", "mi", "mn", "mo", "ms", "mt", "na", "nc", "nd", "ne", "nh", "nj", "nm",
+        "nv", "ny", "oh", "ok", "or", "pa", "pr", "ri", "sc", "sd", "tn", "tx", "ut", "va", "vt", "wa", "wi",
+        "wv", "wy"
+    ]
     state_code_list = []
     status = ''
     success = True
+
+    # Return all politicians from any state in state_codes_for_deduplication
+    #  that have a null duplicate_check_last_completed value
+    # We want to identify new politicians that haven't been deduplicated yet
+    politician_query = Politician.objects.using('readonly').filter(
+        state_code__in=state_codes_for_deduplication,
+        duplicate_check_last_completed__isnull=True,
+    )
+    # Extract a list of politician we_vote_id values from the politician_query organized by state_code
+    politician_list = list(politician_query)
+    politicians_by_state_code = {}
+    for politician in politician_list:
+        if politician.state_code not in politicians_by_state_code:
+            politicians_by_state_code[politician.state_code] = []
+        politicians_by_state_code[politician.state_code].append(politician.we_vote_id)
+
+    # Now cycle through each state in state_codes_for_deduplication and make sure
+    # that none of the we_vote_id values in politicians_by_state_code appear in PoliticiansArePossibleDuplicates
+    for state_code in politicians_by_state_code:
+        politician_we_vote_id_list = politicians_by_state_code[state_code]
+        politician_we_vote_id_remaining_list = politician_we_vote_id_list.copy()
+        politician_duplicate_check_query = PoliticiansArePossibleDuplicates.objects.using('readonly').filter(
+            (
+                Q(politician1_we_vote_id__in=politician_we_vote_id_list) &
+                Q(politician2_we_vote_id__isnull=False)
+            ) | (
+                Q(politician2_we_vote_id__in=politician_we_vote_id_list) &
+                Q(politician1_we_vote_id__isnull=False)
+            )
+        )
+        politician_duplicate_check_list = list(politician_duplicate_check_query)
+        # Cycle through politician_duplicate_check_list and remove one-by-one the values in politician_we_vote_id_list.
+        #  If there are values left, then we can run the deduplication process for the state again
+        for politician_duplicate_check in politician_duplicate_check_list:
+            if politician_duplicate_check.politician1_we_vote_id in politician_we_vote_id_remaining_list:
+                politician_we_vote_id_remaining_list.remove(politician_duplicate_check.politician1_we_vote_id)
+            if politician_duplicate_check.politician2_we_vote_id in politician_we_vote_id_remaining_list:
+                politician_we_vote_id_remaining_list.remove(politician_duplicate_check.politician2_we_vote_id)
+
+        if len(politician_we_vote_id_remaining_list) > 0:
+            # We need to run the deduplication process for this state again
+            state_code_list.append(state_code)
 
     return {
         "state_code_list": state_code_list,

--- a/politician/models.py
+++ b/politician/models.py
@@ -211,8 +211,8 @@ class Politician(models.Model):
     # See these related fields in CandidateCampaign table:
     # updated_from_politician_completed_first = models.DateTimeField(null=True)
     # updated_from_politician_completed_second = models.DateTimeField(null=True)
-    # updates_to_politician_completed = models.DateTimeField(null=True)
-    # See this url for properties: https://docs.python.org/2/library/functions.html#property
+    # updates_to_politician_completed = models.DateTimeField(null=True)  # Research date_last_updated_from_candidate
+
     first_name = models.CharField(verbose_name="first name",
                                   max_length=255, default=None, null=True, blank=True)
     middle_name = models.CharField(verbose_name="middle name",
@@ -2318,7 +2318,7 @@ class PoliticianManager(models.Manager):
 
         # twitter handle does not exist, next look up against other data that might match
         if keep_looking_for_duplicates and positive_value_exists(politician_name):
-            # Search by Candidate name exact match
+            # Search by Politician name exact match
             try:
                 if positive_value_exists(read_only):
                     queryset = Politician.objects.using('readonly').all()
@@ -2566,6 +2566,21 @@ class PoliticianManager(models.Manager):
         politicians_are_not_duplicates_list1 = []
         politicians_are_not_duplicates_list2 = []
         status = ""
+        success = True
+        error_results = {
+            'success':                                          False,
+            'status':                                           status,
+            'politicians_are_not_duplicates_list_found':        False,
+            'politicians_are_not_duplicates_list':              [],
+            'politicians_are_not_duplicates_list_we_vote_ids':  [],
+        }
+
+        if not positive_value_exists(politician_we_vote_id):
+            status += "NOT_DUPLICATES_POLITICIAN_WE_VOTE_ID_NOT_PROVIDED "
+            error_results['status'] = status
+            error_results['success'] = False
+            return error_results
+
         try:
             if positive_value_exists(read_only):
                 politicians_are_not_duplicates_list_query = \
@@ -2577,15 +2592,15 @@ class PoliticianManager(models.Manager):
                     politician1_we_vote_id=politician_we_vote_id,
                 )
             politicians_are_not_duplicates_list1 = list(politicians_are_not_duplicates_list_query)
-            success = True
             status += "POLITICIANS_NOT_DUPLICATES_LIST_UPDATED_OR_CREATED1 "
         except PoliticiansAreNotDuplicates.DoesNotExist:
             # No data found. Try again below
-            success = True
             status += 'NO_POLITICIANS_NOT_DUPLICATES_LIST_RETRIEVED_DoesNotExist1 '
         except Exception as e:
-            success = False
             status += "POLITICIANS_NOT_DUPLICATES_LIST_NOT_UPDATED_OR_CREATED1: " + str(e) + ' '
+            error_results['status'] = status
+            error_results['success'] = False
+            return error_results
 
         if success:
             try:
@@ -2600,14 +2615,15 @@ class PoliticianManager(models.Manager):
                             politician2_we_vote_id=politician_we_vote_id,
                         )
                 politicians_are_not_duplicates_list2 = list(politicians_are_not_duplicates_list_query)
-                success = True
                 status += "POLITICIANS_NOT_DUPLICATES_LIST_UPDATED_OR_CREATED2 "
             except PoliticiansAreNotDuplicates.DoesNotExist:
-                success = True
                 status += 'NO_POLITICIANS_NOT_DUPLICATES_LIST_RETRIEVED2_DoesNotExist2 '
             except Exception as e:
                 success = False
                 status += "POLITICIANS_NOT_DUPLICATES_LIST_NOT_UPDATED_OR_CREATED2: " + str(e) + ' '
+                error_results['status'] = status
+                error_results['success'] = success
+                return error_results
 
         politicians_are_not_duplicates_list = \
             politicians_are_not_duplicates_list1 + politicians_are_not_duplicates_list2
@@ -2615,9 +2631,11 @@ class PoliticianManager(models.Manager):
         politicians_are_not_duplicates_list_we_vote_ids = []
         for one_entry in politicians_are_not_duplicates_list:
             if one_entry.politician1_we_vote_id != politician_we_vote_id:
-                politicians_are_not_duplicates_list_we_vote_ids.append(one_entry.politician1_we_vote_id)
-            elif one_entry.politician2_we_vote_id != politician_we_vote_id:
-                politicians_are_not_duplicates_list_we_vote_ids.append(one_entry.politician2_we_vote_id)
+                if one_entry.politician1_we_vote_id not in politicians_are_not_duplicates_list_we_vote_ids:
+                    politicians_are_not_duplicates_list_we_vote_ids.append(one_entry.politician1_we_vote_id)
+            if one_entry.politician2_we_vote_id != politician_we_vote_id:
+                if one_entry.politician2_we_vote_id not in politicians_are_not_duplicates_list_we_vote_ids:
+                    politicians_are_not_duplicates_list_we_vote_ids.append(one_entry.politician2_we_vote_id)
         results = {
             'success':                                          success,
             'status':                                           status,

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -942,6 +942,12 @@ def politician_merge_process_view(request):
             )
             queryset.delete()
             messages.add_message(request, messages.INFO, 'Prior politicians skipped, and not merged.')
+
+            we_vote_ids_to_update = [politician1_we_vote_id, politician2_we_vote_id]
+            Politician.objects.filter(we_vote_id__in=we_vote_ids_to_update) \
+                .update(duplicate_check_last_completed=None)
+            status += f"DUPLICATE_CHECK_COMPLETE_SET_FOR-{len(we_vote_ids_to_update)}-POLITICIANS "
+
             if positive_value_exists(voter_we_vote_id):
                 try:
                     # Give the volunteer who entered this credit
@@ -1017,6 +1023,12 @@ def politician_merge_process_view(request):
             politician2_we_vote_id=politician2_we_vote_id,
         )
         queryset.delete()
+
+        # Now set the flag so this politician gets checked against other politicians for duplicates
+        Politician.objects.filter(we_vote_id=politician.we_vote_id) \
+            .update(duplicate_check_last_completed=None)
+        status += f"RESET_DUPLICATE_CHECK_FOR-{politician.we_vote_id}-POLITICIAN "
+
         if positive_value_exists(voter_we_vote_id):
             try:
                 # Give the volunteer who entered this credit
@@ -1445,6 +1457,8 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
     facebook_url = request.GET.get('facebook_url', False)
     facebook_url2 = request.GET.get('facebook_url2', False)
     facebook_url3 = request.GET.get('facebook_url3', False)
+    find_candidates_to_link_to_this_politician_on = \
+        request.GET.get('find_candidates_to_link_to_this_politician_on', False)
     first_name = request.GET.get('first_name', False)
     google_civic_candidate_name = request.GET.get('google_civic_candidate_name', False)
     google_civic_candidate_name2 = request.GET.get('google_civic_candidate_name2', False)
@@ -1698,8 +1712,18 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         # Find Candidates to Link to this Politician
         # Finding Candidates that *might* be "children" of this politician
         t0 = time()
-        from politician.controllers import find_candidates_to_link_to_this_politician
-        related_candidate_list = find_candidates_to_link_to_this_politician(politician=politician_on_stage)
+        # find_candidates_to_link_to_this_politician_on = False  # Turned off for now because this is a slow operation
+        # TODO: Connect this to a variable on the Politician Edit page that turns this on.
+        find_candidates_to_link_none_found = False
+        related_candidate_list = []
+        if positive_value_exists(find_candidates_to_link_to_this_politician_on):
+            from politician.controllers import find_candidates_to_link_to_this_politician
+            related_candidate_list = find_candidates_to_link_to_this_politician(politician=politician_on_stage)
+            if len(related_candidate_list) == 0:
+                find_candidates_to_link_to_this_politician_on = False
+                find_candidates_to_link_none_found = True
+            else:
+                find_candidates_to_link_none_found = False
 
         # Find possible duplicate politicians
         duplicate_politician_list = []
@@ -1975,6 +1999,8 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             'facebook_url':                 facebook_url,
             'facebook_url2':                facebook_url2,
             'facebook_url3':                facebook_url3,
+            'find_candidates_to_link_none_found':    find_candidates_to_link_none_found,
+            'find_candidates_to_link_to_this_politician_on':    find_candidates_to_link_to_this_politician_on,
             'first_name_dict':
             {
                 'label':    'First Name',
@@ -2393,6 +2419,8 @@ def politician_edit_process_view(request):
     facebook_url = request.POST.get('facebook_url', False)
     facebook_url2 = request.POST.get('facebook_url2', False)
     facebook_url3 = request.POST.get('facebook_url3', False)
+    find_candidates_to_link_to_this_politician_on = \
+        request.POST.get('find_candidates_to_link_to_this_politician_on', False)
     google_civic_candidate_name = request.POST.get('google_civic_candidate_name', False)
     if positive_value_exists(google_civic_candidate_name):
         google_civic_candidate_name = google_civic_candidate_name.strip()
@@ -3502,15 +3530,19 @@ def politician_edit_process_view(request):
     # ##################################
     # Find Candidates to Link to this Politician
     # Finding Candidates that *might* be "children" of this politician
-    t0 = time()
-    from politician.controllers import find_candidates_to_link_to_this_politician
+    # find_candidates_to_link_to_this_politician_on = False  # Turned off for now because this is a slow operation
+    # TODO: Connect this to a variable on the Politician Edit page that turns this on.
+    related_candidate_list = []
+    if positive_value_exists(find_candidates_to_link_to_this_politician_on):
+        t0 = time()
+        from politician.controllers import find_candidates_to_link_to_this_politician
 
-    related_candidate_list = find_candidates_to_link_to_this_politician(politician=politician_on_stage)
+        related_candidate_list = find_candidates_to_link_to_this_politician(politician=politician_on_stage)
 
-    performance_list.append({
-        'enum_key': 'RET_CANDIDATES_TO_LINK',
-        'time_difference': round(time() - t0, 4),
-    })
+        performance_list.append({
+            'enum_key': 'RET_CANDIDATES_TO_LINK',
+            'time_difference': round(time() - t0, 4),
+        })
 
     # ##################################
     # Link Candidates to this Politician
@@ -3882,6 +3914,9 @@ def politician_edit_process_view(request):
     performance_process_dict_encoded = urlencode({
         'performance_process_dict': json.dumps(performance_dict)
     })
+
+    if find_candidates_to_link_to_this_politician_on:
+        url_variables += "&find_candidates_to_link_to_this_politician_on=true"
 
     if politician_id:
         return HttpResponseRedirect(reverse('politician:politician_edit', args=(politician_id,)) +

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -807,7 +807,25 @@
         </tr>
     {% endfor %}
     </table>
-<input name="submit_text" type="submit" value="{% if politician %}Link These Candidates to This Politician{% endif %}" />
+    <input type="hidden"
+           name="find_candidates_to_link_to_this_politician_on"
+           value="1" >
+    <input name="submit_text" type="submit" value="{% if politician %}Link These Candidates to This Politician{% endif %}" />
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+{% else %}
+    <h4>Candidates That Might Match This Politician</h4>
+    <input id="find_candidates_to_link_to_this_politician_on_id"
+           type="hidden"
+           name="find_candidates_to_link_to_this_politician_on"
+           value="0" >
+    {% if find_candidates_to_link_none_found %}
+        <p>No candidates found to link to this politician.</p>
+    {% endif %}
+    <input name="submit_text"
+           type="submit"
+           value="{% if politician %}Find Candidates that Might Need to be Linked{% endif %}"
+           id="find_candidates_submit_btn" />
     <p>&nbsp;</p>
     <p>&nbsp;</p>
 {% endif %}
@@ -1400,13 +1418,10 @@
 {% endif %}{# End of if politician #}
 
 <script>
-    $(function() {
-        $('#state_code_id').change(function() {
-            this.form.submit();
-        });
+    document.getElementById('find_candidates_submit_btn').addEventListener('click', function() {
+        document.getElementById('find_candidates_to_link_to_this_politician_on_id').value = '1';
     });
 </script>
-
 <style>
     .animated {
         -webkit-transition: height 0.2s;


### PR DESCRIPTION
Created mechanism to start over deduplication for a state if manual merging has happened by a WeVoter. Removed "Find candidates to link to a Politician" from every "Edit Politician" page load because of how slow it is. Now you can click a button start the check. Thanks to @mjacquot1 for finding the "Edit Politician" page slowdown, including the missing "list" call to force the queryset to load.