### PR TITLE
Change SQS process to be a lambda function

### DIFF
--- a/aws/lambda_sqs_worker.py
+++ b/aws/lambda_sqs_worker.py
@@ -2,16 +2,31 @@ import json
 import logging
 import os
 
+logger = logging.getLogger(__name__)
+
+import boto3
+from botocore.exceptions import ClientError
+
+# Load config from Secrets Manager before Django initializes — mirrors what
+# docker/prod/entrypoint does for the ECS task.  Runs once per cold start.
+_secret_arn = os.environ.get('CONFIG_SECRET_ARN')
+_region = os.environ.get('AWS_DEFAULT_REGION') or os.environ.get('AWS_REGION')
+if _secret_arn and _region:
+    try:
+        _client = boto3.session.Session().client('secretsmanager', region_name=_region)
+        _secret = json.loads(_client.get_secret_value(SecretId=_secret_arn)['SecretString'])
+        for _key, _val in _secret.items():
+            if _key not in os.environ:
+                os.environ[_key] = _val
+    except ClientError as e:
+        raise RuntimeError(f"Failed to load config secret {_secret_arn}") from e
+
 # Django must be initialized at module level so it runs once per cold start
 # and is reused across warm Lambda invocations.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
 
 import django
 django.setup()
-
-import wevote_functions.admin
-
-logger = wevote_functions.admin.get_logger(__name__)
 
 
 def handler(event, context):

--- a/aws/lambda_sqs_worker.py
+++ b/aws/lambda_sqs_worker.py
@@ -1,0 +1,58 @@
+import json
+import logging
+import os
+
+# Django must be initialized at module level so it runs once per cold start
+# and is reused across warm Lambda invocations.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+
+import django
+django.setup()
+
+import wevote_functions.admin
+
+logger = wevote_functions.admin.get_logger(__name__)
+
+
+def handler(event, context):
+    """
+    Lambda handler for SQS-triggered async jobs.
+
+    Replaces the long-polling runsqsworker.py management command.
+    Messages arrive from submit_web_function_job() in aws/controllers.py.
+
+    On success Lambda automatically deletes the message from the queue.
+    On exception the message becomes visible again and eventually routes to
+    the dead-letter queue after maxReceiveCount retries.
+    """
+    for record in event['Records']:
+        message_id = record['messageId']
+        attributes = record.get('messageAttributes', {})
+
+        if 'Function' not in attributes:
+            logger.error("SQS record %s missing Function attribute", message_id)
+            raise ValueError(f"SQS record {message_id} missing required Function message attribute")
+
+        function_name = attributes['Function']['stringValue']
+        body = json.loads(record['body'])
+
+        logger.info("SQS Lambda: function=%s messageId=%s", function_name, message_id)
+
+        if function_name == 'caching_facebook_images_for_retrieve_process':
+            from import_export_facebook.controllers import caching_facebook_images_for_retrieve_process
+            caching_facebook_images_for_retrieve_process(
+                body['repair_facebook_related_voter_caching_now'],
+                body['facebook_auth_response_id'],
+                body['voter_we_vote_id_attached_to_facebook'],
+                body['voter_we_vote_id_attached_to_facebook_email'],
+                body['voter_we_vote_id'],
+            )
+        elif function_name == 'voter_cache_facebook_images_process':
+            from voter.controllers import voter_cache_facebook_images_process
+            voter_cache_facebook_images_process(
+                body['voter_id'],
+                body['facebook_auth_response_id'],
+                False,  # is_retrieve — always False for this job type
+            )
+        else:
+            raise ValueError(f"Unknown SQS function: {function_name}")

--- a/codebuild/buildspec-lambda.yaml
+++ b/codebuild/buildspec-lambda.yaml
@@ -1,0 +1,36 @@
+version: 0.2
+
+# BuildSpec for the SQS Worker Lambda image.
+# Environment variables injected by the CDK CodeBuild project:
+#   LAMBDA_REPO_URI        — ECR repository URI for the Lambda image
+#   LAMBDA_FUNCTION_NAME   — Lambda function name to update after push
+#   AWS_DEFAULT_REGION     — AWS region
+
+env:
+  shell: bash
+phases:
+  pre_build:
+    on-failure: ABORT
+    commands:
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=${COMMIT_HASH:=build}
+      - ECR_LOGIN_HOST=$(echo $LAMBDA_REPO_URI | sed 's#/.*##')
+      - echo Logging into ECR
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_LOGIN_HOST
+  build:
+    on-failure: ABORT
+    commands:
+      - echo Build started at $(date)
+      - docker build -f docker/Dockerfile.lambda -t wevote-sqs-worker:latest .
+  post_build:
+    on-failure: ABORT
+    commands:
+      - echo Tagging and pushing Lambda image
+      - docker tag wevote-sqs-worker:latest $LAMBDA_REPO_URI:$IMAGE_TAG
+      - docker tag wevote-sqs-worker:latest $LAMBDA_REPO_URI:latest
+      - docker push $LAMBDA_REPO_URI:$IMAGE_TAG
+      - docker push $LAMBDA_REPO_URI:latest
+      - echo Updating Lambda function to image $LAMBDA_REPO_URI:$IMAGE_TAG
+      - aws lambda update-function-code --function-name $LAMBDA_FUNCTION_NAME --image-uri $LAMBDA_REPO_URI:$IMAGE_TAG
+      - aws lambda wait function-updated --function-name $LAMBDA_FUNCTION_NAME
+      - echo Lambda update complete

--- a/docker/Dockerfile.lambda
+++ b/docker/Dockerfile.lambda
@@ -1,0 +1,21 @@
+# Lambda image for the SQS worker (async Facebook image caching jobs).
+# Uses the AWS-managed Lambda base image which includes the Lambda Runtime
+# Interface Client, so no separate entrypoint wrapper is needed.
+#
+# The AWS Lambda Python 3.12 base uses Amazon Linux 2023.
+# System packages use dnf instead of apt.
+
+FROM public.ecr.aws/lambda/python:3.12
+
+# libmagic is required by the python-magic package used in WeVoteServer
+RUN dnf install -y file-libs && dnf clean all
+
+# Install Python dependencies into the Lambda task root
+COPY requirements.txt ${LAMBDA_TASK_ROOT}/
+RUN pip install -r ${LAMBDA_TASK_ROOT}/requirements.txt --no-cache-dir
+
+# Copy the full WeVoteServer codebase — all Django apps must be importable
+COPY . ${LAMBDA_TASK_ROOT}/
+
+# Handler: aws/lambda_sqs_worker.py → module aws.lambda_sqs_worker, function handler
+CMD ["aws.lambda_sqs_worker.handler"]


### PR DESCRIPTION
Currently, we use a dedicated ECS task to process web functions queued into the SQS queue. This change allows us to create a docker container that can be used as a Lambda function triggered by an SQS queue.