### PR TITLE
[WV-432] When a candidate or politician entry is saved and choice of photo is changed in the Admin Tools, regenerate background color [Team Review]

### DIFF
--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -2364,6 +2364,12 @@ def candidate_edit_view(request, candidate_id=0, candidate_we_vote_id=""):
         queryset = queryset.filter(candidate_we_vote_id=candidate_we_vote_id)
         queryset = queryset.order_by('-log_datetime')
         change_log_list = list(queryset)
+        if positive_value_exists(candidate_on_stage.we_vote_hosted_profile_image_url_large):
+            if candidate_on_stage.profile_image_background_color_needed is not False:
+                candidate_on_stage.profile_image_background_color = generate_background(candidate_on_stage)
+                candidate_on_stage.profile_image_background_color_needed = False
+                candidate_on_stage.save()
+                messages.add_message(request, messages.INFO, "Background color generated")
         t1 = time()
 
         performance_snapshot = {
@@ -2781,7 +2787,7 @@ def candidate_edit_process_view(request):
     profile_image_type_currently_active = request.POST.get('profile_image_type_currently_active', False)
     redirect_to_candidate_list = positive_value_exists(request.POST.get('redirect_to_candidate_list', False))
     refresh_from_twitter = request.POST.get('refresh_from_twitter', False)
-    regenerate_color = request.POST.get('regenerate_color', False)
+    regenerate_color = positive_value_exists(request.POST.get('regenerate_color', False))
     reject_twitter_link_possibility_id = convert_to_int(request.POST.get('reject_twitter_link_possibility_id', 0))
     remove_duplicate_process = request.POST.get('remove_duplicate_process', False)
     select_for_marking_twitter_link_possibility_ids = request.POST.getlist('select_for_marking_checks[]')
@@ -3337,6 +3343,7 @@ def candidate_edit_process_view(request):
                         candidate_on_stage.we_vote_hosted_profile_image_url_large = None
                         candidate_on_stage.we_vote_hosted_profile_image_url_medium = None
                         candidate_on_stage.we_vote_hosted_profile_image_url_tiny = None
+                        candidate_on_stage.profile_image_background_color_needed = True
                         results = organize_object_photo_fields_based_on_image_type_currently_active(
                             object_with_photo_fields=candidate_on_stage)
                         if results['success']:
@@ -3495,10 +3502,12 @@ def candidate_edit_process_view(request):
             elif profile_image_background_color is not False:
                 if profile_image_background_color == '':
                     candidate_on_stage.profile_image_background_color = None
-                    candidate_on_stage.profile_image_background_color_needed = False
+                    if not candidate_on_stage.profile_image_background_color_needed:
+                        candidate_on_stage.profile_image_background_color_needed = False
                 elif validate_hex(profile_image_background_color):
                     candidate_on_stage.profile_image_background_color = profile_image_background_color
-                    candidate_on_stage.profile_image_background_color_needed = False
+                    if not candidate_on_stage.profile_image_background_color_needed:
+                        candidate_on_stage.profile_image_background_color_needed = False
                 else:
                     messages.add_message(request, messages.ERROR,
                                          'Enter hex as \'#\' followed by six hexadecimal characters 0-9a-f')
@@ -3646,6 +3655,7 @@ def candidate_edit_process_view(request):
                     candidate_on_stage.we_vote_hosted_profile_image_url_large = None
                     candidate_on_stage.we_vote_hosted_profile_image_url_medium = None
                     candidate_on_stage.we_vote_hosted_profile_image_url_tiny = None
+                    candidate_on_stage.profile_image_background_color_needed = True
             if profile_image_type_currently_active is not False:
                 results = organize_object_photo_fields_based_on_image_type_currently_active(
                     object_with_photo_fields=candidate_on_stage,
@@ -3654,9 +3664,7 @@ def candidate_edit_process_view(request):
                 if results['success']:
                     candidate_on_stage = results['object_with_photo_fields']
                     if results['profile_image_default_updated']:
-                        # regenerate_color = True
-                        candidate_on_stage.profile_image_background_color = generate_background(candidate_on_stage)
-                        candidate_on_stage.profile_image_background_color_needed = False
+                        candidate_on_stage.profile_image_background_color_needed = True
                     if positive_value_exists(results['save_changes']):
                         changes_found_dict['is_photo_added'] = True
 

--- a/candidate/views_admin.py
+++ b/candidate/views_admin.py
@@ -3502,12 +3502,8 @@ def candidate_edit_process_view(request):
             elif profile_image_background_color is not False:
                 if profile_image_background_color == '':
                     candidate_on_stage.profile_image_background_color = None
-                    if not candidate_on_stage.profile_image_background_color_needed:
-                        candidate_on_stage.profile_image_background_color_needed = False
                 elif validate_hex(profile_image_background_color):
                     candidate_on_stage.profile_image_background_color = profile_image_background_color
-                    if not candidate_on_stage.profile_image_background_color_needed:
-                        candidate_on_stage.profile_image_background_color_needed = False
                 else:
                     messages.add_message(request, messages.ERROR,
                                          'Enter hex as \'#\' followed by six hexadecimal characters 0-9a-f')

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -2427,7 +2427,7 @@ def politician_edit_process_view(request):
     middle_name = request.POST.get('middle_name', False)
     last_name = request.POST.get('last_name', False)
     profile_image_background_color = request.POST.get('profile_image_background_color', False)
-    regenerate_color = request.POST.get('regenerate_color', False)
+    regenerate_color = positive_value_exists(request.POST.get('regenerate_color', False))
     facebook_url = request.POST.get('facebook_url', False)
     facebook_url2 = request.POST.get('facebook_url2', False)
     facebook_url3 = request.POST.get('facebook_url3', False)
@@ -2755,6 +2755,7 @@ def politician_edit_process_view(request):
                     politician_on_stage.we_vote_hosted_profile_image_url_large = None
                     politician_on_stage.we_vote_hosted_profile_image_url_medium = None
                     politician_on_stage.we_vote_hosted_profile_image_url_tiny = None
+                    politician_on_stage.profile_image_background_color_needed = True  # ← ADD THIS
             if profile_image_type_currently_active is not False:
                 results = organize_object_photo_fields_based_on_image_type_currently_active(
                     object_with_photo_fields=politician_on_stage,
@@ -2763,7 +2764,7 @@ def politician_edit_process_view(request):
                 if results['success']:
                     politician_on_stage = results['object_with_photo_fields']
                     if results['profile_image_default_updated']:
-                        regenerate_color = True
+                        politician_on_stage.profile_image_background_color_needed = True
                         # politician_on_stage.profile_image_background_color = generate_background(politician_on_stage)
                         # politician_on_stage.profile_image_background_color_needed = False
 
@@ -2819,6 +2820,7 @@ def politician_edit_process_view(request):
                         politician_on_stage.we_vote_hosted_profile_image_url_large = None
                         politician_on_stage.we_vote_hosted_profile_image_url_medium = None
                         politician_on_stage.we_vote_hosted_profile_image_url_tiny = None
+                        politician_on_stage.profile_image_background_color_needed = True
                         results = organize_object_photo_fields_based_on_image_type_currently_active(
                             object_with_photo_fields=politician_on_stage)
                         if results['success']:
@@ -2895,10 +2897,12 @@ def politician_edit_process_view(request):
             elif profile_image_background_color is not False:
                 if profile_image_background_color == '':
                     politician_on_stage.profile_image_background_color = None
-                    politician_on_stage.profile_image_background_color_needed = False
+                    if not politician_on_stage.profile_image_background_color_needed:
+                        politician_on_stage.profile_image_background_color_needed = False
                 elif validate_hex(profile_image_background_color):
                     politician_on_stage.profile_image_background_color = profile_image_background_color
-                    politician_on_stage.profile_image_background_color_needed = False
+                    if not politician_on_stage.profile_image_background_color_needed:
+                        politician_on_stage.profile_image_background_color_needed = False
                 else:
                     messages.add_message(request, messages.ERROR,
                                          'Enter hex as \'#\' followed by six hexadecimal characters 0-9a-f')
@@ -3358,7 +3362,6 @@ def politician_edit_process_view(request):
 
             # #################################################
             t0 = time()
-            # Save politician object
             politician_on_stage.save()
             politician_we_vote_id = politician_on_stage.we_vote_id
             vote_usa_politician_id = politician_on_stage.vote_usa_politician_id

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -2755,7 +2755,7 @@ def politician_edit_process_view(request):
                     politician_on_stage.we_vote_hosted_profile_image_url_large = None
                     politician_on_stage.we_vote_hosted_profile_image_url_medium = None
                     politician_on_stage.we_vote_hosted_profile_image_url_tiny = None
-                    politician_on_stage.profile_image_background_color_needed = True  # ← ADD THIS
+                    politician_on_stage.profile_image_background_color_needed = True
             if profile_image_type_currently_active is not False:
                 results = organize_object_photo_fields_based_on_image_type_currently_active(
                     object_with_photo_fields=politician_on_stage,

--- a/politician/views_admin.py
+++ b/politician/views_admin.py
@@ -2897,12 +2897,8 @@ def politician_edit_process_view(request):
             elif profile_image_background_color is not False:
                 if profile_image_background_color == '':
                     politician_on_stage.profile_image_background_color = None
-                    if not politician_on_stage.profile_image_background_color_needed:
-                        politician_on_stage.profile_image_background_color_needed = False
                 elif validate_hex(profile_image_background_color):
                     politician_on_stage.profile_image_background_color = profile_image_background_color
-                    if not politician_on_stage.profile_image_background_color_needed:
-                        politician_on_stage.profile_image_background_color_needed = False
                 else:
                     messages.add_message(request, messages.ERROR,
                                          'Enter hex as \'#\' followed by six hexadecimal characters 0-9a-f')


### PR DESCRIPTION
**PR Description**
**Title**: Fix background color regeneration when photo choice changes in Admin Tools
**Description**:
When a candidate or politician entry is saved and the choice of photo is changed in the Admin Tools, the profile image background color should regenerate to match the new photo. This was broken due to several issues in both _politician/views_admin.py_ and _candidate/views_admin.py._
Root causes fixed:

1. _regenerate_color_ **was always truthy** — It was read from the form as a raw string. An empty string _''_ is not _False_ in Python, so the color was being regenerated on every save even when the admin never clicked the regenerate button. This wiped out the _profile_image_background_color_needed_ flag before it could be saved. Fixed by wrapping with _positive_value_exists_().

2. **Photo type switch path regenerated immediately with wrong photo** — When switching photo type, _generate_background_() was called immediately before the new photo was fully active, generating the wrong color. Fixed by removing the immediate generation and instead setting _profile_image_background_color_needed = True_ to let the edit view handle it on next page load.

3. **Photo delete path never set the flag** — When a photo was deleted, _profile_image_background_color_needed_ was never set to _True_, so the color was never updated. Fixed by adding the flag.

4. **Ballotpedia URL cleared path never set the flag** — Same issue as photo delete. Fixed by adding the flag.

5. _profile_image_background_color_ empty string was overriding the flag — When the color field came in as empty from the form, it unconditionally set needed = False, wiping our flag. Fixed by removing the unnecessary flag assignment from this path entirely.

6. _candidate_edit_view_ was missing the color generation trigger — _politician_edit_view_ already had logic to check the flag on page load and generate the color. _candidate_edit_view_ was missing this entirely. Fixed by adding the same trigger.

**Testing**:
Verified background color updates when switching photo type on a politician
Verified background color updates when switching photo type on a candidate