### PR TITLE
[Issue #WV-2314] Refine send time picker in email_template_edit

### DIFF
--- a/email_outbound/views_admin.py
+++ b/email_outbound/views_admin.py
@@ -4,6 +4,7 @@
 
 import json
 from datetime import datetime
+from django.utils import timezone
 from urllib.parse import urlencode
 
 from django.contrib import messages
@@ -90,7 +91,8 @@ def email_campaign_edit_process_view(request):
     scheduled_send_time = None
     if send_time_option == 'scheduled' and scheduled_send_time_str:
         try:
-            scheduled_send_time = datetime.fromisoformat(scheduled_send_time_str)
+            naive_dt = datetime.fromisoformat(scheduled_send_time_str)
+            scheduled_send_time = timezone.make_aware(naive_dt, timezone.get_current_timezone())
         except ValueError:
             pass
 

--- a/templates/email_outbound/email_campaign_edit.html
+++ b/templates/email_outbound/email_campaign_edit.html
@@ -67,6 +67,7 @@
       <option value="tomorrow_16">Tomorrow at 4:00 PM</option>
       <option value="day2_9">Day after tomorrow</option>
       <option value="day3_9">Day after that</option>
+      <option value="saved" style="display: none;"></option>
       <option value="custom">Custom…</option>
     </select>
     <input type="datetime-local" id="scheduled-datetime" class="form-control form-control-sm me-2" style="width: auto; display: none !important;">&nbsp;
@@ -615,6 +616,15 @@
         return;
       }
 
+      if (value === 'saved') {
+        scheduledDatetime.style.display = 'none';
+        scheduledDatetime.style.cssText = 'width: auto; display: none !important;';
+        sendCampaignBtn.textContent = 'Schedule';
+        sendTimeOptionInput.value = 'scheduled';
+        scheduledSendTimeInput.value = scheduledDatetime.value;
+        return;
+      }
+
       const presetDate = computePresetTime(value);
       if (presetDate) {
         const formatted = toDatetimeLocal(presetDate);
@@ -722,10 +732,11 @@
         minute: '2-digit'
       });
       
-      // Update the Custom option to show the saved time
-      const customOption = sendTimeSelect.querySelector('option[value="custom"]');
-      customOption.textContent = formattedSavedTime;
-      sendTimeSelect.value = 'custom';
+      // Update the hidden "saved" option to show the saved time
+      const savedOption = sendTimeSelect.querySelector('option[value="saved"]');
+      savedOption.textContent = formattedSavedTime;
+      savedOption.style.display = '';
+      sendTimeSelect.value = 'saved';
       
       // Hide the datetime picker but keep values set
       scheduledDatetime.style.display = 'none';

--- a/templates/email_outbound/email_campaign_edit.html
+++ b/templates/email_outbound/email_campaign_edit.html
@@ -62,8 +62,12 @@
   </div>
   <div class="d-flex justify-content-end align-items-center mb-3">
     <select name="send-time" id="send-time-select" class="form-select form-select-sm me-2" style="width: auto;">
-      <option value="now">Send Now</option>
-      <option value="scheduled">Send later</option>
+      <option value="now">Now</option>
+      <option value="tomorrow_9">Tomorrow at 9:00 AM</option>
+      <option value="tomorrow_16">Tomorrow at 4:00 PM</option>
+      <option value="day2_9">Day after tomorrow</option>
+      <option value="day3_9">Day after that</option>
+      <option value="custom">Custom…</option>
     </select>
     <input type="datetime-local" id="scheduled-datetime" class="form-control form-control-sm me-2" style="width: auto; display: none !important;">&nbsp;
     <button type="submit" id="send-campaign-btn" class="btn btn-success">Send</button> <!-- Also submits email-campaign-form //-->
