### PR TITLE
fix(docker): use native boto3 with LocalStack via AWS_ENDPOINT_URL instead of localstack_client

### DIFF
--- a/aws/controllers.py
+++ b/aws/controllers.py
@@ -10,14 +10,7 @@ sqs_client = None
 def _init_client(queue_url):
     global sqs_client
     if sqs_client is None:
-        if queue_url.startswith('http://localhost'):
-            try:
-                import localstack_client.session as boto3
-            except:
-                import boto3
-        else:
-            import boto3
-
+        import boto3
         sqs_client = boto3.client('sqs')
     return sqs_client
 

--- a/aws/management/commands/runsqsworker.py
+++ b/aws/management/commands/runsqsworker.py
@@ -76,14 +76,7 @@ def process_request(function, body, message):
 
 
 def worker_run(queue_url):
-    if queue_url.startswith('http://localhost'):
-        try:
-            import localstack_client.session as boto3
-        except:
-            import boto3
-    else:
-        import boto3
-
+    import boto3
     sqs = boto3.client('sqs')
     # print("sqs.receive_message startup--------------------")
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,8 +26,15 @@ services:
       - wevote
     volumes:
       - localstack:/var/lib/localstack
+      - ./docker/dev/localstack-init.sh:/etc/localstack/init/ready.d/init.sh
     environment:
       PERSISTENCE: 1
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
   
   api:
     build:
@@ -50,6 +57,11 @@ services:
       - DATABASE_PORT_READONLY=${DATABASE_PORT:-5432}
       - DJANGO_SUPERUSER_EMAIL
       - DJANGO_SUPERUSER_PASSWORD
+      - AWS_ENDPOINT_URL=http://localstack:4566
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - AWS_DEFAULT_REGION=us-east-1
+      - AWS_SQS_WEB_QUEUE_URL=http://localstack:4566/000000000000/job-queue.fifo
     volumes:
       - .:/wevote/code
     networks:

--- a/docker/dev/localstack-init.sh
+++ b/docker/dev/localstack-init.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+awslocal sqs create-queue \
+  --queue-name job-queue.fifo \
+  --attributes FifoQueue=true,ContentBasedDeduplication=true
+
+awslocal s3 mb s3://wevote-images


### PR DESCRIPTION
## Summary

Removes the `localstack_client` compatibility hack from the SQS integration and replaces it with the standard approach: configuring boto3 to point at LocalStack via the `AWS_ENDPOINT_URL` environment variable. Also adds a LocalStack init script to automatically provision required AWS resources (SQS queue + S3 bucket) on container startup.

## Problem

The previous approach used a conditional import to swap in the `localstack_client` module when the SQS queue URL started with `http://localhost`:

```python
if queue_url.startswith('http://localhost'):
    try:
        import localstack_client.session as boto3
    except:
        import boto3
else:
    import boto3
```

This was a fragile hack — it depended on the `localstack_client` package being installed, silently fell back to real boto3 (and thus real AWS) if it wasn't, and didn't work correctly when LocalStack ran as a named Docker service (`localstack`) rather than `localhost`.

The modern and supported approach is to set `AWS_ENDPOINT_URL` so that boto3 natively redirects all AWS API calls to LocalStack, with no code changes required.

## Changes

### `aws/controllers.py`
- Removed the `localstack_client` conditional import block in `_init_client()`
- Replaced with a simple unconditional `import boto3` — boto3 will use `AWS_ENDPOINT_URL` automatically if set

### `aws/management/commands/runsqsworker.py`
- Same removal in `worker_run()` — dropped the localhost URL check and `localstack_client` import
- Replaced with unconditional `import boto3`

### `compose.yaml`
- Mounted `./docker/dev/localstack-init.sh` into LocalStack's `/etc/localstack/init/ready.d/` so it runs automatically on container startup
- Added a healthcheck for the LocalStack service so dependent containers wait until LocalStack is ready before starting:
  ```yaml
  healthcheck:
    test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
    interval: 10s
    timeout: 5s
    retries: 10
    start_period: 30s
  ```
- Added AWS environment variables to the `api` service so boto3 targets LocalStack:
  ```
  AWS_ENDPOINT_URL=http://localstack:4566
  AWS_ACCESS_KEY_ID=test
  AWS_SECRET_ACCESS_KEY=test
  AWS_DEFAULT_REGION=us-east-1
  AWS_SQS_WEB_QUEUE_URL=http://localstack:4566/000000000000/job-queue.fifo
  ```

### `docker/dev/localstack-init.sh` *(new file)*
- Init script that runs inside LocalStack on startup to provision local AWS resources:
  ```bash
  awslocal sqs create-queue \
    --queue-name job-queue.fifo \
    --attributes FifoQueue=true,ContentBasedDeduplication=true

  awslocal s3 mb s3://wevote-images
  ```
- Creates the FIFO SQS queue (`job-queue.fifo`) and S3 bucket (`wevote-images`) needed by the application

## Result

Running `docker compose up` now:
1. Starts LocalStack and waits for it to be healthy
2. Automatically creates the required SQS queue and S3 bucket
3. Starts the API container with boto3 pointed at LocalStack — no extra packages or manual setup needed