### PR TITLE
[Issue #WV-2314] Add ability to schedule email for "New Email Campaign"

### DIFF
--- a/email_outbound/models.py
+++ b/email_outbound/models.py
@@ -87,6 +87,7 @@ class EmailCampaign(models.Model):
     is_for_politician = models.BooleanField(default=False)
     is_for_staff = models.BooleanField(default=False)
     is_for_voter = models.BooleanField(default=False)
+    scheduled_send_time = models.DateTimeField(null=True, blank=True)
     voter_we_vote_id = models.CharField(max_length=255, default=None, null=True, unique=False, db_index=True)
 
 

--- a/email_outbound/views_admin.py
+++ b/email_outbound/views_admin.py
@@ -3,6 +3,7 @@
 # -*- coding: UTF-8 -*-
 
 import json
+from datetime import datetime
 from urllib.parse import urlencode
 
 from django.contrib import messages
@@ -56,6 +57,16 @@ def email_campaign_edit_process_view(request):
     email_campaign_id = request.POST.get('email_campaign_id', '')
     google_civic_election_id = request.POST.get('google_civic_election_id', 0)
     state_code = request.POST.get('state_code', '')
+    send_time_option = request.POST.get('send_time_option', 'now')
+    scheduled_send_time_str = request.POST.get('scheduled_send_time', '')
+    
+    # Parse scheduled send time
+    scheduled_send_time = None
+    if send_time_option == 'scheduled' and scheduled_send_time_str:
+        try:
+            scheduled_send_time = datetime.fromisoformat(scheduled_send_time_str)
+        except ValueError:
+            pass
     
     # Create or update campaign
     if email_campaign_id:
@@ -65,6 +76,7 @@ def email_campaign_edit_process_view(request):
             campaign.email_template_id = email_template_id
             campaign.email_subject_template_raw = email_subject
             campaign.email_body_template_raw = email_body
+            campaign.scheduled_send_time = scheduled_send_time
             campaign.save()
             
             # Clear existing recipients for this campaign
@@ -76,6 +88,7 @@ def email_campaign_edit_process_view(request):
                 email_template_id=email_template_id,
                 email_subject_template_raw=email_subject,
                 email_body_template_raw=email_body,
+                scheduled_send_time=scheduled_send_time,
             )
             messages.add_message(request, messages.SUCCESS, 'Email campaign created.')
     else:
@@ -84,6 +97,7 @@ def email_campaign_edit_process_view(request):
             email_template_id=email_template_id,
             email_subject_template_raw=email_subject,
             email_body_template_raw=email_body,
+            scheduled_send_time=scheduled_send_time,
         )
         messages.add_message(request, messages.SUCCESS, 'Email campaign created.')
     

--- a/templates/email_outbound/email_campaign_edit.html
+++ b/templates/email_outbound/email_campaign_edit.html
@@ -58,8 +58,15 @@
     <div>
       <a href="{% url 'email_outbound:email_campaign_list' %}?google_civic_election_id={{ google_civic_election_id }}&state_code={{ state_code }}" class="btn btn-outline-secondary me-2">Cancel</a>
       <button type="submit" form="email-campaign-form" class="btn btn-primary me-2">Save</button>
-      <button type="button" id="send-campaign-btn" class="btn btn-success" disabled>Send</button>
     </div>
+  </div>
+  <div class="d-flex justify-content-end align-items-center mb-3">
+    <select id="send-time-select" class="form-select form-select-sm me-2" style="width: auto;">
+      <option value="now">Send Now</option>
+      <option value="scheduled">Send later</option>
+    </select>
+    <input type="datetime-local" id="scheduled-datetime" class="form-control form-control-sm me-2" style="width: auto; display: none !important;">
+    <button type="button" id="send-campaign-btn" class="btn btn-success" disabled>Send</button>
   </div>
 
   <form id="email-campaign-form" method="post" action="{% url 'email_outbound:email_campaign_edit_process' %}">
