### PR TITLE
WV-2447 Add email open-tracking pixel endpoint and recipient fields

### DIFF
--- a/apis_v1/tests/test_views_opened_tracking_pixel.py
+++ b/apis_v1/tests/test_views_opened_tracking_pixel.py
@@ -1,0 +1,55 @@
+# apis_v1/tests/test_views_opened_tracking_pixel.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+
+from django.test import TestCase
+from django.utils import timezone
+from django.urls import reverse
+
+from email_outbound.models import EmailCampaignRecipient
+
+
+class WeVoteAPIsV1TestsOpenedTrackingPixel(TestCase):
+    databases = ["default", "readonly"]
+
+    def setUp(self):
+        self.recipient = EmailCampaignRecipient.objects.create(
+            email_campaign_id=1,
+            open_tracking_code="test_open_code_123",
+            open_tracking_count=0,
+            open_tracking_first_open=None,
+            open_tracking_last_open=None,
+        )
+        self.url = reverse(
+            "apis_v1:opened_tracking_pixel",
+            kwargs={"open_tracking_code": self.recipient.open_tracking_code},
+        )
+
+    def test_opened_tracking_pixel_updates_fields(self):
+        # First hit
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "image/gif")
+
+        self.recipient.refresh_from_db()
+        first_open = self.recipient.open_tracking_first_open
+        last_open = self.recipient.open_tracking_last_open
+
+        self.assertEqual(self.recipient.open_tracking_count, 1)
+        self.assertIsNotNone(first_open)
+        self.assertIsNotNone(last_open)
+
+        # Second hit increments count and last_open, first_open stays same
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        self.recipient.refresh_from_db()
+        self.assertEqual(self.recipient.open_tracking_count, 2)
+        self.assertEqual(self.recipient.open_tracking_first_open, first_open)
+        self.assertNotEqual(self.recipient.open_tracking_last_open, last_open)
+
+    def test_opened_tracking_pixel_unknown_code(self):
+        response = self.client.get(
+            reverse("apis_v1:opened_tracking_pixel", kwargs={"open_tracking_code": "nope"})
+        )
+        self.assertEqual(response.status_code, 204)

--- a/apis_v1/urls.py
+++ b/apis_v1/urls.py
@@ -37,6 +37,7 @@ from position.views_admin import positions_sync_out_view
 from representative.views_admin import representatives_sync_out_view
 from stripe_ip_history.views_admin import stripe_ip_history_clear_for_one_ip
 from voter_guide.views_admin import voter_guides_sync_out_view
