### PR TITLE
refactor: remove hard-coded AWS credentials, use ECS task IAM role

### DIFF
--- a/apis_v1/views/views_extension.py
+++ b/apis_v1/views/views_extension.py
@@ -17,11 +17,8 @@ from config.base import get_environment_variable, get_environment_variable_defau
 from exception.models import handle_exception
 from wevote_functions.functions import positive_value_exists
 
-AWS_ACCESS_KEY_ID = get_environment_variable("AWS_ACCESS_KEY_ID")
-AWS_SECRET_ACCESS_KEY = get_environment_variable("AWS_SECRET_ACCESS_KEY")
 AWS_REGION_NAME = get_environment_variable("AWS_REGION_NAME")
 AWS_STORAGE_BUCKET_NAME = "wevote-temporary"
-AWS_STORAGE_SERVICE = "s3"
 
 logger = wevote_functions.admin.get_logger(__name__)
 
@@ -247,10 +244,8 @@ def store_temporary_html_file_to_aws(temp_file_name):
     try:
         head, tail = os.path.split(temp_file_name)
         date_in_a_year = datetime.datetime.now() + + datetime.timedelta(days=365)
-        session = boto3.session.Session(region_name=AWS_REGION_NAME,
-                                        aws_access_key_id=AWS_ACCESS_KEY_ID,
-                                        aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
-        s3 = session.resource(AWS_STORAGE_SERVICE)
+        session = boto3.session.Session(region_name=AWS_REGION_NAME)
+        s3 = session.resource("s3")
         logger.info('store_temporary_html_file_to_aws upload temp_file: ' + temp_file_name)
         s3.Bucket(AWS_STORAGE_BUCKET_NAME).upload_file(
             temp_file_name, tail, ExtraArgs={'Expires': date_in_a_year, 'ContentType': 'text/html'})

--- a/email_outbound/functions.py
+++ b/email_outbound/functions.py
@@ -232,17 +232,11 @@ def convert_html_to_plain_text(html_content):
 # S3 functions
 # create s3 bucket
 def _s3_client_bucket():
-    # Works with env keys or IAM role
-    AWS_ACCESS_KEY_ID = get_environment_variable("AWS_ACCESS_KEY_ID")
-    AWS_SECRET_ACCESS_KEY = get_environment_variable("AWS_SECRET_ACCESS_KEY")
     AWS_REGION_NAME = get_environment_variable("AWS_REGION_NAME")
     AWS_STORAGE_BUCKET_NAME = get_environment_variable("AWS_STORAGE_BUCKET_NAME")
-    AWS_STORAGE_SERVICE = "s3"
 
-    session = boto3.session.Session(region_name=AWS_REGION_NAME,
-                                  aws_access_key_id=AWS_ACCESS_KEY_ID,
-                                  aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
-    s3 = session.resource(AWS_STORAGE_SERVICE)
+    session = boto3.session.Session(region_name=AWS_REGION_NAME)
+    s3 = session.resource("s3")
     return s3.Bucket(AWS_STORAGE_BUCKET_NAME)
 
 # make filename safe

--- a/image/models.py
+++ b/image/models.py
@@ -42,11 +42,8 @@ VOTE_USA_PROFILE_IMAGE_NAME = "vote_usa_profile_image"
 VOTER_UPLOADED_IMAGE_NAME = "voter_uploaded_profile_image"
 WIKIPEDIA_IMAGE_NAME = "wikipedia_image"
 
-AWS_ACCESS_KEY_ID = get_environment_variable("AWS_ACCESS_KEY_ID")
-AWS_SECRET_ACCESS_KEY = get_environment_variable("AWS_SECRET_ACCESS_KEY")
 AWS_REGION_NAME = get_environment_variable("AWS_REGION_NAME")
 AWS_STORAGE_BUCKET_NAME = get_environment_variable("AWS_STORAGE_BUCKET_NAME")
-AWS_STORAGE_SERVICE = "s3"
 
 GifImagePlugin.LOADING_STRATEGY = GifImagePlugin.LoadingStrategy.RGB_ALWAYS
 
@@ -378,9 +375,7 @@ class WeVoteImageManager(models.Manager):
         """
         try:
 
-            client = boto3.client(AWS_STORAGE_SERVICE, region_name=AWS_REGION_NAME,
-                                  aws_access_key_id=AWS_ACCESS_KEY_ID,
-                                  aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+            client = boto3.client("s3", region_name=AWS_REGION_NAME)
             client.delete_object(Bucket=AWS_STORAGE_BUCKET_NAME, Key=we_vote_image_file_location)
             image_deleted_from_aws = True
         except Exception as e:
@@ -2235,9 +2230,7 @@ class WeVoteImageManager(models.Manager):
         :return:
         """
         try:
-            client = boto3.client(AWS_STORAGE_SERVICE, region_name=AWS_REGION_NAME,
-                                  aws_access_key_id=AWS_ACCESS_KEY_ID,
-                                  aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+            client = boto3.client("s3", region_name=AWS_REGION_NAME)
             upload_image_from_location = "/tmp/" + we_vote_image_file_name
             # print('-------------- temp file upload to aws ' +  upload_image_from_location)
             content_type = "image/{image_format}".format(image_format=image_format)
@@ -2260,10 +2253,8 @@ class WeVoteImageManager(models.Manager):
         :return:
         """
         try:
-            session = boto3.session.Session(region_name=AWS_REGION_NAME,
-                                            aws_access_key_id=AWS_ACCESS_KEY_ID,
-                                            aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
-            s3 = session.resource(AWS_STORAGE_SERVICE)
+            session = boto3.session.Session(region_name=AWS_REGION_NAME)
+            s3 = session.resource("s3")
             s3.Bucket(AWS_STORAGE_BUCKET_NAME).put_object(Key=we_vote_image_file_location,
                                                           Body=image_file)
             image_stored_to_aws = True
@@ -2282,9 +2273,7 @@ class WeVoteImageManager(models.Manager):
         :return:
         """
         try:
-            client = boto3.client(AWS_STORAGE_SERVICE, region_name=AWS_REGION_NAME,
-                                  aws_access_key_id=AWS_ACCESS_KEY_ID,
-                                  aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+            client = boto3.client("s3", region_name=AWS_REGION_NAME)
             download_image_at_location = "/tmp/" + we_vote_image_file_location
             client.download_file(AWS_STORAGE_BUCKET_NAME, we_vote_image_file_location, download_image_at_location)
             image_retrieved_from_aws = True

--- a/organization/controllers_fastly.py
+++ b/organization/controllers_fastly.py
@@ -218,11 +218,10 @@ def route53_record_exists(domain_name):
     response = client.list_resource_record_sets(
         HostedZoneId=AWS_HOSTED_ZONE_ID,
         StartRecordName=domain_name,
-        StartRecordType='CNAME',
         MaxItems='1',
     )
     for record in response.get('ResourceRecordSets', []):
-        if record['Name'].rstrip('.') == domain_name and record['Type'] == 'CNAME':
+        if record['Name'].rstrip('.') == domain_name:
             return True
     return False
 

--- a/organization/controllers_fastly.py
+++ b/organization/controllers_fastly.py
@@ -213,6 +213,20 @@ def activate_new_fastly_config_version(new_fastly_version_number):
     return json_results
 
 
+def route53_record_exists(domain_name):
+    client = boto3.client('route53')
+    response = client.list_resource_record_sets(
+        HostedZoneId=AWS_HOSTED_ZONE_ID,
+        StartRecordName=domain_name,
+        StartRecordType='CNAME',
+        MaxItems='1',
+    )
+    for record in response.get('ResourceRecordSets', []):
+        if record['Name'].rstrip('.') == domain_name and record['Type'] == 'CNAME':
+            return True
+    return False
+
+
 def route53_request(new_domain, action):
     status = ""
     success = True
@@ -254,6 +268,9 @@ def route53_request(new_domain, action):
 def add_subdomain_route53_record(new_subdomain):
     new_full_domain = "{new_subdomain}.wevote.us".format(new_subdomain=new_subdomain)
     logging.info("Adding DNS record for domain [%s]", new_full_domain)
+    if route53_record_exists(new_full_domain):
+        logging.warning("DNS record already exists for domain [%s]", new_full_domain)
+        return {'status': "ROUTE53_RECORD_ALREADY_EXISTS ", 'success': False}
     results = route53_request(new_full_domain, 'CREATE')
     logging.info(results['status'])
     json_status = {

--- a/organization/controllers_fastly.py
+++ b/organization/controllers_fastly.py
@@ -8,9 +8,7 @@ import logging
 import requests
 from wevote_functions.functions import positive_value_exists
 
-AWS_ACCESS_KEY_ID = get_environment_variable("AWS_ACCESS_KEY_ID")
 AWS_HOSTED_ZONE_ID = get_environment_variable("AWS_HOSTED_ZONE_ID")
-AWS_SECRET_ACCESS_KEY = get_environment_variable("AWS_SECRET_ACCESS_KEY")
 AWS_REGION_NAME = get_environment_variable("AWS_REGION_NAME")
 FASTLY_API_HOSTNAME = get_environment_variable("FASTLY_API_HOSTNAME")
 FASTLY_API_SERVICE_ID = get_environment_variable("FASTLY_API_SERVICE_ID")
@@ -220,8 +218,7 @@ def route53_request(new_domain, action):
     success = True
     status += "ADDING_ROUTE53_FOR_DOMAIN: " + str(new_domain) + " " + str(action) + " "
     try:
-        client = boto3.client('route53',
-                              aws_access_key_id=AWS_ACCESS_KEY_ID, aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+        client = boto3.client('route53')
         response = client.change_resource_record_sets(
             HostedZoneId=AWS_HOSTED_ZONE_ID,
             ChangeBatch={

--- a/retrieve_tables/controllers_master.py
+++ b/retrieve_tables/controllers_master.py
@@ -375,16 +375,11 @@ def backup_one_table_to_s3_controller(voter_api_device_id, table_name):
         # command_str, filename = make_filename_and_command(table_name)
         try:
             import boto3
-            AWS_ACCESS_KEY_ID = get_environment_variable("AWS_ACCESS_KEY_ID")
-            AWS_SECRET_ACCESS_KEY = get_environment_variable("AWS_SECRET_ACCESS_KEY")
             AWS_REGION_NAME = get_environment_variable("AWS_REGION_NAME")
             AWS_STORAGE_BUCKET_NAME = get_environment_variable("AWS_STORAGE_BUCKET_NAME")
-            AWS_STORAGE_SERVICE = "s3"
 
-            session = boto3.session.Session(region_name=AWS_REGION_NAME,
-                                            aws_access_key_id=AWS_ACCESS_KEY_ID,
-                                            aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
-            s3 = session.resource(AWS_STORAGE_SERVICE)
+            session = boto3.session.Session(region_name=AWS_REGION_NAME)
+            s3 = session.resource("s3")
 
             ts = '{:.2f} seconds'.format(time.time() - t0)
             print(f"About to dump table at {ts} seconds")


### PR DESCRIPTION
## Summary

Removes all hard-coded AWS credentials across the codebase, replacing them with ECS task IAM role permissions. Also improves Route53 DNS record handling to prevent accidental overwrites.

## Changes
- `organization/controllers_fastly.py` — use task role for Route53 updates
- `apis_v1/views/views_extension.py` — remove hard-coded credentials
- `email_outbound/functions.py` — remove hard-coded credentials
- `image/models.py` — remove hard-coded credentials
- `retrieve_tables/controllers_master.py` — remove hard-coded credentials

## Additional Fixes
- Check for **any** existing DNS record type (not just CNAMEs) before adding a new Route53 record, preventing accidental overrides of required infrastructure records

## Motivation
Hard-coded credentials are a security liability. Using the ECS task role is the AWS-recommended approach — no secrets to rotate, no risk of leakage, and proper least-privilege access.