### PR TITLE
[WV-2253] change header response to json

### DIFF
--- a/apis_v1/views/views_retrieve_tables.py
+++ b/apis_v1/views/views_retrieve_tables.py
@@ -19,11 +19,11 @@ logger = wevote_functions.admin.get_logger(__name__)
 
 WE_VOTE_SERVER_ROOT_URL = get_environment_variable("WE_VOTE_SERVER_ROOT_URL")
 
-# @TokensManager(
-#     token_types=[TokenTypes.SINGLE_USE.value],
-#     scope=Scope.BACKUP_ONE_TABLE_TO_S3.value,
-#     expiration_seconds=1200
-# )
+@TokensManager(
+    token_types=[TokenTypes.SINGLE_USE.value],
+    scope=Scope.BACKUP_ONE_TABLE_TO_S3.value,
+    expiration_seconds=1200
+)
 def backup_one_table_to_s3_view(request):  # backupOneTableToS3
     """
     pg_dump one SQL tables on the master server to AWS s3, for use with December 2025 version of fast load

--- a/retrieve_tables/controllers_local.py
+++ b/retrieve_tables/controllers_local.py
@@ -110,7 +110,7 @@ def retrieve_sql_files_from_master_server(request):
                     token_creation = response_headers['token_creation']
                     print(f"Token creation: {token_creation}")
                     if token_creation['success']:
-                        token_headers[TokenHeaders.AUTHORIZATION.value] = f'Bearer {token_creation['token_info']['token_pk']}'
+                        token_headers[TokenHeaders.AUTHORIZATION.value] = f"Bearer {token_creation['token_info']['token_pk']}"
                         token_headers[TokenHeaders.TOKEN_KEY.value] = token_headers[TokenHeaders.TOKEN_NEW_KEY.value]
                         token_headers[TokenHeaders.TOKEN_NEW_KEY.value] = SingleUseTokenManager.generate_encryption_key()
                 else:

--- a/wevote_tokens/enums.py
+++ b/wevote_tokens/enums.py
@@ -12,6 +12,8 @@ class TokenHeaders(Enum):
 
     TOKEN_EXPIRATION = Prefixes.HEADER_PREFIX.value + "Token-Expiration"
     TOKEN_MESSAGE = Prefixes.HEADER_PREFIX.value + "Token-Message"
+    TOKEN_CREATION = Prefixes.HEADER_PREFIX.value + "Token-Creation"
+    TOKEN_AUTHENTICATION = Prefixes.HEADER_PREFIX.value + "Token-Authentication"
 
     USER_ID = Prefixes.HEADER_PREFIX.value + "User-Id"
     TOKEN_KEY = Prefixes.HEADER_PREFIX.value + "Token-Key"
@@ -27,6 +29,12 @@ class TokenTypes(Enum):
     SINGLE_USE = "single_use"
 
 class TokenResponse(Enum):
+    # MAKE SURE TO UPDATE THIS WHEN ADDING NEW HEADERS OR KEYS
+    HEADERS_MAPPING = {
+        'token_creation': TokenHeaders.TOKEN_CREATION.value,
+        'token_authentication': TokenHeaders.TOKEN_AUTHENTICATION.value,
+    }
+
     TOKEN_RESPONSE = {
         'token_creation': None,
         'token_authentication': None,

--- a/wevote_tokens/tests/test_tokens_manager.py
+++ b/wevote_tokens/tests/test_tokens_manager.py
@@ -69,16 +69,10 @@ class TestTokensManager(TestCase):
         } 
 
         cls.response_token_info = {
-            'level_1': 1,
-            'level_2': {
-                'level_3': 3
-                },
-            'level_4': {
-                'level_5': {
-                    'level_6': 6
-                    }
-                },
-            'level_7': None,
+            **TokenResponse.HEADERS_MAPPING.get_value(),
+            **{
+                'misc_headers': 'misc_value',
+            }
         }
     
     def setUp(self):
@@ -212,6 +206,7 @@ class TestTokensManager(TestCase):
             self.assertEqual(response['status'], 'TOKEN CREATED', "Status Should Be 'TOKEN CREATED'")
             self.assertIsNone(response['error_message'], "Error Message Should Be None")
             self.assertEqual(response['token_info'], mock_return_value, "Token Info Should Be the Mock Return Value")
+            self.assertIsInstance(response['token_info']['expiration_datetime'], str, "Expiration Datetime Should Be a String")
 
     def test_token_creation_invalid_token_type(self):
         request_token_info = self.request_token_info
@@ -345,6 +340,7 @@ class TestTokensManager(TestCase):
             self.assertEqual(response['status'], 'TOKEN RETRIEVED AND AUTHENTICATED', "Status Should Be 'TOKEN RETRIEVED AND AUTHENTICATED'")
             self.assertIsNone(response['error_message'], "Error Message Should Be None")
             self.assertIsNotNone(response['token_info'], "Token Info Should return a value")
+            self.assertIsInstance(response['token_info']['expiration_datetime'], str, "Expiration Datetime Should Be a String")
 
     def test_token_authentication_first_token_not_found(self):
         request_token_info = self.request_token_info
@@ -374,16 +370,29 @@ class TestTokensManager(TestCase):
         test_response = self.response
         test_token_response = self.response_token_info
 
-        expected_response_headers = {**test_response.headers,
-            **{
-            'X-Level-1': '1',
-            'X-Level-2.Level-3': '3',
-            'X-Level-4.Level-5.Level-6': '6'
-            }}
+        expected_headers = {}
+        headers_mapping = TokenResponse.HEADERS_MAPPING.get_value()
+        for key, value in headers_mapping.items():
+            expected_headers[value] = json.dumps(value)
+
+        expected_response_headers = {
+            **test_response.headers,
+            **expected_headers
+        }
 
         response = self.manager.add_response_token_info_headers(test_response, test_token_response)
 
         self.assertEqual(response.headers, expected_response_headers, "Response Headers Should {expected_response_headers} but was {response.headers}")
+
+    def test_add_response_token_info_headers_returns_no_empty_headers(self):
+        test_response = self.response
+        test_token_response = self.response_token_info
+
+        for key, value in test_token_response.items():
+            test_token_response[key] = None
+
+        response = self.manager.add_response_token_info_headers(test_response, test_token_response)
+
 
     def test_add_response_token_info_headers_returns_no_streaming_headers(self):
         test_response = StreamingHttpResponse()
@@ -520,49 +529,3 @@ class TestTokensManagerHelperFunctions(TestCase):
         with self.assertRaisesMessage(ValueError, "Token Key Must Be a String or None"):
             self.manager.encode_token_key(non_string)
 
-    #########################################################
-    # test convert_keys_to_header_keys
-    #########################################################
-    def test_convert_keys_to_header_keys_returns_dict(self):
-        dict_data = {'key1': 'value1', 'key2': 'value2'}
-        
-        response = self.manager.convert_keys_to_header_keys(dict_data)
-        
-        self.assertIsInstance(response, dict, "Keys Should Be Converted to Header Keys")
-
-    def test_convert_keys_to_header_keys_returns_flattened_header_keys(self):
-        dict_data = {'key_1': 'value', 'key_2': {'key_3': 'value', 'key_4': {'key_5': 'value'}}}
-        expected_response = {'X-Key-1': 'value', 'X-Key-2.Key-3': 'value', 'X-Key-2.Key-4.Key-5': 'value'}
-        
-        response = self.manager.convert_keys_to_header_keys(dict_data)
-
-        self.assertEqual(response, expected_response, "Keys Should Be Flattened to Header Keys but response was {response}")
-
-    def test_convert_keys_to_header_keys_with_reject_keys(self):
-        dict_data = {'key_1': 'value', 'key_2': {'key_3': 'value', 'key_4': {'key_5': 'value'}}}
-        reject_keys = {'key_1', 'key_3'}
-        expected_response = {'X-Key-2.Key-4.Key-5': 'value'}
-        
-        response = self.manager.convert_keys_to_header_keys(dict_data, reject_keys=reject_keys)
-        
-        self.assertEqual(response, expected_response, "{reject_keys} should be rejected but response was {response}")
-    
-    def test_convert_keys_to_header_keys_returns_empty(self):
-        empty_dict_data = {}
-        
-        response = self.manager.convert_keys_to_header_keys(empty_dict_data)
-        
-        self.assertEqual(response, {}, "Keys Should Be an Empty Dict")
-    
-    def test_convert_keys_to_header_invalid_dict_data(self):
-        non_dict = 1234567890
-        
-        with self.assertRaisesMessage(ValueError, "dict_data Must Be a Dict"):
-            self.manager.convert_keys_to_header_keys(non_dict)
-    
-    def test_convert_keys_to_header_invalid_reject_keys(self):
-        non_set = []
-        dict_data = {'key1': 'value1', 'key2': 'value2'}
-        
-        with self.assertRaisesMessage(ValueError, "Reject Keys Must Be a Set or None"):
-            self.manager.convert_keys_to_header_keys(dict_data, reject_keys=non_set)

--- a/wevote_tokens/utils.py
+++ b/wevote_tokens/utils.py
@@ -3,6 +3,7 @@ from wevote_tokens.enums import TokenTypes, TokenHeaders, TokenResponse, Prefixe
 from wevote_functions.functions import positive_value_exists
 from django.http import HttpResponse, StreamingHttpResponse
 import re
+import json
 
 class TokensManager():
 
@@ -19,38 +20,38 @@ class TokensManager():
     def __call__(self, view_func):
         def _wrapped_view(request, *args, **kwargs):
             token_response = TokenResponse.TOKEN_RESPONSE.get_value()
-            try:
+            # try:
                 # First, get headers
-                request_token_info = self.get_request_token_info(request)
+            request_token_info = self.get_request_token_info(request)
 
-                if request_token_info['error_message']:
-                    token_response['token_authentication'] = {
-                        'success': False,
-                        'status': "",
-                        'error_message': request_token_info['error_message'],
-                        'token_info': None
-                    }
+            if request_token_info['error_message']:
+                token_response['token_authentication'] = {
+                    'success': False,
+                    'status': "",
+                    'error_message': request_token_info['error_message'],
+                    'token_info': None
+                }
 
-                # Check token type
-                if not request_token_info['error_message'] and \
-                    (not request_token_info['token_type'] or request_token_info['token_type'] not in self.token_types):
-                    #TODO: return 401 unauthorized
-                    token_response['token_authentication'] = {
-                        'success': False,
-                        'status': 'INVALID_TOKEN_TYPE',
-                        'error_message': "Invalid token type",
-                        'token_info': None
-                    }
-                
-                if not token_response['token_authentication']:
-                    # And authenticate it with id, key, and scope
-                    token_response['token_authentication'] = self.token_authentication(request_token_info)
+            # Check token type
+            if not request_token_info['error_message'] and \
+                (not request_token_info['token_type'] or request_token_info['token_type'] not in self.token_types):
+                #TODO: return 401 unauthorized
+                token_response['token_authentication'] = {
+                    'success': False,
+                    'status': 'INVALID_TOKEN_TYPE',
+                    'error_message': "Invalid token type",
+                    'token_info': None
+                }
+            
+            if not token_response['token_authentication']:
+                # And authenticate it with id, key, and scope
+                token_response['token_authentication'] = self.token_authentication(request_token_info)
 
-                    # if exists and is True, then create a new token
-                    if request_token_info['create_token'] and token_response['token_authentication']['success']:
-                            token_response['token_creation'] = self.token_creation(request_token_info)
-            except:
-                pass
+                # if exists and is True, then create a new token
+                if request_token_info['create_token'] and token_response['token_authentication']['success']:
+                        token_response['token_creation'] = self.token_creation(request_token_info)
+            # except:
+            #     pass
                 
             response = view_func(request, *args, **kwargs)
             
@@ -182,6 +183,9 @@ class TokensManager():
         if token_type == TokenTypes.SINGLE_USE.value:
             # breakpoint()
             token_info = SingleUseTokenManager.authenticate_retrieve_token(token_id, token_key, scope)
+            if token_info['success']:
+                token_info['expiration_datetime'] = \
+                    token_info['expiration_datetime'].strftime('%Y-%m-%d %H:%M:%S')
 
             # This is for retries in case of faulty api connection
             # if the previous token key was used, its likely that
@@ -218,10 +222,11 @@ class TokensManager():
     @staticmethod
     def add_response_token_info_headers(response, token_response, reject_keys=None):
         if isinstance(response, HttpResponse) and not isinstance(response, StreamingHttpResponse):
-            headers = TokensManager.convert_keys_to_header_keys(token_response, reject_keys=reject_keys)
-            for key, value in headers.items():
-                if value is not None:
-                    response[key] = value
+            headers_mapping = TokenResponse.HEADERS_MAPPING.get_value()
+
+            for key, value in token_response.items():
+                if key in headers_mapping.keys() and value is not None:
+                    response[headers_mapping[key]] = json.dumps(value)
 
         return response
 
@@ -292,47 +297,8 @@ class TokensManager():
         raise ValueError("Token Key Must Be a String or None")
 
     @staticmethod
-    def convert_keys_to_header_keys(dict_data, reject_keys=None):
-        if not isinstance(dict_data, dict):
-            raise ValueError("dict_data Must Be a Dict")
-
-        if not isinstance(reject_keys, (set, type(None))):
-            raise ValueError("Reject Keys Must Be a Set or None")
-
-        if reject_keys is None:
-            reject_keys = set()
-
-        result = {}
-        sep = '.'
-        stack = [((), dict_data)]  # (key_path_tuple, current_dict)
-
-        while stack:
-            path, current = stack.pop()
-
-            for key, value in current.items():
-                if str(key).lower() in reject_keys or key in reject_keys:
-                    continue
-
-                key = str(key).lower()
-                key = [p for p in re.split(r'[^a-zA-Z0-9]', key) if p]
-                key = '-'.join(key_word.capitalize() for key_word in key)
-
-                new_path = path + (key,)
-
-                if isinstance(value, dict):
-                    # push deeper branch onto stack
-                    stack.append((new_path, value))
-                else:
-                    # leaf value -> flatten
-                    result[Prefixes.HEADER_PREFIX.value + sep.join(new_path)] = value
-
-        return result
-
-    @staticmethod
     def convert_headers_to_dict(headers):
-        sep = '.'
-        prefix = Prefixes.HEADER_PREFIX.value
-            
+        headers_mapping = TokenResponse.HEADERS_MAPPING.get_value()
 
         try:
             headers = dict(headers)
@@ -341,30 +307,8 @@ class TokensManager():
 
         result = {}
 
-        for header_key, value in headers.items():
-            if header_key.startswith(prefix):
-                key_path = header_key[len(prefix):]
-            else:
-                key_path = header_key
-            
-            key_path = key_path.replace('-','_')
-            key_path = key_path.lower()
-
-            # Split into nesting levels
-            parts = key_path.split(sep)
-
-            current = result
-            for part in parts[:-1]:
-                # Create nested dicts as needed
-                current = current.setdefault(part, {})
-
-            # Assign leaf value
-            if value == 'True' or value == 'False':
-                value = value == 'True'
-            
-            if value != 'None':
-                current[parts[-1]] = value
-            else:
-                current[parts[-1]] = None
+        for key, header_key in headers_mapping.items():
+            if header_key in headers:
+                result[key] = json.loads(headers[header_key])
 
         return result

--- a/wevote_tokens/utils.py
+++ b/wevote_tokens/utils.py
@@ -20,38 +20,38 @@ class TokensManager():
     def __call__(self, view_func):
         def _wrapped_view(request, *args, **kwargs):
             token_response = TokenResponse.TOKEN_RESPONSE.get_value()
-            # try:
+            try:
                 # First, get headers
-            request_token_info = self.get_request_token_info(request)
+                request_token_info = self.get_request_token_info(request)
 
-            if request_token_info['error_message']:
-                token_response['token_authentication'] = {
-                    'success': False,
-                    'status': "",
-                    'error_message': request_token_info['error_message'],
-                    'token_info': None
-                }
+                if request_token_info['error_message']:
+                    token_response['token_authentication'] = {
+                        'success': False,
+                        'status': "",
+                        'error_message': request_token_info['error_message'],
+                        'token_info': None
+                    }
 
-            # Check token type
-            if not request_token_info['error_message'] and \
-                (not request_token_info['token_type'] or request_token_info['token_type'] not in self.token_types):
-                #TODO: return 401 unauthorized
-                token_response['token_authentication'] = {
-                    'success': False,
-                    'status': 'INVALID_TOKEN_TYPE',
-                    'error_message': "Invalid token type",
-                    'token_info': None
-                }
-            
-            if not token_response['token_authentication']:
-                # And authenticate it with id, key, and scope
-                token_response['token_authentication'] = self.token_authentication(request_token_info)
+                # Check token type
+                if not request_token_info['error_message'] and \
+                    (not request_token_info['token_type'] or request_token_info['token_type'] not in self.token_types):
+                    #TODO: return 401 unauthorized
+                    token_response['token_authentication'] = {
+                        'success': False,
+                        'status': 'INVALID_TOKEN_TYPE',
+                        'error_message': "Invalid token type",
+                        'token_info': None
+                    }
+                
+                if not token_response['token_authentication']:
+                    # And authenticate it with id, key, and scope
+                    token_response['token_authentication'] = self.token_authentication(request_token_info)
 
-                # if exists and is True, then create a new token
-                if request_token_info['create_token'] and token_response['token_authentication']['success']:
-                        token_response['token_creation'] = self.token_creation(request_token_info)
-            # except:
-            #     pass
+                    # if exists and is True, then create a new token
+                    if request_token_info['create_token'] and token_response['token_authentication']['success']:
+                            token_response['token_creation'] = self.token_creation(request_token_info)
+            except:
+                pass
                 
             response = view_func(request, *args, **kwargs)
             


### PR DESCRIPTION
NOTE: I also turned on the decorator for `backup_one_table_to_s3_view` in the interest of expediting functionality testing. This should not have any issue in prod due to all the try/except statements.

The previous issue is that NGINX would remove headers that contained a period `.`
This caused the code to run fine in local, but error in production.

After looking into RFC standards (https://datatracker.ietf.org/doc/html/rfc7230) the best course of action is to send JSON bodies over token headers.

This changes `TokensManager` functions to send and handle headers as JSON now.

Testing:
Tested functionality on local instance
Modified unit tests to handle `JSON` and expect string `datetimes`.