### PR TITLE
Disabled logs that had a risk of sensitive information

### DIFF
--- a/apis_v1/views/views_activity.py
+++ b/apis_v1/views/views_activity.py
@@ -632,8 +632,9 @@ def firebase_notification_send_to_cordova_apps(we_vote_id, speaker_name, stateme
                 for device in device_list:
                     send_single_message(device.platform_type, device.firebase_fcm_token, "We Vote", body,
                                         badge_number)
-                    logger.info('firebase_notification_send_to_cordova_apps sent : ' + device.platform_type +
-                                device.firebase_fcm_token + "We Vote" + body + str(badge_number))
+                    # Disabled due to logging possible sensitive data
+                    # logger.info('firebase_notification_send_to_cordova_apps sent : ' + device.platform_type +
+                    #             device.firebase_fcm_token + "We Vote" + body + str(badge_number))
             except Exception as e:
                 logger.error('firebase_notification_send_to_cordova_apps threw: ', e)
     end = str(time.time() - start)

--- a/aws/management/commands/runsqsworker.py
+++ b/aws/management/commands/runsqsworker.py
@@ -48,7 +48,8 @@ MAX_JOB_PROCESSING_TIME = 60
 MAX_JOB_RETRY_ATTEMPTS = 5
 
 def process_request(function, body, message):
-    logger.info('(Ok) SQS job execute process_request ' + function + '  ' + str(body))
+    # Disabled due to logging possible sensitive information
+    # logger.info('(Ok) SQS job execute process_request ' + function + '  ' + str(body))
 
     if function == 'caching_facebook_images_for_retrieve_process':
         from import_export_facebook.controllers import caching_facebook_images_for_retrieve_process

--- a/donate/controllers.py
+++ b/donate/controllers.py
@@ -692,7 +692,8 @@ def donation_process_charge(event):           # 'charge.succeeded'
             voter_we_vote_id = charge['metadata']['voter_we_vote_id']
             if voter_we_vote_id:
                 # Has our metadata?  Then we have already made a journal entry at the time of the donation
-                logger.info("Stripe 'charge.succeeded' received for a PAYMENT_FROM_UI -- ignored, charge = " + charge)
+                 # Disabled due to logging possible sensitive information
+                # logger.info("Stripe 'charge.succeeded' received for a PAYMENT_FROM_UI -- ignored, charge = " + charge)
                 return
         except Exception:
             voter_we_vote_id = DonationManager.find_we_vote_voter_id_for_stripe_customer(customer)

--- a/donate/models.py
+++ b/donate/models.py
@@ -1676,8 +1676,10 @@ class DonationManager(models.Manager):
             how_many_days= 10
             queryset = DonationInvoice.objects.filter(invoice_date__lte=datetime.fromtimestamp(
                 int(time.time()), timezone.utc) - timedelta(days=how_many_days))
-            logger.info("update_subscription_with_latest_charge_date: DELETED " + str(queryset.count()) +
-                        " invoice rows that were older than " + str(how_many_days) + " days old.")
+            
+            # Disabled due to logging possible sensitive information
+            # logger.info("update_subscription_with_latest_charge_date: DELETED " + str(queryset.count()) +
+            #             " invoice rows that were older than " + str(how_many_days) + " days old.")
             queryset.delete()
 
         except Exception as e:

--- a/import_export_facebook/controllers.py
+++ b/import_export_facebook/controllers.py
@@ -746,8 +746,9 @@ def update_organization_facebook_images(facebook_user_id, facebook_profile_image
         if organization_updated:
             try:
                 organization.save()
-                logger.info("update_organization_facebook_images saved updated images for organization: " +
-                            organization.we_vote_id + ", facebook_id: " + str(organization.facebook_id))
+                # Disabled due to logging possible sensitive information
+                # logger.info("update_organization_facebook_images saved updated images for organization: " +
+                #             organization.we_vote_id + ", facebook_id: " + str(organization.facebook_id))
                 return
             except Exception as e:
                 logger.error("update_organization_facebook_images threw: " + str(e))

--- a/organization/models.py
+++ b/organization/models.py
@@ -2340,7 +2340,8 @@ class OrganizationManager(models.Manager):
         results = organization_manager.retrieve_organization(twitter_user_id=twitter_user_id)
 
         if not results['organization_found']:
-            logger.info("update_organization_single_voter_data was not able to find " + str(twitter_user_id))
+            # Disabled due to logging possible sensitive information
+            # logger.info("update_organization_single_voter_data was not able to find " + str(twitter_user_id))
             return False
         try:
             organization = results['organization']

--- a/stripe_donations/models.py
+++ b/stripe_donations/models.py
@@ -2049,7 +2049,8 @@ class StripeManager(models.Manager):
             return 'none'
 
         except Exception as e:
-            logger.info("FAILED_TO RETRIEVE_DONATION_PAYMENT_LIST ", e)
+            # Disabled due to logging possible sensitive information
+            # logger.info("FAILED_TO RETRIEVE_DONATION_PAYMENT_LIST ", e)
             return 'none'
 
     @staticmethod
@@ -2080,7 +2081,8 @@ class StripeManager(models.Manager):
             return 'none'
 
         except Exception as e:
-            logger.info("FAILED_TO RETRIEVE_DONATION_PAYMENT_LIST ", e)
+            # Disabled due to logging possible sensitive information
+            # logger.info("FAILED_TO RETRIEVE_DONATION_PAYMENT_LIST ", e)
             return 'none'
 
 

--- a/voter/controllers.py
+++ b/voter/controllers.py
@@ -334,7 +334,8 @@ def delete_all_voter_information_permanently(voter_to_delete=None, user=None):  
     except Exception as e:
         log += 'LOGGING_PROBLEM ' + str(e) + " "
     log += 'STATUS: ' + status + ' '
-    logger.info(log)
+    # Disabled due to logging possible sensitive information
+    # logger.info(log)
 
     results = {
         'status':                       status,

--- a/wevote_social/utils.py
+++ b/wevote_social/utils.py
@@ -213,7 +213,8 @@ def social_user(backend, uid, details, user=None, *args, **kwargs):
 def switch_user(backend, switch_user=False, user=None, social=None, *args, **kwargs):
 
     if switch_user and social:
-        logger.warning('[authplus.social_pipeline.switch_user] switch to user %s' % user.email)
+        # Disabled due to logging possible sensitive information
+        # logger.warning('[authplus.social_pipeline.switch_user] switch to user %s' % user.email)
 
         # Do we have a voter who's twitter_id matches the incoming user_id?
         # Is social.user_id the Twitter id?


### PR DESCRIPTION
Since the log level is lowered to `INFO`, `WARNING` & `INFO` will now be sent to cloudwatch.

I commented out these logs as they run the risk of exposing user P-I-I, financial information, internal queries, and keys.

I recommend these (and other logs of these levels) be changed to `DEBUG` in the future for local development purposes. 