### PR TITLE
[Issue #WV-2255] Create customization tokens on `email_template_edit` page

### DIFF
--- a/email_outbound/views_admin.py
+++ b/email_outbound/views_admin.py
@@ -254,6 +254,15 @@ def email_template_edit_view(request):
     elif default_folder_id:
         selected_folder_id = int(default_folder_id)
 
+    # customization tokens
+    TOKEN_LIST = [
+        "[official email]",
+        "[person first name]",
+        "[person last name]",
+        "[person full name]",
+        "[personal email]",
+        ]
+
     template_values = {
         # 'election':               election,
         # 'election_list':          election_list,
@@ -262,6 +271,7 @@ def email_template_edit_view(request):
         'selected_folder_id':       selected_folder_id,
         'google_civic_election_id': google_civic_election_id,
         'state_code':               state_code,
+        'token_list':               TOKEN_LIST,
         # 'state_list':             sorted_state_list,
     }
     return render(request, 'email_outbound/email_template_edit.html', template_values)

--- a/templates/email_outbound/email_template_edit.html
+++ b/templates/email_outbound/email_template_edit.html
@@ -63,12 +63,40 @@
         <textarea id="message" name="message" class="form-control" rows="10">{% if email_template %}{{ email_template.message }}{% endif %}</textarea>
     </div>
 
+    <!-- Customization tokens -->
+    <div class="mb-4">
+      <h5>Customization Tokens</h5>
+      <p class="text-muted">Click a token to copy it so you can paste it into the message above.</p>
+
+      <div class="token-grid">
+        {% for token in token_list %}
+          <button type="button" class="btn btn-outline-secondary btn-sm token-btn"
+                  data-token="{{ token }}"
+                  style="min-width: 240px; text-align: left;">
+            {{ token }}
+          </button>
+        {% endfor %}
+      </div>
+    </div>
+
     <input type="hidden" name="google_civic_election_id" value="{{ google_civic_election_id }}">
     <input type="hidden" name="state_code" value="{{ state_code }}">
     <input type="hidden" name="email_template_id" value="{% if email_template %}{{ email_template.id }}{% endif %}">
     <input type="hidden" name="selected_folder_id" value="{{ selected_folder_id }}">
   </form>
 </div>
+<style>
+  .token-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 8px;
+  }
+
+  .token-btn.copied {
+    background-color: #d4edda;
+    border-color: #c3e6cb;
+  }
+</style>
 
 <!-- Use TinyMCE via Local -->
 {% load static %}
@@ -136,5 +164,20 @@
       }
     });
   });
+</script>
+
+<!-- Customization tokens copy script -->
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.token-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const token = btn.dataset.token;
+      navigator.clipboard.writeText(token).then(() => {
+        btn.classList.add('copied');
+        setTimeout(() => btn.classList.remove('copied'), 800);
+      });
+    });
+  });
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
This PR addresses WV-2255: Add Customization Tokens UI to the Edit Template interface. It adds several customization tokens to this page: http://localhost:8000/email/edit_template/
<img width="849" height="683" alt="Screenshot 2025-12-01 at 10 34 56 PM" src="https://github.com/user-attachments/assets/a683a2e0-d92f-45e9-afde-7eb1ff060b26" />
