### PR TITLE
Iteration on first metrics on email campaign send, so staff looking at a message that was sent doesn't call the "OPENED" URL and mark the EmailCampaignRecipient as viewed.

### DIFF
--- a/email_outbound/views_admin.py
+++ b/email_outbound/views_admin.py
@@ -3,6 +3,7 @@
 # -*- coding: UTF-8 -*-
 
 import json
+import re
 from datetime import datetime
 from django.utils import timezone
 from urllib.parse import urlencode
@@ -1585,9 +1586,19 @@ def email_recipient_view(request, email_recipient_id=0):
     status = ''
 
     email_recipient = EmailCampaignRecipient.objects.get(id=email_recipient_id)
+    email_body_assembled = email_recipient.email_body_assembled
+    if email_body_assembled:
+        try:
+            # We want to search for this pattern "/apis/v1/opened/hcRlYMGJCK4yLZuz/" in email_body_assembled,
+            #  where hcRlYMGJCK4yLZuz could be any random string, and then remove that final random string.
+            email_body_assembled = re.sub(r'/apis/v1/opened/[a-zA-Z0-9]+/', '/apis/v1/opened/DONOTTRACK/',
+                                          email_body_assembled)
+        except Exception as e:
+            email_body_assembled = email_recipient.email_body_assembled
+            status += "ERROR_SUBSTITUTING_EMAIL_BODY_ASSEMBLED: " + str(e) + " "
 
     template_values = {
-        'email_recipient':          email_recipient,
+        'email_body_assembled':     email_body_assembled,
         'google_civic_election_id': google_civic_election_id,
         'state_code':               state_code,
     }

--- a/templates/email_outbound/audience_builder_preview_list.html
+++ b/templates/email_outbound/audience_builder_preview_list.html
@@ -175,6 +175,7 @@
       <thead>
         <tr>
           <th>Recipient name</th>
+          <th></th>
           <th>Phone</th>
           <th>Email</th>
           <th>Type</th>
@@ -186,7 +187,18 @@
         {% if preview_list %}
           {% for recipient in preview_list %}
           <tr class="recipient-row" data-name="{{ recipient.email_recipient_name|lower }}">
-            <td>{{ recipient.name }}</td>
+            <td>{{ recipient.full_name }}</td>
+            <td>
+                <a href="{% url 'politician:politician_we_vote_id_edit' recipient.politician_we_vote_id %}?google_civic_election_id={{ google_civic_election_id }}"
+                   class="campaign-link" target="_blank">
+                  edit
+                </a>
+                &nbsp;
+                <a href="https://quality.wevote.us/{{ recipient.politician_seo_friendly_path }}/-/?google_civic_election_id={{ google_civic_election_id }}"
+                   class="campaign-link" target="_blank">
+                  view
+                </a>
+            </td>
             <td>{{ recipient.phone }}</td>
             <td>{{ recipient.email }}</td>
             <td>{{ recipient.type }}</td>

--- a/templates/email_outbound/view_recipient_email.html
+++ b/templates/email_outbound/view_recipient_email.html
@@ -12,7 +12,7 @@
 
 
 <div class="container mt-5 p-4 bg-white rounded shadow-sm border" style="max-width: 800px;">
-    {{ email_recipient.email_body_assembled|safe }}
+    {{ email_body_assembled|safe }}
 </div>
 
 {% load static %}


### PR DESCRIPTION
Iteration on first metrics on email campaign send, so staff looking at a message that was sent doesn't call the "OPENED" URL and mark the EmailCampaignRecipient as viewed.