@@ -591,17 +595,105 @@
     const scheduledSendTimeInput = document.getElementById('scheduled_send_time_input');
 
     function updateScheduleDisplay() {
-      if (sendTimeSelect.value === 'scheduled') {
-        scheduledDatetime.style.display = 'inline-block';
-        scheduledDatetime.style.cssText = 'width: auto; display: inline-block !important;';
-        sendCampaignBtn.textContent = 'Schedule';
-      } else {
+      scheduledDatetime.disabled = sendTimeSelect.value !== 'custom';
+      const value = sendTimeSelect.value;
+      if (value === 'now') {
         scheduledDatetime.style.display = 'none';
         scheduledDatetime.style.cssText = 'width: auto; display: none !important;';
         sendCampaignBtn.textContent = 'Send';
+        sendTimeOptionInput.value = 'now';
+        scheduledSendTimeInput.value = '';
+        return;
+      };
+      
+      if (value === 'custom') {
+        scheduledDatetime.style.display = 'inline-block';
+        scheduledDatetime.style.cssText = 'width: auto; display: inline-block !important;';
+        sendCampaignBtn.textContent = 'Schedule';
+        sendTimeOptionInput.value = 'scheduled';
+        scheduledSendTimeInput.value = scheduledDatetime.value;
+        return;
       }
-      sendTimeOptionInput.value = sendTimeSelect.value;
+
+      const presetDate = computePresetTime(value);
+      if (presetDate) {
+        const formatted = toDatetimeLocal(presetDate);
+        scheduledDatetime.style.display = 'none';
+        scheduledDatetime.value = formatted;
+        scheduledSendTimeInput.value = formatted;
+        sendCampaignBtn.textContent = 'Schedule';
+        sendTimeOptionInput.value = 'scheduled';
+      }
     }
+
+    function toDatetimeLocal(date) {
+      const pad = n => String(n).padStart(2, '0');
+      return `${date.getFullYear()}-${pad(date.getMonth()+1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+    }
+
+    function computePresetTime(option) {
+      const now = new Date();
+      let d = new Date(now);
+
+      switch (option) {
+        case 'tomorrow_9':
+          d.setDate(d.getDate() + 1);
+          d.setHours(9, 0, 0, 0);
+          break;
+
+        case 'tomorrow_16':
+          d.setDate(d.getDate() + 1);
+          d.setHours(16, 0, 0, 0);
+          break;
+
+        case 'day2_9':
+          d.setDate(d.getDate() + 2);
+          d.setHours(9, 0, 0, 0);
+          break;
+
+        case 'day3_9':
+          d.setDate(d.getDate() + 3);
+          d.setHours(9, 0, 0, 0);
+          break;
+
+        default:
+          return null;
+      }
+
+      return d;
+    }
+
+    function formatWeekdayDate(daysFromNow) {
+      const d = new Date();
+      d.setDate(d.getDate() + daysFromNow);
+
+      return d.toLocaleDateString(undefined, {
+        weekday: 'long',
+        month: 'numeric',
+        day: 'numeric'
+      });
+    }
+
+    // Update dropdown labels with formatted dates
+    function updateRelativeDateLabels() {
+      const options = sendTimeSelect.options;
+      for (let opt of options) {
+        if (opt.value === 'tomorrow_9') {
+          opt.textContent = `${formatWeekdayDate(1)} at 9:00 AM`;
+        }
+        if (opt.value === 'tomorrow_16') {
+          opt.textContent = `${formatWeekdayDate(1)} at 4:00 PM`;
+        }
+        if (opt.value === 'day2_9') {
+          opt.textContent = `${formatWeekdayDate(2)} at 9:00 AM`;
+        }
+        if (opt.value === 'day3_9') {
+          opt.textContent = `${formatWeekdayDate(3)} at 9:00 AM`;
+        }
+      }
+    }
+    updateRelativeDateLabels();
+    updateScheduleDisplay();
 
     sendTimeSelect.addEventListener('change', updateScheduleDisplay);
 
@@ -609,16 +701,43 @@
       scheduledSendTimeInput.value = this.value;
     });
 
+    // Update hidden inputs before form submission
+    document.getElementById('email-campaign-form').addEventListener('submit', function() {
+      updateScheduleDisplay();
+    });
+
     // Restore saved schedule values if editing
     {% if email_campaign.scheduled_send_time %}
-      sendTimeSelect.value = 'scheduled';
-      scheduledDatetime.value = '{{ email_campaign.scheduled_send_time|date:'Y-m-d\TH:i' }}';
-      updateScheduleDisplay();
+      const savedTime = '{{ email_campaign.scheduled_send_time|date:'Y-m-d\TH:i' }}';
+      scheduledDatetime.value = savedTime;
+      
+      // Format the saved time for display
+      const savedDate = new Date(savedTime);
+      const formattedSavedTime = savedDate.toLocaleDateString(undefined, {
+        weekday: 'long',
+        month: 'numeric',
+        day: 'numeric'
+      }) + ' at ' + savedDate.toLocaleTimeString(undefined, {
+        hour: 'numeric',
+        minute: '2-digit'
+      });
+      
+      // Update the Custom option to show the saved time
+      const customOption = sendTimeSelect.querySelector('option[value="custom"]');
+      customOption.textContent = formattedSavedTime;
+      sendTimeSelect.value = 'custom';
+      
+      // Hide the datetime picker but keep values set
+      scheduledDatetime.style.display = 'none';
+      scheduledDatetime.style.cssText = 'width: auto; display: none !important;';
+      sendCampaignBtn.textContent = 'Schedule';
+      sendTimeOptionInput.value = 'scheduled';
+      scheduledSendTimeInput.value = savedTime;
     {% endif %}
 
     // Handle Send/Schedule button
     document.getElementById('send-campaign-btn').addEventListener('click', function() {
-      const isScheduled = sendTimeSelect.value === 'scheduled';
+      const isScheduled = sendTimeSelect.value !== 'now';
       const scheduledTime = scheduledDatetime.value;
 
       if (isScheduled && !scheduledTime) {


### PR DESCRIPTION
This PR follows up on #2986 and adds some default values in the send time dropdown in the `email_campaign_edit` view.
The new UI at http://localhost:8000/email/edit_campaign/: 
<img width="866" height="479" alt="Screenshot 2025-12-20 at 10 58 22 AM" src="https://github.com/user-attachments/assets/98249559-9cd8-4672-8a78-b39cefa5fda4" />