### PR TITLE
WV-2304: Update like and dislike counts for candidates, politicians and campaign objects so that counts are unified across ballot, candidate search and politician pages

### DIFF
--- a/ballot/controllers.py
+++ b/ballot/controllers.py
@@ -2915,17 +2915,23 @@ def generate_ballot_item_list_from_object_list(
                 candidates_to_display = []
                 if results['candidate_list_found']:
                     candidate_list = results['candidate_list']
-                    for candidate in candidate_list:
-                        candidate_dict_results = generate_candidate_dict_from_candidate_object(
-                            candidate=candidate,
-                            google_civic_election_id=google_civic_election_id,
-                            office_id=office_id,
-                            office_name=office_name,
-                            office_we_vote_id=office_we_vote_id,
-                        )
-                        if candidate_dict_results['success']:
-                            candidate_dict = candidate_dict_results['candidate_dict']
-                            candidates_to_display.append(candidate_dict)
+                    # update candidate support and oppose counts in bulk
+                    from candidate.controllers import refresh_candidate_supporters_count_from_politician
+                    refresh_candidate_results = refresh_candidate_supporters_count_from_politician(candidate_list)
+                    if refresh_candidate_results['success']:
+                        for candidate in candidate_list:
+                            candidate_dict_results = generate_candidate_dict_from_candidate_object(
+                                candidate=candidate,
+                                google_civic_election_id=google_civic_election_id,
+                                office_id=office_id,
+                                office_name=office_name,
+                                office_we_vote_id=office_we_vote_id,
+                            )
+                            if candidate_dict_results['success']:
+                                candidate_dict = candidate_dict_results['candidate_dict']
+                                candidates_to_display.append(candidate_dict)
+                    else:
+                         status += refresh_candidate_results['status']
             except Exception as e:
                 status += 'FAILED retrieve_all_candidates_for_office. ' + str(e) + " "
                 candidates_to_display = []

--- a/campaign/controllers.py
+++ b/campaign/controllers.py
@@ -1,7 +1,9 @@
 # campaign/controllers.py
 # Brought to you by We Vote. Be good.
 # -*- coding: UTF-8 -*-
+from django.db import transaction
 
+from politician.models import PoliticianManager
 from .models import CampaignX, CampaignXListedByOrganization, CampaignXManager, CampaignXNewsItem, CampaignXOwner, \
     CampaignXPolitician, CampaignXSupporter, CAMPAIGNX_UNIQUE_ATTRIBUTES_TO_BE_CLEARED, CAMPAIGNX_UNIQUE_IDENTIFIERS, \
     FINAL_ELECTION_DATE_COOL_DOWN
@@ -482,6 +484,10 @@ def campaignx_retrieve_for_api(  # campaignRetrieve & campaignRetrieveAsOwner (N
     campaignx = results['campaignx']
     campaignx_owner_list = results['campaignx_owner_list']
     seo_friendly_path_list = results['seo_friendly_path_list']
+
+    refresh_campaignx_results = refresh_campaignx_supporters_count_from_politician_object(campaignx)
+    if not refresh_campaignx_results['success']:
+        status += refresh_campaignx_results['status']
 
     if hasattr(campaignx, 'we_vote_id'):
         # We need to know all the politicians this voter can vote for, so we can figure out
@@ -1231,6 +1237,76 @@ def refresh_campaignx_supporters_count_for_campaignx_we_vote_id_list(campaignx_w
     }
     return results
 
+
+def refresh_campaignx_supporters_count_from_politician_object(one_campaignx):
+    """
+    Pass in a CampaignX model instance to sync counts from its linked politician.
+    """
+    error_message_to_print = ''
+    status = ''
+    success = True
+    update_message = ''
+    politician_manager = PoliticianManager()
+
+    if not one_campaignx or not hasattr(one_campaignx, 'we_vote_id'):
+        return {
+            'success': False,
+            'status': 'INVALID_CAMPAIGNX_OBJECT',
+            'error_message_to_print': 'The object passed is not a valid CampaignX instance.',
+        }
+
+    try:
+        # Wrap in atomic transaction
+        with transaction.atomic():
+            if positive_value_exists(one_campaignx.linked_politician_we_vote_id):
+                # Retrieve with row locking (read_only=False, for_update=True)
+                pol_results = politician_manager.retrieve_politician(
+                    politician_we_vote_id=one_campaignx.linked_politician_we_vote_id,
+                    read_only=False,
+                    for_update=True)
+
+                if pol_results['politician_found']:
+                    politician = pol_results['politician']
+                    supporters_count = politician.supporters_count
+                    opposers_count = politician.opposers_count
+
+                    changes_found = False
+                    if opposers_count != one_campaignx.opposers_count:
+                        one_campaignx.opposers_count = opposers_count
+                        changes_found = True
+                    if supporters_count != one_campaignx.supporters_count:
+                        one_campaignx.supporters_count = supporters_count
+                        changes_found = True
+
+                    if changes_found:
+                        # Save changes
+                        one_campaignx.save()
+                        update_message = "CampaignX updated from Politician counts."
+                    else:
+                        update_message = "No changes found; counts already match."
+                else:
+                    success = False
+                    status = "POLITICIAN_NOT_FOUND"
+                    error_message_to_print = "Politician not found for ID: " + str(
+                        one_campaignx.linked_politician_we_vote_id)
+            else:
+                success = False
+                status = "NO_LINKED_POLITICIAN"
+                error_message_to_print = "CampaignX {id} has no linked_politician_we_vote_id.".format(
+                    id=one_campaignx.we_vote_id)
+
+    except Exception as e:
+        success = False
+        status = "ERROR_REFRESHING_CAMPAIGNX_OBJECT"
+        error_message_to_print = str(e)
+
+    results = {
+        'error_message_to_print': error_message_to_print,
+        'status': status,
+        'success': success,
+        'update_message': update_message,
+    }
+    return results
 
 def refresh_campaignx_supporters_count_in_all_children(request=None, campaignx_we_vote_id_list=[]):
     # Now push updates to campaignx entries out to candidates and politicians linked to the campaignx entries

--- a/candidate/controllers.py
+++ b/candidate/controllers.py
@@ -5,6 +5,8 @@ import datetime as the_other_datetime
 import json
 import urllib.request
 from socket import timeout
+
+from django.db import transaction
 from django.db.models import Q
 from django.http import HttpResponse
 from django.utils.timezone import now
@@ -1511,6 +1513,12 @@ def candidates_query_for_api(  # candidatesQuery
             success = results['success']
             status = results['status']
             candidate_list = results['candidate_list_objects']
+            # update candidate support and oppose counts in bulk
+            refresh_candidate_results = refresh_candidate_supporters_count_from_politician(candidate_list)
+            if not refresh_candidate_results['success']:
+                print('refresh_candidate_results did not work in candidates_query_for_api ')
+                status += refresh_candidate_results['status']
+
         except Exception as e:
             status = 'FAILED retrieve_all_candidates_for_upcoming_election. ' \
                      '{error} [type: {error_type}]'.format(error=e, error_type=type(e))
@@ -1861,6 +1869,7 @@ def generate_candidate_dict_from_candidate_object(
         'seo_friendly_path':                candidate.seo_friendly_path,
         'state_code':                       candidate.state_code,
         'supporters_count':                 candidate.supporters_count,
+        'opposers_count':                   candidate.opposers_count,
         'twitter_url':                      candidate.twitter_url,
         'twitter_handle':                   candidate.fetch_twitter_handle(),
         'twitter_description':              candidate.twitter_description
@@ -1880,6 +1889,77 @@ def generate_candidate_dict_from_candidate_object(
     }
     return results
 
+
+def refresh_candidate_supporters_count_from_politician(candidate_list=[]):
+    error_message_to_print = ''
+    status = ''
+    success = True
+    update_message = ''
+    candidate_bulk_update_list = []
+    candidate_updates_made = 0
+
+    politician_manager = PoliticianManager()
+
+    if not candidate_list:
+        return {
+            'error_message_to_print': "No candidates provided.",
+            'status': "NO_CANDIDATES_PROVIDED",
+            'success': True,
+            'update_message': "",
+        }
+
+    try:
+        with transaction.atomic():
+            for one_candidate in candidate_list:
+                if positive_value_exists(one_candidate.politician_we_vote_id):
+                    # We use for_update=True here.
+                    # Inside the manager, this should trigger .select_for_update()
+                    pol_results = politician_manager.retrieve_politician(
+                        politician_we_vote_id=one_candidate.politician_we_vote_id,
+                        read_only=False,
+                        for_update=True)
+
+                    if pol_results['politician_found']:
+                        politician = pol_results['politician']
+                        supporters_count = politician.supporters_count
+                        opposers_count = politician.opposers_count
+
+                        changes_found = False
+                        # Check if counts differ
+                        if opposers_count != one_candidate.opposers_count:
+                            one_candidate.opposers_count = opposers_count
+                            changes_found = True
+                        if supporters_count != one_candidate.supporters_count:
+                            one_candidate.supporters_count = supporters_count
+                            changes_found = True
+
+                        if changes_found:
+                            candidate_bulk_update_list.append(one_candidate)
+                            candidate_updates_made += 1
+                    else:
+                        status += "POLITICIAN_NOT_FOUND_FOR: " + str(one_candidate.we_vote_id) + " "
+                else:
+                    status += "NO_POLITICIAN_LINK_EXISTS : "
+
+            # Perform the bulk update
+            if candidate_bulk_update_list:
+                CandidateCampaign.objects.bulk_update(
+                    candidate_bulk_update_list, ['opposers_count', 'supporters_count'])
+
+                update_message += \
+                    "{candidate_updates_made:,} Candidate entries updated from Politician counts. " \
+                    "".format(candidate_updates_made=candidate_updates_made)
+
+    except Exception as e:
+        status += "ERROR_IN_REFRESH_ATOMIC_BLOCK: {e} ".format(e=e)
+        success = False
+
+    return {
+        'error_message_to_print': error_message_to_print,
+        'status': status,
+        'success': success,
+        'update_message': update_message,
+    }
 
 def refresh_candidate_data_from_master_tables(candidate_we_vote_id):
     # Pull from ContestOffice and TwitterUser tables and update CandidateCampaign table

--- a/politician/models.py
+++ b/politician/models.py
@@ -1139,6 +1139,7 @@ class PoliticianManager(models.Manager):
             politician_id=0,
             politician_we_vote_id='',
             read_only=False,
+            for_update=False,
             seo_friendly_path='',
             voter_we_vote_id=None):
         error_result = False
@@ -1152,6 +1153,8 @@ class PoliticianManager(models.Manager):
             if positive_value_exists(politician_id):
                 if positive_value_exists(read_only):
                     politician = Politician.objects.using('readonly').get(id=politician_id)
+                elif positive_value_exists(for_update):
+                    politician = Politician.objects.select_for_update().get(id=politician_id)
                 else:
                     politician = Politician.objects.get(id=politician_id)
                 politician_id = politician.id
@@ -1160,6 +1163,8 @@ class PoliticianManager(models.Manager):
             elif positive_value_exists(politician_we_vote_id):
                 if positive_value_exists(read_only):
                     politician = Politician.objects.using('readonly').get(we_vote_id=politician_we_vote_id)
+                elif positive_value_exists(for_update):
+                    politician = Politician.objects.select_for_update().get(we_vote_id=politician_we_vote_id)
                 else:
                     politician = Politician.objects.get(we_vote_id=politician_we_vote_id)
                 politician_id = politician.id
@@ -1168,6 +1173,8 @@ class PoliticianManager(models.Manager):
             elif positive_value_exists(seo_friendly_path):
                 if positive_value_exists(read_only):
                     politician = Politician.objects.using('readonly').get(seo_friendly_path__iexact=seo_friendly_path)
+                elif positive_value_exists(for_update):
+                    politician = Politician.objects.select_for_update().get(seo_friendly_path__iexact=seo_friendly_path)
                 else:
                     politician = Politician.objects.get(seo_friendly_path__iexact=seo_friendly_path)
                 politician_id = politician.id


### PR DESCRIPTION
- Added bulk update function refresh_candidate_supporters_count_from_politician in candidate/controllers.py to update candidate counts from politician
- Added refresh_campaignx_supporters_count_from_politician_object in campaign/controllers.py to match campaign and politician counts
- Did not have access to master follow_followorganization table to verify if like/dislike actions update counts correctly, so that needs to be verified