### PR TITLE
[WV-2311] MAIN fast load token validation / issuance

### DIFF
--- a/apis_v1/tests/test_views_backup_one_table_to_s3.py
+++ b/apis_v1/tests/test_views_backup_one_table_to_s3.py
@@ -2,13 +2,14 @@
 from django.test import TestCase
 from unittest.mock import patch, MagicMock
 from django.test import RequestFactory
-from wevote_tokens.models.single_use_tokens import SingleUseTokenManager
+from wevote_tokens.models.single_use_tokens import SingleUseTokenManager, Scope
 from wevote_tokens.enums import TokenUsage
 from apis_v1.views.views_retrieve_tables import backup_one_table_to_s3_view
 import json
 
 class TestBackupOneTableToS3Tokens(TestCase):
     def setUp(self):
+        self.scope = Scope.BACKUP_ONE_TABLE_TO_S3
         self.host = 'localhost:8000'
         self.url = f'{self.host}/apis/v1/backupOneTableToS3/'
         self.request = RequestFactory().get(
@@ -20,12 +21,14 @@ class TestBackupOneTableToS3Tokens(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.validation_key = SingleUseTokenManager.generate_encryption_key()
+        cls.scope = Scope.BACKUP_ONE_TABLE_TO_S3
         cls.user_id = 'user_id'
         cls.test_token_info = SingleUseTokenManager.create_token(
             user_id=cls.user_id,
             validation_key=cls.validation_key,
+            scope=cls.scope,
             expiration_seconds=1200,
-            json_data={'usage': TokenUsage.FAST_LOAD.value}
+            json_data=None
         )
         # Convert bytes to string for testing, in production headers are strings
         cls.validation_key_str = cls.validation_key.decode('utf-8')
@@ -53,14 +56,17 @@ class TestBackupOneTableToS3Tokens(TestCase):
         patch.stopall()
         super().tearDownClass()
 
-    def test_tests(self):
-        self.assertEqual(1, 1)
+    def _assert_equal(self, values_dict, keys_to_check, expected_value, reason):
+        for i, key in enumerate(keys_to_check):
+            self.assertEqual(values_dict[key], expected_value[i], f"'{key}' Should Be {expected_value[i]} on {reason} but was {values_dict[key]}")
+
 
     def test_auth_token_and_new_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
         request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
         request.META['HTTP_X_NEW_KEY'] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
+        message_addon = "Valid Auth Token and New Key"
 
         response = backup_one_table_to_s3_view(request)
         response_json = json.loads(response.content)
@@ -68,77 +74,101 @@ class TestBackupOneTableToS3Tokens(TestCase):
         # breakpoint()
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response_json['token_info']['success'], True)
+        self._assert_equal(response_json['token_info'], ['success'], [True], message_addon)
         self.assertIsNotNone(response_json['token_info']['token_pk'])
         self.assertNotEqual(response_json['token_info']['token_pk'], self.test_token_info['token_pk'])
-        self.assertEqual(response_json['token_info']['token_user'], self.user_id)
-        # self.assertEqual(response_json['token_info']['json_data'], {'usage': TokenUsage.FAST_LOAD.value})
 
     def test_auth_token_and_no_new_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
         request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
+        message_addon = "Valid Auth Token and No New Key"
 
         response = backup_one_table_to_s3_view(request)
         response_json = json.loads(response.content)
         
+
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response_json['token_info']['success'], True)
-        self.assertEqual(response_json['token_info']['token_user'], self.user_id)
-        self.assertEqual(response_json['token_info']['json_data'], {'usage': TokenUsage.FAST_LOAD.value})
+        self._assert_equal(
+            response_json['token_info'],
+            ['success', 'scope', 'scope_display', 'token_user'],
+            [True, self.scope, self.scope.label, self.user_id], 
+            message_addon)
+
     
     def test_bad_token(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"] + 99999999999999999}'
         request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
+        message_addon = "Bad Token"
 
         response = backup_one_table_to_s3_view(request)
         response_json = json.loads(response.content)
         
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response_json['token_info']['success'], False)
+        self._assert_equal(
+            response_json['token_info'],
+            ['success'],
+            [False],
+            message_addon)
     
     def test_bad_token_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
         request.META['HTTP_X_TOKEN_KEY'] = 'invalid_token_key'
