### PR TITLE
Adding null=True to avoid this error when making migrations: It is impossible to add a non-nullable field '_user_id' to singleusetoken without specifying a default. This is because the database needs something to populate existing rows. Please select a fix:  1) Provide a one-off default now (will be set on all existing rows with a null value for this column)  2) Quit and manually define a default value in models.py.

### DIFF
--- a/wevote_tokens/models/single_use_tokens.py
+++ b/wevote_tokens/models/single_use_tokens.py
@@ -23,18 +23,21 @@ class SingleUseToken(models.Model):
     _user_id = models.BinaryField(
         verbose_name='user we_vote_id',
         help_text='The user this token is assigned to.',
+        null=True,
     )
 
     # Retrieval Key Setting
     _validation = models.BinaryField(
         verbose_name='Encoded Validation Data',
         help_text='Field used to test if the passed validation key is valid.',
+        null=True,
     )
 
     # Expiration time - tokens expire after this datetime
     _expiration_datetime = models.DateTimeField(
         verbose_name='token expiration datetime',
         help_text='When this token expires.',
+        null=True,
     )
     
     # JSON blob for storing additional metadata
@@ -52,6 +55,7 @@ class SingleUseToken(models.Model):
         db_index=True,
         help_text='Timestamp when token was created.',
         default=timezone.now,
+        null=True,
     )
     
     class Meta:
@@ -60,9 +64,9 @@ class SingleUseToken(models.Model):
         # db_table = 'authtoken_token' # Replacing DRF's default Token model
     
     def __str__(self):
-        return f"Single Use Token for {self._user} (expires: {self._expiration_datetime})"
+        return f"Single Use Token for {self._user_id} (expires: {self._expiration_datetime})"
 
-    ## Only modify on creation.
+    # Only modify on creation.
     def save(self, user_id, validation_key, expiration_seconds=None, json_data=None, *args, **kwargs):
 
         if self.pk is not None:  # object exists
@@ -84,14 +88,13 @@ class SingleUseToken(models.Model):
         user_id = str(user_id)
         user_id_encrypted = cipher.encrypt(user_id.encode('utf-8'))
         
-        #default to 5 minutes expiration time
+        # default to 5 minutes expiration time
         if expiration_seconds is None:
             expiration_seconds = 300
         elif expiration_seconds < 0:
             raise ValueError("Expiration Seconds must be a positive value.")
-        elif expiration_seconds > 1800: # 30 minutes
+        elif expiration_seconds > 1800:  # 30 minutes
             raise ValueError("Expiration Seconds must be <= 1800.")
-            
 
         if json_data is not None:
             json_data = json.dumps(json_data)
@@ -110,6 +113,7 @@ class SingleUseToken(models.Model):
 
         super().save(*args, **kwargs)
 
+
 class SingleUseTokenManager(models.Manager):
 
     def __str__(self):              # __unicode__ on Python 2
@@ -117,7 +121,7 @@ class SingleUseTokenManager(models.Manager):
 
     @staticmethod
     def generate_encryption_key():
-        ## Add cryptographically secure random URL safe base 64 encoded string generation
+        # Add cryptographically secure random URL safe base 64 encoded string generation
         return Fernet.generate_key()
 
     @staticmethod
@@ -187,7 +191,6 @@ class SingleUseTokenManager(models.Manager):
             token_info['expiration_datetime'] = token._expiration_datetime
             token.delete()
             return token_info
-
 
         if token._json_data_encrypted is not None:
             # Convert BinaryField (memoryview) to bytes for Fernet.decrypt()


### PR DESCRIPTION
Adding null=True to avoid this error when making migrations:
It is impossible to add a non-nullable field '_user_id' to singleusetoken without specifying a default. This is because the database needs something to populate existing rows. Please select a fix:
 1) Provide a one-off default now (will be set on all existing rows with a null value for this column)
 2) Quit and manually define a default value in models.py.