@@ -146,6 +153,8 @@
     <input type="hidden" name="state_code" value="{{ state_code }}">
     <input type="hidden" name="email_campaign_id" id="email_campaign_id" value="{% if email_campaign %}{{ email_campaign.id }}{% endif %}">
     <input type="hidden" name="selected_template_id" value="{{ selected_template_id }}">
+    <input type="hidden" name="send_time_option" id="send_time_option_input" value="{% if email_campaign.scheduled_send_time %}scheduled{% else %}now{% endif %}">
+    <input type="hidden" name="scheduled_send_time" id="scheduled_send_time_input" value="{% if email_campaign.scheduled_send_time %}{{ email_campaign.scheduled_send_time|date:'Y-m-d\TH:i' }}{% endif %}">
   </form>
 </div>
     </div><!-- end col-md-8 -->
@@ -439,11 +448,55 @@
         });
     }
     
-    // Handle Send button
+    // Handle schedule send dropdown
+    const sendTimeSelect = document.getElementById('send-time-select');
+    const scheduledDatetime = document.getElementById('scheduled-datetime');
+    const sendCampaignBtn = document.getElementById('send-campaign-btn');
+    const sendTimeOptionInput = document.getElementById('send_time_option_input');
+    const scheduledSendTimeInput = document.getElementById('scheduled_send_time_input');
+    
+    function updateScheduleDisplay() {
+      if (sendTimeSelect.value === 'scheduled') {
+        scheduledDatetime.style.display = 'inline-block';
+        scheduledDatetime.style.cssText = 'width: auto; display: inline-block !important;';
+        sendCampaignBtn.textContent = 'Schedule';
+      } else {
+        scheduledDatetime.style.display = 'none';
+        scheduledDatetime.style.cssText = 'width: auto; display: none !important;';
+        sendCampaignBtn.textContent = 'Send';
+      }
+      sendTimeOptionInput.value = sendTimeSelect.value;
+    }
+    
+    sendTimeSelect.addEventListener('change', updateScheduleDisplay);
+    
+    scheduledDatetime.addEventListener('change', function() {
+      scheduledSendTimeInput.value = this.value;
+    });
+    
+    // Restore saved schedule values if editing
+    {% if email_campaign.scheduled_send_time %}
+      sendTimeSelect.value = 'scheduled';
+      scheduledDatetime.value = '{{ email_campaign.scheduled_send_time|date:'Y-m-d\TH:i' }}';
+      updateScheduleDisplay();
+    {% endif %}
+    
+    // Handle Send/Schedule button
     document.getElementById('send-campaign-btn').addEventListener('click', function() {
-      if (confirm('Send this email campaign to ' + selectedRecipients.size + ' recipient(s)?')) {
-        alert('Send functionality will be implemented on the backend.');
-        // TODO: Implement actual send logic
+      const isScheduled = sendTimeSelect.value === 'scheduled';
+      const scheduledTime = scheduledDatetime.value;
+      
+      if (isScheduled && !scheduledTime) {
+        alert('Please select a date and time to schedule the campaign.');
+        return;
+      }
+      
+      const action = isScheduled ? 'schedule' : 'send';
+      const timeInfo = isScheduled ? ' for ' + new Date(scheduledTime).toLocaleString() : '';
+      
+      if (confirm(action.charAt(0).toUpperCase() + action.slice(1) + ' this email campaign to ' + selectedRecipients.size + ' recipient(s)' + timeInfo + '?')) {
+        alert(action.charAt(0).toUpperCase() + action.slice(1) + ' functionality will be implemented on the backend.');
+        // TODO: Implement actual send/schedule logic
       }
     });
     


### PR DESCRIPTION
This PR adds a schedule send functionality to the "create email campaign" [page](http://localhost:8000/email/edit_campaign/). It adds a dropdown where users can select whether to send emails now or enter a future time to schedule emails. See photo below for the UI:
<img width="873" height="346" alt="Screenshot 2025-12-08 at 6 04 17 PM" src="https://github.com/user-attachments/assets/26fed534-f3d0-4db3-8c4f-284716daceca" />