+        message_addon = "Bad Token Key"
 
         response = backup_one_table_to_s3_view(request)
         response_json = json.loads(response.content)
         
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response_json['token_info']['success'], False)
+        self._assert_equal(
+            response_json['token_info'],
+            ['success'],
+            [False],
+            message_addon)
 
     def test_no_auth_token(self):
         request = self.request
         request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
-
+        message_addon = "No Auth Token"
         response = backup_one_table_to_s3_view(request)
         response_json = json.loads(response.content)
         
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response_json['token_info']['success'], False)
-        self.assertEqual(response_json['token_info']['status'], 'Authorization token and key are required')
+        self._assert_equal(
+            response_json['token_info'],
+            ['success', 'status'],
+            [False, 'Authorization token and key are required'],
+            message_addon)
 
     def test_no_token_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
-
+        message_addon = "No Token Key"
+        
         response = backup_one_table_to_s3_view(request)
         response_json = json.loads(response.content)
         
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response_json['token_info']['success'], False)
-        self.assertEqual(response_json['token_info']['status'], 'Authorization token and key are required')
+        self._assert_equal(
+            response_json['token_info'],
+            ['success', 'status'],
+            [False, 'Authorization token and key are required'],
+            message_addon)
 
     def test_invalid_token_new_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"] + 99999999999999999}'
         request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
         request.META['HTTP_X_NEW_KEY'] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
-
+        message_addon = "Invalid Token New Key"
         response = backup_one_table_to_s3_view(request)
         response_json = json.loads(response.content)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response_json['token_info']['success'], False)
+        self._assert_equal(
+            response_json['token_info'],
+            ['success'],
+            [False],
+            message_addon)

--- a/apis_v1/tests/test_views_backup_one_table_to_s3.py
+++ b/apis_v1/tests/test_views_backup_one_table_to_s3.py
@@ -64,8 +64,8 @@ class TestBackupOneTableToS3Tokens(TestCase):
     def test_auth_token_and_new_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
-        request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
-        request.META['HTTP_X_NEW_KEY'] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
+        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = self.validation_key_str
+        request.META['HTTP_X_SINGLE_USE_TOKEN_NEW_KEY'] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
         message_addon = "Valid Auth Token and New Key"
 
         response = backup_one_table_to_s3_view(request)
@@ -81,7 +81,7 @@ class TestBackupOneTableToS3Tokens(TestCase):
     def test_auth_token_and_no_new_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
-        request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
+        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = self.validation_key_str
         message_addon = "Valid Auth Token and No New Key"
 
         response = backup_one_table_to_s3_view(request)
