### PR TITLE
WV-130: Server side to fix which updates supporters_count field in CampignX table on Voter delete

### DIFF
--- a/campaign/models.py
+++ b/campaign/models.py
@@ -2472,7 +2472,8 @@ class CampaignXManager(models.Manager):
                     campaignx.linked_politician_we_vote_id = update_values['linked_politician_we_vote_id']
                     campaignx_changed = True
                 if 'opposers_count' in update_values \
-                        and positive_value_exists(update_values['opposers_count']):
+                    and (positive_value_exists(update_values['opposers_count']) or \
+                         update_values['opposers_count'] == 0):
                     campaignx.opposers_count = update_values['opposers_count']
                     campaignx_changed = True
                 if 'politician_delete_list_serialized' in update_values \
@@ -2533,7 +2534,8 @@ class CampaignXManager(models.Manager):
                             update_values['politician_starter_list_serialized']
                         campaignx_changed = True
                 if 'supporters_count' in update_values \
-                        and positive_value_exists(update_values['supporters_count']):
+                        and (positive_value_exists(update_values['supporters_count']) or \
+                            update_values['supporters_count'] == 0):
                     campaignx.supporters_count = update_values['supporters_count']
                     campaignx_changed = True
                 if campaignx_changed:

--- a/follow/controllers.py
+++ b/follow/controllers.py
@@ -15,7 +15,7 @@ from campaign.controllers import refresh_campaignx_supporters_count_in_all_child
 from campaign.models import CampaignXManager
 from friend.models import FriendManager
 from organization.models import Organization, OrganizationManager
-from politician.models import Politician
+from politician.models import Politician, PoliticianManager
 from position.models import OPPOSE, PositionEntered, PositionForFriends, SUPPORT
 from twitter.models import TwitterUserManager
 from voter.models import VoterManager, fetch_voter_we_vote_id_from_voter_device_link
@@ -44,11 +44,27 @@ def delete_follow_entries_for_voter(voter_to_delete_id):
 
     follow_organization_list = FollowOrganizationList()
     from_follow_list = follow_organization_list.retrieve_follow_organization_by_voter_id(voter_to_delete_id)
-
+    campaignx_manager = CampaignXManager()
+    organization_manager = OrganizationManager()
     for from_follow_entry in from_follow_list:
         try:
+            follow_entry_organization_results = \
+                organization_manager.retrieve_organization_from_id(from_follow_entry.organization_id)
+
+            if follow_entry_organization_results['success'] and follow_entry_organization_results['organization_found']:
+                follow_entry_organization = follow_entry_organization_results['organization']
+
             from_follow_entry.delete()
             follow_entries_deleted += 1
+
+            # Get Campaign associated with deleted follow_entry to update supporters_count
+            if follow_entry_organization and follow_entry_organization.politician_we_vote_id:
+                count_results = campaignx_manager.update_campaignx_supporters_count(
+                    politician_we_vote_id=follow_entry_organization.politician_we_vote_id)
+                if not count_results['success']:
+                    status += count_results['status']
+            else:
+                status += "FOLLOW ENTRY LINKED ORGANIZATION AND CAMPAIGN NOT FOUND "
         except Exception as e:
             follow_entries_not_deleted += 1
             status += "FAILED_DELETING_FROM_FOLLOW_ENTRY: " + str(e) + ' '


### PR DESCRIPTION
- The supporters_count field in the CampignX table is what the frontend uses to display the support count for politicians on load. This field was not updating on voter delete, so I fixed it under the delete_follow_entries_for_voter() function
- There was also other minor bugs where the support and don't support counts did not go back to zero after reload, so I fixed it at update_or_create_campaignx() function