### PR TITLE
[WV-2620]Create checkbox for find duplicates in candidate and politician pages to compare trigram index search vs no trigram index search results

### DIFF
--- a/candidate/controllers.py
+++ b/candidate/controllers.py
@@ -3090,7 +3090,7 @@ def find_organization_endorsements_of_candidates_on_one_web_page(site_url, endor
     return results
 
 
-def find_possible_duplicate_candidates_to_merge_with_this_candidate(candidate=None):
+def find_possible_duplicate_candidates_to_merge_with_this_candidate(candidate=None, use_trigram_match=False):
     """
     Find Candidates that might be duplicates to see if we want to merge them with this Candidate
 

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -2105,6 +2105,7 @@ def candidate_edit_view(request, candidate_id=0, candidate_we_vote_id=""):
     state_code = request.GET.get('state_code', "")
     show_all_google_search_users = request.GET.get('show_all_google_search_users', False)
     show_all_twitter_search_results = request.GET.get('show_all_twitter_search_results', False)
+    use_trigram_match = positive_value_exists(request.GET.get('use_trigram_match', False))
     withdrawal_date = request.GET.get('withdrawal_date', False)
     withdrawn_from_election = positive_value_exists(request.GET.get('withdrawn_from_election', False))
     do_not_display_on_ballot = positive_value_exists(request.GET.get('do_not_display_on_ballot', False))
@@ -2346,7 +2347,9 @@ def candidate_edit_view(request, candidate_id=0, candidate_we_vote_id=""):
         from candidate.controllers import find_possible_duplicate_candidates_to_merge_with_this_candidate
         t0 = time()
         related_candidate_list = \
-            find_possible_duplicate_candidates_to_merge_with_this_candidate(candidate=candidate_on_stage)
+            find_possible_duplicate_candidates_to_merge_with_this_candidate(
+                candidate=candidate_on_stage,
+                use_trigram_match=use_trigram_match)
         t1 = time()
 
         performance_snapshot = {
@@ -2506,6 +2509,7 @@ def candidate_edit_view(request, candidate_id=0, candidate_we_vote_id=""):
             'performance_process_dict':         performance_process_dict,
             'rating_list':                      rating_list,
             'related_candidate_list':           related_candidate_list,
+            'use_trigram_match':                use_trigram_match,
             'state_code':                       state_code,
             'state_code_dict':              
             {

--- a/politician/controllers.py
+++ b/politician/controllers.py
@@ -445,7 +445,7 @@ def find_campaignx_list_to_link_to_this_politician(politician=None):
     return related_list
 
 
-def find_candidates_to_link_to_this_politician(politician=None):
+def find_candidates_to_link_to_this_politician(politician=None,use_trigram_match=False):
     """
     Find Candidates to Link to this Politician
     Finding Candidates that *might* be "children" of this politician

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -1488,6 +1488,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
     politician_url5 = request.GET.get('politician_url5', False)
     political_party = request.GET.get('political_party', False)
     state_code = request.GET.get('state_code', False)
+    use_trigram_match = positive_value_exists(request.GET.get('use_trigram_match', False))
     vote_smart_id = request.GET.get('vote_smart_id', False)
     vote_usa_politician_id = request.GET.get('vote_usa_politician_id', False)
     youtube_url = request.GET.get('youtube_url', False)
@@ -1718,7 +1719,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
         related_candidate_list = []
         if positive_value_exists(find_candidates_to_link_to_this_politician_on):
             from politician.controllers import find_candidates_to_link_to_this_politician
-            related_candidate_list = find_candidates_to_link_to_this_politician(politician=politician_on_stage)
+            related_candidate_list = find_candidates_to_link_to_this_politician(politician=politician_on_stage,use_trigram_match=use_trigram_match)
             if len(related_candidate_list) == 0:
                 find_candidates_to_link_to_this_politician_on = False
                 find_candidates_to_link_none_found = True
@@ -2142,6 +2143,7 @@ def politician_edit_view(request, politician_id=0, politician_we_vote_id=''):
             'related_campaignx_list':       related_campaignx_list,
             'related_candidate_list':       related_candidate_list,
             'related_representative_list':  related_representative_list,
+            'use_trigram_match':            use_trigram_match,
             'state_code':                   state_code,
             'state_code_dict':
             {

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -844,10 +844,21 @@ th, td {
 </div>
 {% endif %}
 <br />
-    
-    
+
+
 {% if related_candidate_list %}
     <h3>Possible Duplicate Candidates for {{ candidate.candidate_name }}</h3>
+    <div style="margin-bottom: 15px;">
+            <label for="use_trigram_match_id">
+                <input type="checkbox" name="use_trigram_match" id="use_trigram_match_id" value="1" />
+                <strong>Use Trigram-Based Fuzzy Matching</strong> (finds candidates with similar names even with spelling variations)
+            </label>
+            {% if use_trigram_match %}
+                <span style="color: #0066cc; margin-left: 20px;">✓ Currently viewing fuzzy matching results</span>
+            {% else %}
+                <span style="color: #6c757d; margin-left: 20px;">Currently viewing exact matching results</span>
+            {% endif %}
+        </div>
     <table class="table">
     <thead>
         <tr>
@@ -1207,6 +1218,28 @@ th, td {
       console.log('txt fld changed');
       $('#facebook_a_tag').removeAttr('href').attr('type', 'button').attr('disabled');
       $('#facebook_a_tag').css('color', 'lightblue');
+    });
+  });
+
+  // Handle trigram fuzzy matching checkbox change
+  $(function() {
+    $('#use_trigram_match_id').change(function() {
+      // Get the current URL
+      let url = new URL(window.location.href);
+      
+      if (this.checked) {
+        // Add or update the use_trigram_match parameter
+        url.searchParams.set('use_trigram_match', '1');
+      } else {
+        // Remove the use_trigram_match parameter
+        url.searchParams.delete('use_trigram_match');
+      }
+      
+      // Open in a new popup window
+      window.open(url.toString(), '_blank', 'width=1200,height=800,scrollbars=yes,resizable=yes');
+      
+      // Uncheck the checkbox after opening the popup
+      this.checked = false;
     });
   });
 </script>