@@ -99,7 +99,7 @@ class TestBackupOneTableToS3Tokens(TestCase):
     def test_bad_token(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"] + 99999999999999999}'
-        request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
+        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = self.validation_key_str
         message_addon = "Bad Token"
 
         response = backup_one_table_to_s3_view(request)
@@ -115,7 +115,7 @@ class TestBackupOneTableToS3Tokens(TestCase):
     def test_bad_token_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
-        request.META['HTTP_X_TOKEN_KEY'] = 'invalid_token_key'
+        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = 'invalid_token_key'
         message_addon = "Bad Token Key"
 
         response = backup_one_table_to_s3_view(request)
@@ -130,7 +130,7 @@ class TestBackupOneTableToS3Tokens(TestCase):
 
     def test_no_auth_token(self):
         request = self.request
-        request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
+        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = self.validation_key_str
         message_addon = "No Auth Token"
         response = backup_one_table_to_s3_view(request)
         response_json = json.loads(response.content)
@@ -160,8 +160,8 @@ class TestBackupOneTableToS3Tokens(TestCase):
     def test_invalid_token_new_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"] + 99999999999999999}'
-        request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
-        request.META['HTTP_X_NEW_KEY'] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
+        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = self.validation_key_str
+        request.META['HTTP_X_SINGLE_USE_TOKEN_NEW_KEY'] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
         message_addon = "Invalid Token New Key"
         response = backup_one_table_to_s3_view(request)
         response_json = json.loads(response.content)

--- a/apis_v1/tests/test_views_backup_one_table_to_s3.py
+++ b/apis_v1/tests/test_views_backup_one_table_to_s3.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from unittest.mock import patch, MagicMock
 from django.test import RequestFactory
 from wevote_tokens.models.single_use_tokens import SingleUseTokenManager, Scope
-from wevote_tokens.enums import TokenUsage
+from wevote_tokens.enums import TokenHeaders
 from apis_v1.views.views_retrieve_tables import backup_one_table_to_s3_view
 import json
 
@@ -64,8 +64,8 @@ class TestBackupOneTableToS3Tokens(TestCase):
     def test_auth_token_and_new_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
-        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = self.validation_key_str
-        request.META['HTTP_X_SINGLE_USE_TOKEN_NEW_KEY'] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
+        request.META['HTTP_' + (TokenHeaders.SINGLE_USE_TOKEN_KEY.value).upper()] = self.validation_key_str
+        request.META['HTTP_' + (TokenHeaders.SINGLE_USE_TOKEN_NEW_KEY.value).upper()] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
         message_addon = "Valid Auth Token and New Key"
 
         response = backup_one_table_to_s3_view(request)
@@ -81,7 +81,7 @@ class TestBackupOneTableToS3Tokens(TestCase):
     def test_auth_token_and_no_new_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
-        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = self.validation_key_str
+        request.META['HTTP_' + (TokenHeaders.SINGLE_USE_TOKEN_KEY.value).upper()] = self.validation_key_str
         message_addon = "Valid Auth Token and No New Key"
 
         response = backup_one_table_to_s3_view(request)
@@ -99,7 +99,7 @@ class TestBackupOneTableToS3Tokens(TestCase):
     def test_bad_token(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"] + 99999999999999999}'
-        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = self.validation_key_str
+        request.META['HTTP_' + (TokenHeaders.SINGLE_USE_TOKEN_KEY.value).upper()] = self.validation_key_str
         message_addon = "Bad Token"
 
         response = backup_one_table_to_s3_view(request)
@@ -115,7 +115,7 @@ class TestBackupOneTableToS3Tokens(TestCase):
     def test_bad_token_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
-        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = 'invalid_token_key'
+        request.META['HTTP_' + (TokenHeaders.SINGLE_USE_TOKEN_KEY.value).upper()] = 'invalid_token_key'
         message_addon = "Bad Token Key"
 
         response = backup_one_table_to_s3_view(request)
@@ -130,7 +130,7 @@ class TestBackupOneTableToS3Tokens(TestCase):
 
     def test_no_auth_token(self):
         request = self.request
-        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = self.validation_key_str
+        request.META['HTTP_' + (TokenHeaders.SINGLE_USE_TOKEN_KEY.value).upper()] = self.validation_key_str
         message_addon = "No Auth Token"
         response = backup_one_table_to_s3_view(request)
         response_json = json.loads(response.content)
@@ -160,8 +160,8 @@ class TestBackupOneTableToS3Tokens(TestCase):
     def test_invalid_token_new_key(self):
         request = self.request
         request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"] + 99999999999999999}'
-        request.META['HTTP_X_SINGLE_USE_TOKEN_KEY'] = self.validation_key_str
-        request.META['HTTP_X_SINGLE_USE_TOKEN_NEW_KEY'] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
+        request.META['HTTP_' + (TokenHeaders.SINGLE_USE_TOKEN_KEY.value).upper()] = self.validation_key_str
+        request.META['HTTP_' + (TokenHeaders.SINGLE_USE_TOKEN_NEW_KEY.value).upper()] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
         message_addon = "Invalid Token New Key"
         response = backup_one_table_to_s3_view(request)
         response_json = json.loads(response.content)

--- a/apis_v1/tests/test_views_backup_one_table_to_s3.py
+++ b/apis_v1/tests/test_views_backup_one_table_to_s3.py
@@ -1,0 +1,144 @@
+
+from django.test import TestCase
+from unittest.mock import patch, MagicMock
+from django.test import RequestFactory
+from wevote_tokens.models.single_use_tokens import SingleUseTokenManager
+from wevote_tokens.enums import TokenUsage
+from apis_v1.views.views_retrieve_tables import backup_one_table_to_s3_view
+import json
+
+class TestBackupOneTableToS3Tokens(TestCase):
+    def setUp(self):
+        self.host = 'localhost:8000'
+        self.url = f'{self.host}/apis/v1/backupOneTableToS3/'
+        self.request = RequestFactory().get(
+            self.url,
+            {'table_name': 'table_name',
+            'voter_api_device_id': ''}
+            )
+    
+    @classmethod
+    def setUpTestData(cls):
+        cls.validation_key = SingleUseTokenManager.generate_encryption_key()
+        cls.user_id = 'user_id'
+        cls.test_token_info = SingleUseTokenManager.create_token(
+            user_id=cls.user_id,
+            validation_key=cls.validation_key,
+            expiration_seconds=1200,
+            json_data={'usage': TokenUsage.FAST_LOAD.value}
+        )
+        # Convert bytes to string for testing, in production headers are strings
+        cls.validation_key_str = cls.validation_key.decode('utf-8')
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Start patches at class level
+        cls.mock_get_voter_api_device_id = patch(
+            'apis_v1.views.views_retrieve_tables.get_voter_api_device_id',
+            return_value=''
+        ).start()
+        
+        cls.mock_backup_one_table_to_s3_controller = patch(
+            'apis_v1.views.views_retrieve_tables.backup_one_table_to_s3_controller',
+            return_value={
+                'success': True,
+                'status': '',
+                'aws_s3_file_url': 'https://example.com/aws_s3_file_url'
+            }
+        ).start()
+    
+    @classmethod
+    def tearDownClass(cls):
+        patch.stopall()
+        super().tearDownClass()
+
+    def test_tests(self):
+        self.assertEqual(1, 1)
+
+    def test_auth_token_and_new_key(self):
+        request = self.request
+        request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
+        request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
+        request.META['HTTP_X_NEW_KEY'] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
+
+        response = backup_one_table_to_s3_view(request)
+        response_json = json.loads(response.content)
+
+        # breakpoint()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_json['token_info']['success'], True)
+        self.assertIsNotNone(response_json['token_info']['token_pk'])
+        self.assertNotEqual(response_json['token_info']['token_pk'], self.test_token_info['token_pk'])
+        self.assertEqual(response_json['token_info']['token_user'], self.user_id)
+        # self.assertEqual(response_json['token_info']['json_data'], {'usage': TokenUsage.FAST_LOAD.value})
+
+    def test_auth_token_and_no_new_key(self):
+        request = self.request
+        request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
+        request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
+
+        response = backup_one_table_to_s3_view(request)
+        response_json = json.loads(response.content)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_json['token_info']['success'], True)
+        self.assertEqual(response_json['token_info']['token_user'], self.user_id)
+        self.assertEqual(response_json['token_info']['json_data'], {'usage': TokenUsage.FAST_LOAD.value})
+    
+    def test_bad_token(self):
+        request = self.request
+        request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"] + 99999999999999999}'
+        request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
+
+        response = backup_one_table_to_s3_view(request)
+        response_json = json.loads(response.content)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_json['token_info']['success'], False)
+    
+    def test_bad_token_key(self):
+        request = self.request
+        request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
+        request.META['HTTP_X_TOKEN_KEY'] = 'invalid_token_key'
+
+        response = backup_one_table_to_s3_view(request)
+        response_json = json.loads(response.content)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_json['token_info']['success'], False)
+
+    def test_no_auth_token(self):
+        request = self.request
+        request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
+
+        response = backup_one_table_to_s3_view(request)
+        response_json = json.loads(response.content)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_json['token_info']['success'], False)
+        self.assertEqual(response_json['token_info']['status'], 'Authorization token and key are required')
+
+    def test_no_token_key(self):
+        request = self.request
+        request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"]}'
+
+        response = backup_one_table_to_s3_view(request)
+        response_json = json.loads(response.content)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_json['token_info']['success'], False)
+        self.assertEqual(response_json['token_info']['status'], 'Authorization token and key are required')
+
+    def test_invalid_token_new_key(self):
+        request = self.request
+        request.META['HTTP_AUTHORIZATION'] = f'Token {self.test_token_info["token_pk"] + 99999999999999999}'
+        request.META['HTTP_X_TOKEN_KEY'] = self.validation_key_str
+        request.META['HTTP_X_NEW_KEY'] = SingleUseTokenManager.generate_encryption_key().decode('utf-8')
+
+        response = backup_one_table_to_s3_view(request)
+        response_json = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_json['token_info']['success'], False)

