### PR TITLE
[WV-2253] Add scopes, secure user id from leaking on token creation

### DIFF
--- a/wevote_tokens/models/single_use_tokens.py
+++ b/wevote_tokens/models/single_use_tokens.py
@@ -7,6 +7,10 @@ import json
 from wevote_functions.functions import positive_value_exists
 
 
+class Scope(models.IntegerChoices):
+    NONE = 0, 'none'
+    BACKUP_ONE_TABLE_TO_S3 = 1, 'backup_one_table_to_s3'
+
 class SingleUseToken(models.Model):
     """
     ###################################################
@@ -29,6 +33,13 @@ class SingleUseToken(models.Model):
     _validation = models.BinaryField(
         verbose_name='Encoded Validation Data',
         help_text='Field used to test if the passed validation key is valid.',
+    )
+
+    _scope = models.IntegerField(
+        verbose_name='scope',
+        help_text='The scope of the token.',
+        choices=Scope.choices,
+        default=Scope.NONE,
     )
 
     # Expiration time - tokens expire after this datetime
@@ -63,7 +74,7 @@ class SingleUseToken(models.Model):
         return f"Single Use Token for {self._user} (expires: {self._expiration_datetime})"
 
     ## Only modify on creation.
-    def save(self, user_id, validation_key, expiration_seconds=None, json_data=None, *args, **kwargs):
+    def save(self, user_id, validation_key, scope, expiration_seconds=None, json_data=None, *args, **kwargs):
 
         if self.pk is not None:  # object exists
             raise ValueError("Direct save is not allowed. Tokens are meant to be immutable after creation.")
@@ -73,17 +84,23 @@ class SingleUseToken(models.Model):
             raise ValueError("User ID must be a string or integer.")
         if not isinstance(validation_key, (bytes)):
             raise ValueError("Validation key must be a bytes object.")
+        if not isinstance(scope, int):
+            raise ValueError("Scope must be an integer.")
         if not isinstance(expiration_seconds, (int, float, type(None))):
             raise ValueError("Expiration time must be an integer or float, in seconds.")
         if not isinstance(json_data, (dict, type(None))):
             raise ValueError("JSON data must be a dictionary or None.")
 
         cipher = Fernet(validation_key)
-        time_now = timezone.now()
-            
         user_id = str(user_id)
         user_id_encrypted = cipher.encrypt(user_id.encode('utf-8'))
-        
+        time_now = timezone.now()
+
+        try:
+            Scope(scope)
+        except Exception as e:
+            raise ValueError(f"Invalid scope of {scope} : {str(e)}")
+
         #default to 5 minutes expiration time
         if expiration_seconds is None:
             expiration_seconds = 300
@@ -103,11 +120,12 @@ class SingleUseToken(models.Model):
             json_data_encrypted = None
         
         self._user_id = user_id_encrypted
+        self._scope = scope
         self._created_at = time_now
         self._validation = cipher.encrypt(validation_key)
         self._expiration_datetime = time_now + timedelta(seconds=int(expiration_seconds))
         self._json_data_encrypted = json_data_encrypted
-
+        
         super().save(*args, **kwargs)
 
 class SingleUseTokenManager(models.Manager):
@@ -121,22 +139,35 @@ class SingleUseTokenManager(models.Manager):
         return Fernet.generate_key()
 
     @staticmethod
-    def create_token(user_id, validation_key, expiration_seconds=None, json_data=None):
+    def create_token(user_id, validation_key, scope, expiration_seconds=None, json_data=None):
         token_info = {
             'success': False,
             'status': '',
             'token_pk': None,
             'expiration_datetime': None,
-            'token_user': None,
         }
         
+        if not isinstance(scope, (int, str)):
+            token_info['status'] = "SCOPE MUST BE AN INTEGER OR STRING INTEGER."
+            return token_info
+
+        try:
+            int(scope)
+            Scope(scope)
+        except Exception as e:
+            token_info['status'] = f"INVALID SCOPE OF {scope}: {str(e)}"
+            return token_info
+
         if not isinstance(validation_key, (bytes)):
             token_info['status'] = "VALIDATION KEY MUST BE A BYTES OR STRING."
             return token_info
 
         new_token = SingleUseToken()
         try:
-            new_token.save(user_id, validation_key=validation_key,
+            new_token.save(
+                user_id=user_id,
+                validation_key=validation_key, 
+                scope=scope,
                 expiration_seconds=expiration_seconds,
                 json_data=json_data)
         except Exception as e:
@@ -147,31 +178,46 @@ class SingleUseTokenManager(models.Manager):
         token_info['status'] = 'TOKEN CREATED'
         token_info['token_pk'] = new_token.pk
         token_info['expiration_datetime'] = new_token._expiration_datetime
-        token_info['token_user'] = user_id
 
         return token_info
 
     @staticmethod
-    def authenticate_retrieve_token(pk, validation_key):
+    def authenticate_retrieve_token(pk, validation_key, scope):
         token_info = {
             'success': False,
             'status': '',
+            'scope': None,
+            'scope_display': None,
             'expiration_datetime': None,
             'json_data': None,
             'token_user': None,
             'expired': False,
         }
-        
-        cipher = Fernet(validation_key)
+
+        if not isinstance(scope, (int, str)):
+            token_info['status'] = "SCOPE MUST BE AN INTEGER OR STRING INTEGER."
+            return token_info
+
+        try:
+            int(scope)
+            Scope(scope)
+        except Exception as e:
+            token_info['status'] = f"INVALID SCOPE OF {scope} : {str(e)}"
+            return token_info
+
+        if not isinstance(validation_key, (bytes)):
+            token_info['status'] = "VALIDATION KEY MUST BE A BYTES OBJECT."
+            return token_info
 
         try:
             token = SingleUseToken.objects.get(pk=pk)
         except Exception as e:
             token_info['status'] = 'TOKEN NOT FOUND: ' + str(e)
             return token_info
-        
+
         try:
             # Convert BinaryField (memoryview) to bytes for Fernet.decrypt()
+            cipher = Fernet(validation_key)
             validation_bytes = bytes(token._validation) if token._validation else b''
             cipher.decrypt(validation_bytes)
         except InvalidToken:
@@ -188,6 +234,9 @@ class SingleUseTokenManager(models.Manager):
             token.delete()
             return token_info
 
+        if token._scope != scope:
+            token_info['status'] = f"INVALID SCOPE OF {scope}"
+            return token_info
 
         if token._json_data_encrypted is not None:
             # Convert BinaryField (memoryview) to bytes for Fernet.decrypt()
@@ -200,6 +249,8 @@ class SingleUseTokenManager(models.Manager):
 
         token_info['success'] = True
         token_info['status'] = 'TOKEN RETRIEVED AND AUTHENTICATED'
+        token_info['scope'] = token._scope
+        token_info['scope_display'] = token.get__scope_display()
         token_info['expiration_datetime'] = token._expiration_datetime
         token_info['json_data'] = json_data
         token_info['token_user'] = decrypted_user_id

--- a/wevote_tokens/tests/test_single_use_token.py
+++ b/wevote_tokens/tests/test_single_use_token.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from voter.models import VoterManager
-from wevote_tokens.models.single_use_tokens import SingleUseToken, SingleUseTokenManager
+from wevote_tokens.models.single_use_tokens import SingleUseToken, SingleUseTokenManager, Scope
 from cryptography.fernet import Fernet
 import json
 from datetime import timedelta
@@ -14,15 +14,32 @@ class TestSingleUseToken(TestCase):
         self.test_voter = '1234567890' # Only need voter ID for testing
         self.test_validation_key = Fernet.generate_key()
         self.test_cipher = Fernet(self.test_validation_key)
+        self.test_scope = Scope.BACKUP_ONE_TABLE_TO_S3
+
+    def _save_test_token(self, voter=None, validation_key=None, scope=None, expiration_seconds=None, json_data=None):
+        if voter is None:
+            voter = self.test_voter
+        if validation_key is None:
+            validation_key = self.test_validation_key
+        if scope is None:
+            scope = self.test_scope
+
+        token = SingleUseToken()
+        try:
+            token.save(user_id=voter, validation_key=validation_key, scope=scope, expiration_seconds=expiration_seconds, json_data=json_data)
+        except Exception as e:
+            raise ValueError(str(e))
+        
+        return token
     
     def test_single_use_token_creation(self):
         voter = self.test_voter
         validation_key = self.test_validation_key
-        expiration = 300
+        scope = self.test_scope
+        expiration_seconds = 300
         json_data = {'test': 'test'}
 
-        token = SingleUseToken()
-        token.save(voter, validation_key=validation_key, expiration_seconds=expiration, json_data=json_data)
+        token = self._save_test_token(voter=voter, validation_key=validation_key, scope=scope, expiration_seconds=expiration_seconds, json_data=json_data)
 
         self.assertEqual(
             self.test_cipher.decrypt(bytes(token._user_id)).decode('utf-8'),
@@ -37,16 +54,30 @@ class TestSingleUseToken(TestCase):
             json_data, 
             "_json_data_encrypted Not Set Correctly")
         self.assertLessEqual(
-            (timezone.now() + timedelta(seconds=expiration)) - token._expiration_datetime,
+            (timezone.now() + timedelta(seconds=expiration_seconds)) - token._expiration_datetime,
             timedelta(seconds=1),
             "_expiration_datetime Not Set Correctly")
+        self.assertEqual(
+            token._scope,
+            scope,
+            "_scope Not Set Correctly")
+
+    def test_single_use_token_creation_with_invalid_scope_value(self):
+        scope = 99999999
+
+        with self.assertRaisesMessage(ValueError, f'Invalid scope of {scope}'):
+            self._save_test_token(scope=scope)
+
+    def test_single_use_token_creation_with_invalid_scope_type(self):
+        scope = '1'
+
+        with self.assertRaisesMessage(ValueError, 'Scope must be an integer.'):
+            self._save_test_token(scope=scope)
 
     def test_single_use_token_creation_with_int_user_id(self):
         int_user_id = 1234567890
-        validation_key = self.test_validation_key
 
-        token = SingleUseToken()
-        token.save(user_id=int_user_id, validation_key=validation_key)
+        token = self._save_test_token(voter=int_user_id)
 
         self.assertEqual(
             self.test_cipher.decrypt(bytes(token._user_id)).decode('utf-8'),
@@ -55,48 +86,33 @@ class TestSingleUseToken(TestCase):
 
     def test_single_use_token_creation_with_invalid_user_id(self):
         invalid_user = []
-        validation_key = self.test_validation_key
-
-        token = SingleUseToken()
 
         with self.assertRaisesMessage(ValueError, 'User ID must be a string or integer.'):
-            token.save(user_id=invalid_user, validation_key=validation_key)
+            self._save_test_token(voter=invalid_user)
 
     def test_single_use_token_creation_with_invalid_validation_key(self):
-        voter = self.test_voter
         invalid_validation_key = 'invalid'
 
-        token = SingleUseToken()
-
         with self.assertRaisesMessage(ValueError, "Validation key must be a bytes object."):
-            token.save(user_id=voter, validation_key=invalid_validation_key)
+            self._save_test_token(validation_key=invalid_validation_key)
 
     def test_single_use_token_creation_with_invalid_json_data(self):
-        voter = self.test_voter
         invalid_json_data = 1
 
-        token = SingleUseToken()
-
         with self.assertRaisesMessage(ValueError, "JSON data must be a dictionary or None."):
-            token.save(user_id=voter, validation_key=self.test_validation_key, json_data=invalid_json_data)
+            self._save_test_token(json_data=invalid_json_data)
     
     def test_single_use_token_creation_with_large_json_data(self):
-        voter = self.test_voter
         large_json_data = {'test': 'test' * 10000}
         large_json_data_size = len(bytes(json.dumps(large_json_data), "utf-8"))
 
-        token = SingleUseToken()
-
         with self.assertRaisesMessage(ValueError, f"Json Data must be <= 8kb, currently {large_json_data_size} bytes."):
-            token.save(user_id=voter, validation_key=self.test_validation_key, json_data=large_json_data)
+            self._save_test_token(json_data=large_json_data)
     
     def test_single_use_token_creation_with_default_expiration(self):
-        voter = self.test_voter
         default_expiration = 300
-        validation_key = self.test_validation_key
 
-        token = SingleUseToken()
-        token.save(user_id=voter, validation_key=validation_key)
+        token = self._save_test_token()
 
         self.assertLessEqual(
             (timezone.now() + timedelta(seconds=default_expiration)) - token._expiration_datetime,
@@ -104,34 +120,22 @@ class TestSingleUseToken(TestCase):
             "_expiration_datetime Not Set With Correct Default Expiration")
 
     def test_single_use_token_creation_with_invalid_expiration(self):
-        voter = self.test_voter
         invalid_expiration = 'invalid'
-        validation_key = self.test_validation_key
-
-        token = SingleUseToken()
 
         with self.assertRaisesMessage(ValueError, "Expiration time must be an integer or float, in seconds."):
-            token.save(user_id=voter, validation_key=validation_key, expiration_seconds=invalid_expiration)
+            self._save_test_token(expiration_seconds=invalid_expiration)
 
     def test_single_use_token_creation_with_negative_expiration(self):
-        voter = self.test_voter
         negative_expiration = -1
-        validation_key = self.test_validation_key
-
-        token = SingleUseToken()
 
         with self.assertRaisesMessage(ValueError, "Expiration Seconds must be a positive value."):
-            token.save(user_id=voter, validation_key=validation_key, expiration_seconds=negative_expiration)
+            self._save_test_token(expiration_seconds=negative_expiration)
 
     def test_single_use_token_creation_with_large_expiration(self):
-        voter = self.test_voter
         large_expiration = 1801
-        validation_key = self.test_validation_key
-
-        token = SingleUseToken()
 
         with self.assertRaisesMessage(ValueError, "Expiration Seconds must be <= 1800."):
-            token.save(user_id=voter, validation_key=validation_key, expiration_seconds=large_expiration)
+            self._save_test_token(expiration_seconds=large_expiration)
 
 
 class TestSingleUseTokenManager(TestCase):
@@ -140,6 +144,7 @@ class TestSingleUseTokenManager(TestCase):
         # self.test_voter = VoterManager().create_voter(email='test@example.com', password='testpassword')['voter'].id
         self.test_voter = '1234567890' # Only need voter ID for testing
         self.test_validation_key = Fernet.generate_key()
+        self.test_scope = Scope.BACKUP_ONE_TABLE_TO_S3
 
     def _assert_equal(self, values_dict, keys_to_check, expected_value, reason):
         for i, key in enumerate(keys_to_check):
@@ -161,14 +166,30 @@ class TestSingleUseTokenManager(TestCase):
         for key in keys_to_check:
             self.assertFalse(values_dict[key], f"'{key}' Should Be False on {reason} but was {values_dict[key]}")
 
-    def _get_test_token_pk(self, voter=None, validation_key=None, expiration_seconds=None, json_data=None):
+    def _get_test_token_pk(self, voter=None, validation_key=None, scope=None, expiration_seconds=None, json_data=None):
         if voter is None:
             voter = self.test_voter
         if validation_key is None:
             validation_key = self.test_validation_key
-            
-        token_info = SingleUseTokenManager.create_token(user_id=voter, validation_key=validation_key, expiration_seconds=expiration_seconds, json_data=json_data)
+        if scope is None:
+            scope = self.test_scope
+
+        token_info = SingleUseTokenManager.create_token(
+            user_id=voter,
+            validation_key=validation_key,
+            scope=scope,
+            expiration_seconds=expiration_seconds,
+            json_data=json_data)
+
         return token_info['token_pk']
+
+    def _authenticate_retrieve_token(self, token_pk, validation_key=None, scope=None):
+        if validation_key is None:
+            validation_key = self.test_validation_key
+        if scope is None:
+            scope = self.test_scope
+
+        return SingleUseTokenManager.authenticate_retrieve_token(token_pk, validation_key, scope)
 
     def test_generate_encryption_key(self):
         
@@ -184,13 +205,14 @@ class TestSingleUseTokenManager(TestCase):
 
     def test_create_token(self):
         voter = self.test_voter
+        scope = self.test_scope
         validation_key = self.test_validation_key
         expiration = 300
         message_addon = "Token Creation Success"
 
-        token_info = SingleUseTokenManager.create_token(user_id=voter, validation_key=validation_key, expiration_seconds=expiration)
+        token_info = SingleUseTokenManager.create_token(user_id=voter, validation_key=validation_key, scope=scope, expiration_seconds=expiration)
 
-        self._assert_equal(token_info, ['status', 'token_user'], ["TOKEN CREATED", voter], message_addon)
+        self._assert_equal(token_info, ['status'], ["TOKEN CREATED"], message_addon)
         self._assert_is_not_none(token_info, ['token_pk'], message_addon)
         self.assertLessEqual(
             (timezone.now() + timedelta(seconds=expiration)) - token_info['expiration_datetime'],
@@ -199,44 +221,70 @@ class TestSingleUseTokenManager(TestCase):
 
     def test_create_token_failure(self):
         voter = self.test_voter
+        scope = self.test_scope
         validation_key = self.test_validation_key
         message_addon = "Token Creation Failure"
 
-        token_info = SingleUseTokenManager.create_token(user_id=voter, validation_key=validation_key, expiration_seconds='invalid')
+        token_info = SingleUseTokenManager.create_token(user_id=voter, validation_key=validation_key, scope=scope, expiration_seconds='invalid')
         
         self._assert_false(token_info, ['success'], message_addon)
-        self._assert_is_none(token_info, ['token_pk', 'expiration_datetime', 'token_user'], message_addon)
+        self._assert_is_none(token_info, ['token_pk', 'expiration_datetime'], message_addon)
         self._assert_equal(
             token_info,
             ['status'],
             ["TOKEN SAVE FAILED: Expiration time must be an integer or float, in seconds."],
             message_addon)
+    
+    def test_create_token_with_invalid_scope_value(self):
+        voter = self.test_voter
+        validation_key = self.test_validation_key
+        scope = 99999999
+        message_addon = "Invalid Scope"
+
+        token_info = SingleUseTokenManager.create_token(user_id=voter, validation_key=validation_key, scope=scope)
+
+        self._assert_false(token_info, ['success'], message_addon)
+        self._assert_is_none(token_info, ['token_pk', 'expiration_datetime'], message_addon)
+        self.assertIn(f'INVALID SCOPE OF {scope}', token_info['status'], message_addon)
+
+    def test_create_token_with_invalid_scop_type(self):
+        voter = self.test_voter
+        validation_key = self.test_validation_key
+        scope = 'invalid'
+        message_addon = "Invalid Scope"
+
+        token_info = SingleUseTokenManager.create_token(user_id=voter, validation_key=validation_key, scope=scope)
+
+        self._assert_false(token_info, ['success'], message_addon)
+        self._assert_is_none(token_info, ['token_pk', 'expiration_datetime'], message_addon)
 
     def test_create_token_with_invalid_validation_key(self):
         voter = self.test_voter
+        scope = self.test_scope
         invalid_validation_key = 99999999
         message_addon = "Invalid Validation Key"
         
-        token_info = SingleUseTokenManager.create_token(user_id=voter, validation_key=invalid_validation_key)
+        token_info = SingleUseTokenManager.create_token(user_id=voter, validation_key=invalid_validation_key, scope=scope)
 
         self._assert_false(token_info, ['success'], message_addon)
-        self._assert_is_none(token_info, ['token_pk', 'expiration_datetime', 'token_user'], message_addon)
+        self._assert_is_none(token_info, ['token_pk', 'expiration_datetime'], message_addon)
         self._assert_equal(token_info, ['status'], ["VALIDATION KEY MUST BE A BYTES OR STRING."], message_addon)
 
     def test_authenticate_retrieve_token(self):
         voter = self.test_voter
+        scope = self.test_scope
         json_data = {'test': 'test'}
         message_addon = "Authentication Success"
         
-        token_pk = self._get_test_token_pk(voter=voter, json_data=json_data)
-        token_info = SingleUseTokenManager.authenticate_retrieve_token(token_pk, self.test_validation_key)
+        token_pk = self._get_test_token_pk(voter=voter, scope=scope, json_data=json_data)
+        token_info = self._authenticate_retrieve_token(token_pk, scope=scope)
 
         self._assert_false(token_info, ['expired'], message_addon)
         self._assert_false({'exists': SingleUseToken.objects.filter(pk=token_pk).exists()}, ['exists'], message_addon)
         self._assert_equal(
             token_info,
-            ['status', 'json_data', 'token_user'],
-            ["TOKEN RETRIEVED AND AUTHENTICATED", json_data, voter],
+            ['status', 'json_data', 'scope', 'scope_display'],
+            ["TOKEN RETRIEVED AND AUTHENTICATED", json_data, scope.value, scope.label],
             message_addon)
         self._assert_is_not_none(token_info, ['expiration_datetime'], message_addon)
         self._assert_true(token_info, ['success'], message_addon)
@@ -247,10 +295,10 @@ class TestSingleUseTokenManager(TestCase):
         message_addon = "Token Not Found"
 
         token_pk = self._get_test_token_pk()
-        token_info = SingleUseTokenManager.authenticate_retrieve_token(invalid_pk, self.test_validation_key)
+        token_info = self._authenticate_retrieve_token(invalid_pk)
 
         self._assert_false(token_info, ['success', 'expired'], message_addon)
-        self._assert_is_none(token_info, ['expiration_datetime', 'token_user', 'json_data'], message_addon)
+        self._assert_is_none(token_info, ['expiration_datetime', 'json_data'], message_addon)
         self._assert_equal(token_info, ['status'], ["TOKEN NOT FOUND: SingleUseToken matching query does not exist."], message_addon)
         self._assert_true({'exists': SingleUseToken.objects.filter(pk=token_pk).exists()}, ['exists'], message_addon)
     
@@ -259,10 +307,10 @@ class TestSingleUseTokenManager(TestCase):
         message_addon = "Invalid Validation Key"
 
         token_pk = self._get_test_token_pk()
-        token_info = SingleUseTokenManager.authenticate_retrieve_token(token_pk, invalid_validation_key)
+        token_info = self._authenticate_retrieve_token(token_pk, invalid_validation_key)
 
         self._assert_false(token_info, ['success', 'expired'], message_addon)
-        self._assert_is_none(token_info, ['expiration_datetime', 'token_user', 'json_data'], message_addon)
+        self._assert_is_none(token_info, ['expiration_datetime', 'json_data'], message_addon)
         self._assert_equal(token_info, ['status'], ["VALIDATION DECRYPTION ERROR: Invalid Key"], message_addon)
         self._assert_true({'exists': SingleUseToken.objects.filter(pk=token_pk).exists()}, ['exists'], message_addon)
 
@@ -272,14 +320,47 @@ class TestSingleUseTokenManager(TestCase):
 
         token_pk = self._get_test_token_pk(expiration_seconds=expiration)
         time.sleep(1)
-        token_info = SingleUseTokenManager.authenticate_retrieve_token(token_pk, self.test_validation_key)
+        token_info = self._authenticate_retrieve_token(token_pk)
 
         self._assert_false(token_info, ['success'], message_addon)
         self._assert_false({'exists': SingleUseToken.objects.filter(pk=token_pk).exists()}, ['exists'], message_addon)
-        self._assert_is_none(token_info, ['token_user', 'json_data'], message_addon)
+        self._assert_is_none(token_info, ['json_data'], message_addon)
         self._assert_equal(token_info, ['status'], ["TOKEN EXPIRED"], message_addon)
         self._assert_is_not_none(token_info, ['expiration_datetime'], message_addon)
         self._assert_true(token_info, ['expired'], message_addon)
+
+    def test_authenticate_retrieve_token_invalid_scope(self):
+        invalid_scope = 99999999
+        message_addon = "Invalid Scope"
+
+        token_pk = self._get_test_token_pk()
+        token_info = self._authenticate_retrieve_token(token_pk, scope=invalid_scope)
+
+        self._assert_false(token_info, ['success', 'expired'], message_addon)
+        self._assert_is_none(token_info, ['expiration_datetime', 'json_data'], message_addon)
+        self.assertIn(f'INVALID SCOPE OF {invalid_scope}', token_info['status'], message_addon)
+
+    def test_authenticate_retrieve_token_invalid_scope_type(self):
+        invalid_scope = []
+        message_addon = "Invalid Scope"
+
+        token_pk = self._get_test_token_pk()
+        token_info = self._authenticate_retrieve_token(token_pk, scope=invalid_scope)
+
+        self._assert_false(token_info, ['success', 'expired'], message_addon)
+        self._assert_is_none(token_info, ['expiration_datetime', 'json_data'], message_addon)
+        self._assert_equal(token_info, ['status'], ["SCOPE MUST BE AN INTEGER OR STRING INTEGER."], message_addon)
+
+    def test_authenticate_retrieve_token_icorrect_scope(self):
+        incorrect_scope = 0
+        message_addon = "Incorrect Scope"
+
+        token_pk = self._get_test_token_pk()
+        token_info = self._authenticate_retrieve_token(token_pk, scope=incorrect_scope)
+
+        self._assert_false(token_info, ['success', 'expired'], message_addon)
+        self._assert_is_none(token_info, ['expiration_datetime', 'json_data'], message_addon)
+        self._assert_equal(token_info, ['status'], [f'INVALID SCOPE OF {incorrect_scope}'], message_addon)
 
     def test_authenticate_retrieve_token_with_json_data(self):
         voter = self.test_voter
@@ -287,14 +368,14 @@ class TestSingleUseTokenManager(TestCase):
         message_addon = "Authentication Success with JSON Data"
         
         token_pk = self._get_test_token_pk(voter=voter, json_data=json_data)
-        token_info = SingleUseTokenManager.authenticate_retrieve_token(token_pk, self.test_validation_key)
+        token_info = self._authenticate_retrieve_token(token_pk)
 
         self._assert_false(token_info, ['expired'], message_addon)
         self._assert_false({'exists': SingleUseToken.objects.filter(pk=token_pk).exists()}, ['exists'], message_addon)
         self._assert_equal(
             token_info,
-            ['status', 'json_data', 'token_user'],
-            ["TOKEN RETRIEVED AND AUTHENTICATED", json_data, voter],
+            ['status', 'json_data'],
+            ["TOKEN RETRIEVED AND AUTHENTICATED", json_data],
             message_addon)
         self._assert_is_not_none(token_info, ['expiration_datetime'], message_addon)
         self._assert_true(token_info, ['success'], message_addon)
@@ -304,14 +385,14 @@ class TestSingleUseTokenManager(TestCase):
         message_addon = "Authentication Success With No JSON Data"
 
         token_pk = self._get_test_token_pk(voter=voter)
-        token_info = SingleUseTokenManager.authenticate_retrieve_token(token_pk, self.test_validation_key)
+        token_info = self._authenticate_retrieve_token(token_pk)
 
         self._assert_false(token_info, ['expired'], message_addon)
         self._assert_false({'exists': SingleUseToken.objects.filter(pk=token_pk).exists()}, ['exists'], message_addon)
         self._assert_equal(
             token_info,
-            ['status', 'json_data', 'token_user'],
-            ["TOKEN RETRIEVED AND AUTHENTICATED", None, voter],
+            ['status', 'json_data'],
+            ["TOKEN RETRIEVED AND AUTHENTICATED", None],
             message_addon)
         self._assert_is_not_none(token_info, ['expiration_datetime'], message_addon)
         self._assert_true(token_info, ['success'], message_addon)


### PR DESCRIPTION
Part of several branches being worked on in concurrence for Fast Load.

Due to no longer needing a direct user connection, some security has been added:

1. Now a scope is required to create and authenticate a token. IE, if we had `Process A` and `Process B`, a token generated for `Process A` cannot be use for `Process B`.
2. Removed returning a user id when a token is created. Now whatever process that is creating the token needs to track the user.

Testing:
Added and modified unit tests to ensure functionality.