+from email_outbound import views as email_outbound_views
 
 urlpatterns = [
                   # Actual API Calls
@@ -225,6 +226,8 @@ urlpatterns = [
                           offices_held_for_location_sync_out_view, name='officesHeldForLocationSyncOutView'),
                   re_path(r'^officeRetrieve/', views_misc.office_retrieve_view, name='officeRetrieveView'),
                   re_path(r'^officesSyncOut/', offices_sync_out_view, name='officesSyncOutView'),
+                  re_path(r'^opened/(?P<open_tracking_code>[-\w]+)/',
+                          email_outbound_views.opened_tracking_pixel_view, name='opened_tracking_pixel'),
                   re_path(r'^organizationAnalyticsByVoter/',
                           views_organization.organization_analytics_by_voter_view,
                           name='organizationAnalyticsByVoterView'),

--- a/email_outbound/controllers_email_campaign.py
+++ b/email_outbound/controllers_email_campaign.py
@@ -331,6 +331,10 @@ def schedule_email_campaign_recipient(
     status = ""
     template_variables_in_json = {}
 
+    # Generate an open tracking code for the recipient
+    if email_campaign_recipient:
+        EmailCampaignRecipient.generate_open_tracking_code(email_campaign_recipient)
+
     email_template_results = merge_email_campaign_recipient_with_template(
         email_body_raw=email_body_raw,
         email_campaign_recipient=email_campaign_recipient,
@@ -457,13 +461,22 @@ def merge_email_campaign_recipient_with_template(
         # These are all related to EMAIL_TEMPLATE_CUSTOMIZATION_TOKENS
 
         #
-        open_tracking_pixel_html = ''  # WV-2447 "Open Tracking for Email Campaign System" should go here
-        email_footer_html = \
-            "<br />This email uses tracking to understand whether messages are opened " \
-            "so we can improve our communications. Learn more: [Privacy Policy]." \
-            "{open_tracking_pixel_html}<br />".format(
-                open_tracking_pixel_html=open_tracking_pixel_html,
-            )
+        open_tracking_code = getattr(email_campaign_recipient, "open_tracking_code", "") or ""
+        open_tracking_pixel_html = ""
+        # Tracking pixel and footer text only generated if open tracking code is present
+        if open_tracking_code:
+            open_tracking_pixel_html = (
+                f'<img src="{WE_VOTE_SERVER_ROOT_URL}/apis/v1/opened/'
+                f'{open_tracking_code}/" width="1" height="1" alt="" />'
+            )  # WV-2447 "Open Tracking for Email Campaign System" should go here
+            email_footer_html = \
+                "<br />This email uses tracking to understand whether messages are opened " \
+                "so we can improve our communications. Learn more: <a href='https://wevote.us/privacy'>Privacy Policy</a>." \
+                "{open_tracking_pixel_html}<br />".format(
+                    open_tracking_pixel_html=open_tracking_pixel_html,
+                )
+        else:
+            email_footer_html = ""
         token_replacements['[email_footer]'] = email_footer_html
 
         # Add link to subscription key

--- a/email_outbound/models.py
+++ b/email_outbound/models.py
@@ -161,7 +161,7 @@ class EmailCampaignRecipient(models.Model):
     manually_added = models.BooleanField(default=False)
     office_url = models.TextField(null=True, blank=True)
     office_we_vote_id = models.CharField(max_length=255, default=None, null=True, db_index=True)
-    open_tracking_code = models.CharField(max_length=64, default=None, null=True,  unique=True, db_index=True)
+    open_tracking_code = models.CharField(max_length=255, default=None, null=True,  unique=True, db_index=True)
     open_tracking_count = models.PositiveIntegerField(default=0, null=False)
     open_tracking_first_open = models.DateTimeField(null=True)
     open_tracking_last_open = models.DateTimeField(null=True)

--- a/email_outbound/models.py
+++ b/email_outbound/models.py
@@ -4,7 +4,7 @@
 
 from datetime import date, timedelta
 from django.apps import apps
-from django.db import models
+from django.db import IntegrityError, models
 from django.core.mail import EmailMultiAlternatives, get_connection
 from config.base import get_environment_variable
 from wevote_functions.functions import convert_to_int, extract_email_addresses_from_string, generate_random_string, \
@@ -63,6 +63,7 @@ SEND_STATUS_CHOICES = (
 )
 
 EMAIL_SECRET_KEY_LENGTH = 12
+OPEN_TRACKING_CODE_LENGTH = 16
 SUBSCRIPTION_SECRET_KEY_LENGTH = 48
 
 SENDGRID_API_KEY = get_environment_variable("SENDGRID_API_KEY", no_exception=True)
@@ -160,7 +161,7 @@ class EmailCampaignRecipient(models.Model):
     manually_added = models.BooleanField(default=False)
     office_url = models.TextField(null=True, blank=True)
     office_we_vote_id = models.CharField(max_length=255, default=None, null=True, db_index=True)
-    open_tracking_code = models.CharField(max_length=255, default=None, null=True, db_index=True)
+    open_tracking_code = models.CharField(max_length=64, default=None, null=True,  unique=True, db_index=True)
     open_tracking_count = models.PositiveIntegerField(default=0, null=False)
     open_tracking_first_open = models.DateTimeField(null=True)
     open_tracking_last_open = models.DateTimeField(null=True)
@@ -187,6 +188,25 @@ class EmailCampaignRecipient(models.Model):
     sender_voter_we_vote_id = models.CharField(max_length=255, null=True)
     supporters_count = models.PositiveIntegerField(default=0, null=False)
     voter_we_vote_id = models.CharField(max_length=255, default=None, null=True, unique=False, db_index=True)
+
+    # Generate an open tracking code for the recipient
+    @staticmethod
+    def generate_open_tracking_code(email_campaign_recipient):
+        # If the recipient does not exist, or does not have an open tracking code, return an empty string
+        if not email_campaign_recipient or not hasattr(email_campaign_recipient, "open_tracking_code"):
+            return ""
+        if positive_value_exists(email_campaign_recipient.open_tracking_code):
+            return email_campaign_recipient.open_tracking_code
+        # Try 5 times to generate a unique open tracking code
+        for _ in range(5):
+            email_campaign_recipient.open_tracking_code = generate_random_string(OPEN_TRACKING_CODE_LENGTH)
+            try:
+                email_campaign_recipient.save(update_fields=["open_tracking_code"])
+                return email_campaign_recipient.open_tracking_code
+            except IntegrityError:
+                pass
+        # If we fail to generate a unique open tracking code, return an empty string
+        return ""
 
 
 class EmailAddress(models.Model):

--- a/email_outbound/views.py
+++ b/email_outbound/views.py
@@ -4,4 +4,39 @@
 
 # See also email_outbound/views_admin.py for views used in the admin area
 
+from django.db.models import F
+from django.http import HttpResponse
+from django.utils import timezone
+from email_outbound.models import EmailCampaignRecipient
+from wevote_functions.functions import positive_value_exists
 
+# 1x1 transparent GIF bytes
+PIXEL_GIF_BYTES = (
+    b'GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff!'
+    b'\xf9\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01'
+    b'\x00\x00\x02\x02D\x01\x00;'
+)
+
+def opened_tracking_pixel_view(request, open_tracking_code):
+    if not positive_value_exists(open_tracking_code):
+        return HttpResponse(status=204)
+    # Try to get the recipient by the open tracking code
+    try:
+        recipient = EmailCampaignRecipient.objects.get(open_tracking_code=open_tracking_code)
+    # If the recipient does not exist, return a 204 response
+    except EmailCampaignRecipient.DoesNotExist:
+        return HttpResponse(status=204)
+
+    now = timezone.now()
+    # Update the recipient's open tracking information
+    EmailCampaignRecipient.objects.filter(id=recipient.id).update(
+        open_tracking_count=F("open_tracking_count") + 1,
+        open_tracking_last_open=now,
+        open_tracking_first_open=recipient.open_tracking_first_open or now,
+    )
+
+    # Return the tracking pixel
+    response = HttpResponse(PIXEL_GIF_BYTES, content_type="image/gif")
+    response["Cache-Control"] = "no-cache, no-store, must-revalidate"
+    response["Expires"] = "0"
+    return response


### PR DESCRIPTION
- Added tracking pixel endpoint /apis/v1/opened/<open_tracking_code>/ that updates counts/timestamps and returns a 1x1 GIF (204 if missing/unknown code).
- Updated email assembly to generate tracking code before merge and to render a pixel + footer only when a code exists; footer is empty otherwise.
- Added privacy policy link in the footer and used empty alt on the pixel image.
- Added a unit test for the new pixel endpoint in apis_v1/tests/.