--- a/apis_v1/views/views_retrieve_tables.py
+++ b/apis_v1/views/views_retrieve_tables.py
@@ -26,8 +26,8 @@ def backup_one_table_to_s3_view(request):  # backupOneTableToS3
     :return:
     """
     authorization = request.headers.get('Authorization')
-    token_key = request.headers.get('X-Token-Key')
-    new_token_key = request.headers.get('X-New-Key')
+    token_key = request.headers.get('X-Single-Use-Token-Key')
+    new_token_key = request.headers.get('X-Single-Use-Token-New-Key')
     table_name = request.GET.get('table_name', 'bad_table_param_error')
     voter_api_device_id = get_voter_api_device_id(request)
 

--- a/apis_v1/views/views_retrieve_tables.py
+++ b/apis_v1/views/views_retrieve_tables.py
@@ -11,6 +11,8 @@ from retrieve_tables.controllers_master import fast_load_status_retrieve, get_to
     retrieve_sql_tables_as_csv, backup_one_table_to_s3_controller
 from retrieve_tables.controllers_master import fast_load_status_update
 from wevote_functions.functions import get_voter_api_device_id
+from wevote_tokens.models.single_use_tokens import SingleUseTokenManager
+from wevote_tokens.enums import TokenUsage
 
 logger = wevote_functions.admin.get_logger(__name__)
 
@@ -23,12 +25,57 @@ def backup_one_table_to_s3_view(request):  # backupOneTableToS3
     :param request:
     :return:
     """
