### PR TITLE
Allow simplejson >= 3.17.2, to work with awslambdaric dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ robot-detection==0.4
 rsa==4.7.2
 ruff==0.3.5
 sendgrid==6.9.7
-simplejson==3.17.2
+simplejson>=3.17.2
 six==1.16.0
 # setuptools==70.0.0    Removed in Py 3.12, but still needed by some slow to update packages)
 social-auth-app-django==5.4.1


### PR DESCRIPTION
## Summary

Updates the `simplejson` version constraint to allow `>= 3.17.2`, resolving a dependency conflict with the `awslambdaric` package.

## Changes
- Loosened `simplejson` version pin to be compatible with `awslambdaric` requirements

## Motivation
The `awslambdaric` dependency requires a version of `simplejson` that was previously blocked by the existing constraint. This change unblocks that dependency while maintaining a minimum safe version.