### PR TITLE
Add pgadmin container to docker compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -69,6 +69,18 @@ services:
     ports:
       - "127.0.0.1:8000:8000" # this allows access to the WeVote API at localhost:8000
 
+  pgadmin:
+    image: dpage/pgadmin4:8.4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PG_ADMIN_EMAIL:-fake_email@wevoteeducation.org}
+      PGADMIN_DEFAULT_PASSWORD: ${PG_ADMIN_PASSWORD:-admin}
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    ports:
+      - "8080:80"
+    networks:
+      - wevote
+
 networks:
   wevote:
     name: wevote
@@ -78,3 +90,4 @@ networks:
 volumes:
   localstack:
   postgres_data:
+  pgadmin_data:

--- a/config/environment_variables-template.json
+++ b/config/environment_variables-template.json
@@ -35,6 +35,10 @@
   "DATABASE_HOST_ANALYTICS":        "",
   "DATABASE_PORT_ANALYTICS":        "",
 
+  "_comment":                       "profile for pgadmin",
+  "PG_ADMIN_EMAIL":                 "fake_email@wevoteeducation.org",
+  "PG_ADMIN_PASSWORD":              "admin",
+  
   "_comment":                       "The connection string for Elastic Search database",
   "ELASTIC_SEARCH_CONNECTION_STRING": "",
 


### PR DESCRIPTION
Runs as expected.

1. `docker compose up --build` to statrt and create the container.
2. Go to `localhost:8080`
3. Default username: `fake_email@wevoteeducation.org`
4. Default Password: `admin`
5. Select `Add New Server`
<img width="692" height="135" alt="image" src="https://github.com/user-attachments/assets/c6ad5816-26dc-4b5d-a745-c2bbcb0cefbc" />
6. Name: `environment_variables.json` value for `DATABASE_NAME`
<img width="696" height="547" alt="image" src="https://github.com/user-attachments/assets/f78e03dc-4a91-4a70-a0c8-740fd57a9bbd" />

- Host name/address: `db`
- Port: 5432
- Maintenance database: postgres
- Username:  `environment_variables.json` value for `DATABASE_USER`
- Password: Whatever password was used when setup up your postgres superuser as in these instructions: https://github.com/mjacquot1/WeVoteServer/blob/develop/docs/README_API_INSTALL_POSTGRES_MAC.md
- Click `Save`
<img width="704" height="560" alt="image" src="https://github.com/user-attachments/assets/3a04dd1f-49b5-44ec-8fe8-f65f18fc1727" />

Results:
![Uploading Screenshot 2026-04-23 at 13-35-38 pgAdmin 4.png…]()