+    authorization = request.headers.get('Authorization')
+    token_key = request.headers.get('X-Token-Key')
+    new_token_key = request.headers.get('X-New-Key')
     table_name = request.GET.get('table_name', 'bad_table_param_error')
     voter_api_device_id = get_voter_api_device_id(request)
+
+    if authorization and token_key:
+        token = authorization.split(' ')[-1]
+        token_key_bytes = token_key.encode()
+
+        token_info = SingleUseTokenManager.authenticate_retrieve_token(token, token_key_bytes)
+        if token_info['success']:
+            token_info['expiration_datetime'] = token_info['expiration_datetime'].strftime('%Y-%m-%d %H:%M:%S')
+        
+        # TODO: return 401 status code
+        # return HttpResponse(json.dumps({
+        #     'success': False,
+        #     'status': "Authentication failed",
+        #     'token_info': token_info
+        # }) ,status=401, content_type='application/json')
+    
+    else:
+        token_info = {
+            'success': False,
+            'status': 'Authorization token and key are required',
+        }
+        # TODO: return 401 status code
+        # return HttpResponse(json.dumps({
+        #     'success': False,
+        #     'status': 'Authorization and token key are required',
+        # }), status=401, content_type='application/json')
 
     print("backup_one_table_to_s3 voter_api_device_id: ", voter_api_device_id)
     json_data = backup_one_table_to_s3_controller(voter_api_device_id, table_name)
 
+    if new_token_key and token_info['success']:
+        new_token_key_bytes = new_token_key.encode()
+        new_token_info = SingleUseTokenManager.create_token(
+            token_info['token_user'],
+            new_token_key_bytes,
+            expiration_seconds=1200,
+            json_data={'usage': TokenUsage.FAST_LOAD.value}
+            )
+        new_token_info['expiration_datetime'] = new_token_info['expiration_datetime'].strftime('%Y-%m-%d %H:%M:%S')
+        
+    # TODO: move this to only a new token case after 401 status code is implemented
+    if new_token_key and token_info['success']:
+        json_data['token_info'] = new_token_info
+    else:
+        json_data['token_info'] = token_info
+    
     return HttpResponse(json.dumps(json_data), content_type='application/json')
 
 

--- a/apis_v1/views/views_retrieve_tables.py
+++ b/apis_v1/views/views_retrieve_tables.py
@@ -11,7 +11,7 @@ from retrieve_tables.controllers_master import fast_load_status_retrieve, get_to
     retrieve_sql_tables_as_csv, backup_one_table_to_s3_controller
 from retrieve_tables.controllers_master import fast_load_status_update
 from wevote_functions.functions import get_voter_api_device_id
-from wevote_tokens.models.single_use_tokens import SingleUseTokenManager
+from wevote_tokens.models.single_use_tokens import SingleUseTokenManager, Scope
 from wevote_tokens.enums import TokenUsage
 
 logger = wevote_functions.admin.get_logger(__name__)