--- a/templates/candidate/candidate_edit.html
+++ b/templates/candidate/candidate_edit.html
@@ -1238,8 +1238,6 @@ th, td {
       // Open in a new popup window
       window.open(url.toString(), '_blank', 'width=1200,height=800,scrollbars=yes,resizable=yes');
       
-      // Uncheck the checkbox after opening the popup
-      this.checked = false;
     });
   });
 </script>

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -734,6 +734,17 @@
 
 {% if related_candidate_list %}
     <h4>Candidates That Might Match This Politician</h4>
+        <div style="margin-bottom: 15px;">
+            <label for="use_trigram_match_id">
+                <input type="checkbox" name="use_trigram_match" id="use_trigram_match_id" value="1" />
+                <strong>Use Trigram-Based Fuzzy Matching</strong> (finds candidates with similar names even with spelling variations)
+            </label>
+            {% if use_trigram_match %}
+                <span style="color: #0066cc; margin-left: 20px;">✓ Currently viewing fuzzy matching results</span>
+            {% else %}
+                <span style="color: #6c757d; margin-left: 20px;">Currently viewing exact matching results</span>
+            {% endif %}
+        </div>
     <table class="table">
         <tr>
             <td>&nbsp;</td>
@@ -1472,6 +1483,28 @@
         // on page load translate the database token for politician.gender_likelihood to the text version
         setSourceOfGenderId();
     });
+     // Handle trigram fuzzy matching checkbox change
+    $(function() {
+        $('#use_trigram_match_id').change(function() {
+        // Get the current URL
+        let url = new URL(window.location.href);
+      
+        if (this.checked) {
+            // Add or update the use_trigram_match parameter
+            url.searchParams.set('use_trigram_match', '1');
+        } else {
+            // Remove the use_trigram_match parameter
+            url.searchParams.delete('use_trigram_match');
+        }
+      
+        // Open in a new popup window
+        window.open(url.toString(), '_blank', 'width=1200,height=800,scrollbars=yes,resizable=yes');
+      
+        // Uncheck the checkbox after opening the popup
+        this.checked = false;
+    });
+  });
+
 
 </script>
 

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -1531,8 +1531,6 @@
         // Open in a new popup window
         window.open(url.toString(), '_blank', 'width=1200,height=800,scrollbars=yes,resizable=yes');
       
-        // Uncheck the checkbox after opening the popup
-        this.checked = false;
     });
   });
 

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -1185,6 +1185,17 @@
 
 {% if duplicate_politician_list %}
     <h4>Possible Duplicate Politicians</h4>
+        <div style="margin-bottom: 15px;">
+            <label for="use_trigram_match_duplicates_id">
+                <input type="checkbox" name="use_trigram_match_duplicates" id="use_trigram_match_duplicates_id" value="1" />
+                <strong>Use Trigram-Based Fuzzy Matching</strong> (finds duplicate politicians with similar names even with spelling variations)
+            </label>
+            {% if use_trigram_match %}
+                <span style="color: #0066cc; margin-left: 20px;">✓ Currently viewing fuzzy matching results</span>
+            {% else %}
+                <span style="color: #6c757d; margin-left: 20px;">Currently viewing exact matching results</span>
+            {% endif %}
+        </div>
     <table class="table">
         <tr>
             <td>&nbsp;</td>
@@ -1486,6 +1497,26 @@
      // Handle trigram fuzzy matching checkbox change
     $(function() {
         $('#use_trigram_match_id').change(function() {
+        // Get the current URL
+        let url = new URL(window.location.href);
+      
+        if (this.checked) {
+            // Add or update the use_trigram_match parameter
+            url.searchParams.set('use_trigram_match', '1');
+        } else {
+            // Remove the use_trigram_match parameter
+            url.searchParams.delete('use_trigram_match');
+        }
+      
+        // Open in a new popup window
+        window.open(url.toString(), '_blank', 'width=1200,height=800,scrollbars=yes,resizable=yes');
+      
+        // Uncheck the checkbox after opening the popup
+        this.checked = false;
+    });
+
+    // Handle trigram fuzzy matching checkbox change for duplicate politicians
+    $('#use_trigram_match_duplicates_id').change(function() {
         // Get the current URL
         let url = new URL(window.location.href);
       

--- a/templates/politician/politician_edit.html
+++ b/templates/politician/politician_edit.html
@@ -1511,8 +1511,6 @@
         // Open in a new popup window
         window.open(url.toString(), '_blank', 'width=1200,height=800,scrollbars=yes,resizable=yes');
       
-        // Uncheck the checkbox after opening the popup
-        this.checked = false;
     });
 
     // Handle trigram fuzzy matching checkbox change for duplicate politicians


### PR DESCRIPTION
**What github.com/wevote server/issues does this fix?
[WV-2620]Create checkbox for find duplicates in candidate and politician pages to compare trigram index search vs no trigram index search results


Changes included this pull request?**
Frame work for comparing trigram index search vs no trigram index search results.
- A checkbox is created on the candidate and politician pages.
- When the checkbox is clicked, a new window should pop up.
- The new window displays the search results from the trigram index.

[WV-2620]: https://wevoteusa.atlassian.net/browse/WV-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