### PR TITLE
Update docker install instructions and refactor compose file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,29 +13,21 @@ services:
       retries: 5
     image: postgres:16-alpine
     networks:
-      - back_end
+      - wevote
     ports:
-      - "127.0.0.1:5432:5432"
-    restart: unless-stopped
+      - "127.0.0.1:5432:5432" # to allow postgres clients on the host machine to connect to the database at localhost:5432
     user: postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data
     
-  aws:
-    depends_on:
-      db:
-        condition: service_healthy
-        restart: true
-    environment:
-      DOCKER_HOST: unix:///var/run/docker.sock
-    image: localstack/localstack
+  localstack:
+    image: localstack/localstack:4.14.0
     networks:
-      - back_end
-    profiles:
-      - optional
+      - wevote
     volumes:
       - localstack:/var/lib/localstack
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      PERSISTENCE: 1
   
   api:
     build:
@@ -43,7 +35,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
-        restart: true
+      localstack:
+        condition: service_healthy
     environment:
       - DATABASE_NAME=${DATABASE_NAME:-wevoteserverdb}
       - DATABASE_NAME_READONLY=${DATABASE_NAME:-wevoteserverdb}
@@ -60,15 +53,14 @@ services:
     volumes:
       - .:/wevote/code
     networks:
-      - back_end
+      - wevote
     ports:
-      - "127.0.0.1:8000:8000"
+      - "127.0.0.1:8000:8000" # this allows access to the WeVote API at localhost:8000
 
 networks:
-  back_end:
-    driver: bridge
-    driver_opts:
-      com.docker.network.bridge.host_binding_ipv4: "127.0.0.1"
+  wevote:
+    name: wevote
+    external: true
 
 
 volumes:

--- a/docs/README_API_INSTALL_DOCKER.md
+++ b/docs/README_API_INSTALL_DOCKER.md
@@ -7,45 +7,62 @@ Only [Docker Desktop](https://docs.docker.com/get-docker/) is required.
 
 ## Installation
 
-1. Clone your WeVoteServer fork
+### 1. Clone your WeVoteServer fork (replace wevote with your github username)
 
-    ```
-    git clone https://github.com/wevote/WeVoteServer.git
-    cd WeVoteServer
-    ```
+  ```
+  git clone https://github.com/wevote/WeVoteServer.git
+  cd WeVoteServer
+  ```
 
-2. Create an environment file called `.env` to provide required settings. Example:
+### 2. Create an environment file called `.env` to provide required settings. Example:
 
-    ```
-    DATABASE_PASSWORD=MyDBpassword
-    DJANGO_SUPERUSER_EMAIL=email@test.com
-    DJANGO_SUPERUSER_PASSWORD=MyAdminPassword
+  ```
+  DATABASE_PASSWORD=MyDBpassword
+  DJANGO_SUPERUSER_EMAIL=email@test.com
+  DJANGO_SUPERUSER_PASSWORD=MyAdminPassword
 
-    # You can optionally override the default values for database user and name
-    # DATABASE_USER=postgres
-    # DATABASE_NAME=wevoteserverdb
-    ```
+  # You can optionally override the default values for database user and name
+  # DATABASE_USER=postgres
+  # DATABASE_NAME=wevoteserverdb
+  ```
 
-3. Create and start containers
+### 3. Create Docker network
+We will run all WeVote docker containers in an isolated docker network. Since the backend (WeVoteServer) and frontend (WebApp) both use docker compose (which typically manage docker networks for us), we must manually create this shared network to avoid conflicts. Even if you are not planning on running your own backend, this step must still be completed.
+```
+docker network create wevote
+```
 
-    ```
-    docker compose up --detach --build --remove-orphans
-    ```
-    Use the `--profile` flag, if you need to also run the AWS localstack container (when developing features specific to AWS environment).
-    ```
-    docker compose --profile optional up --detach --build --remove-orphans
-    ```
-    Once docker is running, you can now access the API at [http://localhost:8000/](http://localhost:8000/)
+### 4. Starting the containers
 
-4. Stop and remove containers
+To start the WeVote API service and dependencies, use one of these commands. If you are just getting started, we recommend using the first (foreground) method below. These commands assume you are in the `WeVoteServer` folder created in Step 1 above.
 
-    ```
-    docker compose down
-    ```
-    Use the `--volumes` flag to remove volumes (includes database data - you will lose all previously saved data). Only do this if you want to completely remove development environment or start over from scratch.
-    ```
-    docker compose down --volumes
-    ```
+#### 1. Start in the foreground (for debugging/logs):
+```
+docker compose up
+```
+This command builds, (re)creates, and starts all services, and aggregates their logs in your terminal. **Press `Ctrl+C` to stop the containers gracefully.**
+
+#### 2. Start in the background (detached mode):
+```
+docker compose up -d
+```
+The `-d` (detached) flag runs containers in the background, leaving them running after you exit the terminal. Once started in detached state, use this command to stop the containers:
+```
+docker compose down
+```
+
+Once the containers are running, you can now access the API at [http://localhost:8000/](http://localhost:8000/)
+
+### 5. Remove containers and data
+
+To stop and remove all containers and saved data (including database data), run the following command. Only do this if you want to completely remove your development environment or start over from scratch.
+```
+docker compose down -v
+```
+You can also remove the wevote docker network:
+```
+docker network rm wevote
+```
 
 ## Resources
 

--- a/docs/README_API_INSTALL_DOCKER.md
+++ b/docs/README_API_INSTALL_DOCKER.md
@@ -27,7 +27,7 @@ Only [Docker Desktop](https://docs.docker.com/get-docker/) is required.
   ```
 
 ### 3. Create Docker network
-We will run all WeVote docker containers in an isolated docker network. Since the backend (WeVoteServer) and frontend (WebApp) both use docker compose (which typically manage docker networks for us), we must manually create this shared network to avoid conflicts. Even if you are not planning on running your own backend, this step must still be completed.
+We will run all WeVote docker containers in an isolated docker network. Since the backend (WeVoteServer) and frontend (WebApp) both use docker compose (which typically manages docker networks for us), we must manually create this shared network to avoid conflicts. Even if you are not planning on running your own frontend, this step must still be completed.
 ```
 docker network create wevote
 ```


### PR DESCRIPTION
To make setting up development environment as simple as possible, making a few changes to the instructions and docker compose file:

1. Use a common `wevote` docker network and add instructions to create it. This allows full-stack devs to run both front and backends locally and have them communicate together.
2. Always run the localstack (AWS simulator) container to simplify the options. We plan to utilize this for the S3 stuff that currently requires hitting a real S3 bucket in the cloud.
3. Update the docker setup documentation to be as simple as possible.