@@ -35,7 +35,7 @@ def backup_one_table_to_s3_view(request):  # backupOneTableToS3
         token = authorization.split(' ')[-1]
         token_key_bytes = token_key.encode()
 
-        token_info = SingleUseTokenManager.authenticate_retrieve_token(token, token_key_bytes)
+        token_info = SingleUseTokenManager.authenticate_retrieve_token(token, token_key_bytes, Scope.BACKUP_ONE_TABLE_TO_S3)
         if token_info['success']:
             token_info['expiration_datetime'] = token_info['expiration_datetime'].strftime('%Y-%m-%d %H:%M:%S')
         
@@ -65,6 +65,7 @@ def backup_one_table_to_s3_view(request):  # backupOneTableToS3
         new_token_info = SingleUseTokenManager.create_token(
             token_info['token_user'],
             new_token_key_bytes,
+            Scope.BACKUP_ONE_TABLE_TO_S3,
             expiration_seconds=1200,
             json_data={'usage': TokenUsage.FAST_LOAD.value}
             )

--- a/apis_v1/views/views_retrieve_tables.py
+++ b/apis_v1/views/views_retrieve_tables.py
@@ -12,7 +12,7 @@ from retrieve_tables.controllers_master import fast_load_status_retrieve, get_to
 from retrieve_tables.controllers_master import fast_load_status_update
 from wevote_functions.functions import get_voter_api_device_id
 from wevote_tokens.models.single_use_tokens import SingleUseTokenManager, Scope
-from wevote_tokens.enums import TokenUsage
+from wevote_tokens.enums import TokenHeaders
 
 logger = wevote_functions.admin.get_logger(__name__)
 
@@ -26,8 +26,8 @@ def backup_one_table_to_s3_view(request):  # backupOneTableToS3
     :return:
     """
     authorization = request.headers.get('Authorization')
-    token_key = request.headers.get('X-Single-Use-Token-Key')
-    new_token_key = request.headers.get('X-Single-Use-Token-New-Key')
+    token_key = request.headers.get(TokenHeaders.SINGLE_USE_TOKEN_KEY.value)
+    new_token_key = request.headers.get(TokenHeaders.SINGLE_USE_TOKEN_NEW_KEY.value)
     table_name = request.GET.get('table_name', 'bad_table_param_error')
     voter_api_device_id = get_voter_api_device_id(request)
 
@@ -66,8 +66,7 @@ def backup_one_table_to_s3_view(request):  # backupOneTableToS3
             token_info['token_user'],
             new_token_key_bytes,
             Scope.BACKUP_ONE_TABLE_TO_S3,
-            expiration_seconds=1200,
-            json_data={'usage': TokenUsage.FAST_LOAD.value}
+            expiration_seconds=1200
             )
         new_token_info['expiration_datetime'] = new_token_info['expiration_datetime'].strftime('%Y-%m-%d %H:%M:%S')
         

--- a/wevote_tokens/enums.py
+++ b/wevote_tokens/enums.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+class TokenHeaders(Enum):
+    SINGLE_USE_TOKEN_KEY = "X-Single-Use-Token-Key"
+    SINGLE_USE_TOKEN_NEW_KEY = "X-Single-Use-Token-New-Key"

--- a/wevote_tokens/models/single_use_tokens.py
+++ b/wevote_tokens/models/single_use_tokens.py
@@ -28,6 +28,7 @@ class SingleUseToken(models.Model):
         verbose_name='user we_vote_id',
         help_text='The user this token is assigned to.',
         null=True,
+        default=None,
     )
 
     # Retrieval Key Setting


### PR DESCRIPTION
@DaleMcGrew DO NOT MERGE YET
Considering what we discussed, I should update `SingleUseToken` separately to change `_user_id` in a way that won' cause migration issues.

Added validation for `SingleUseToken` and issuance in `backup_one_table_to_s3_view`.

Receive token and validation information from requests headers, and return Auth failure or new token info. Right now, this won't really do anything regarding stopping a Fast Load process. However, it will validate and issue new tokens and return the information to the sender.

Testing:
Unit Testing set up for token usage.

PS: Don't know how a `null=True` got snuck into `SingleUseToken._validation` but we certainly don't want it there.