### PR TITLE
[WV-775] Issues with .svg, .tiff, .gif type image files while uploading profile photo [Team Review]

### DIFF
--- a/image/controllers.py
+++ b/image/controllers.py
@@ -2296,9 +2296,6 @@ def cache_voter_master_uploaded_image(
     :param voter_we_vote_id:
     :return:
     """
-    # TEMP DEBUG
-    print("DEBUG frames at entry:", getattr(python_image_library_image, 'n_frames', 1))
-    print("DEBUG format at entry:", python_image_library_image.format)
     time0 = log_and_time_cache_action(True, 0, 'cache_voter_master_uploaded_image')
     we_vote_parent_image_id = None
     success = False
@@ -2335,7 +2332,6 @@ def cache_voter_master_uploaded_image(
 
     # image file validation and get source image properties
     analyze_source_images_results = analyze_image_in_memory(python_image_library_image)
-    print("DEBUG frames in analyze:", getattr(python_image_library_image, 'n_frames', 1))
 
     if not analyze_source_images_results['image_url_valid']:
         error_results = {

--- a/image/controllers.py
+++ b/image/controllers.py
@@ -2296,6 +2296,9 @@ def cache_voter_master_uploaded_image(
     :param voter_we_vote_id:
     :return:
     """
+    # TEMP DEBUG
+    print("DEBUG frames at entry:", getattr(python_image_library_image, 'n_frames', 1))
+    print("DEBUG format at entry:", python_image_library_image.format)
     time0 = log_and_time_cache_action(True, 0, 'cache_voter_master_uploaded_image')
     we_vote_parent_image_id = None
     success = False
@@ -2332,6 +2335,7 @@ def cache_voter_master_uploaded_image(
 
     # image file validation and get source image properties
     analyze_source_images_results = analyze_image_in_memory(python_image_library_image)
+    print("DEBUG frames in analyze:", getattr(python_image_library_image, 'n_frames', 1))
 
     if not analyze_source_images_results['image_url_valid']:
         error_results = {

--- a/image/models.py
+++ b/image/models.py
@@ -2135,20 +2135,28 @@ class WeVoteImageManager(models.Manager):
         try:
             image = Image.open(original_image_local_path)
             media_type = image.get_format_mimetype()
-            # Color
-            if image.has_transparency_data:
-                image = image.convert('RGBA')
-            else:
-                image = image.convert('RGB')
-            # GPS
-            exif = image.getexif()
-            gps_ifd = exif.get_ifd(ExifTags.IFD.GPSInfo)
-            gps_ifd.clear()
-            # Pillow still cannot handle animated images
-            # Forward those to a CDN
+
+            # Check for animated formats FIRST — before any convert() call
+            # convert() strips all animation frames, so we skip it for gif/webp
             if media_type in {'image/gif', 'image/webp'}:
-                pass
+                # Pillow cannot reliably resize animated images frame by frame
+                # The proper long-term fix is Fastly CDN handling, but for now
+                # the pragmatic fix is to copy the original file as-is for animated
+                # formats instead of trying to resize
+                # Copy the original file as-is to preserve all animation frames.
+                import shutil
+                shutil.copy2(original_image_local_path, converted_image_local_path)
             else:
+                # Color conversion (safe for non-animated formats)
+                if image.has_transparency_data:
+                    image = image.convert('RGBA')
+                else:
+                    image = image.convert('RGB')
+                # GPS EXIF stripping
+                exif = image.getexif()
+                gps_ifd = exif.get_ifd(ExifTags.IFD.GPSInfo)
+                gps_ifd.clear()
+                # Resize
                 centering_x = 0.5
                 target_size = (image_width, image_height)
                 if image_type == FACEBOOK_BACKGROUND_IMAGE_NAME:
@@ -2161,13 +2169,14 @@ class WeVoteImageManager(models.Manager):
                     image.save(converted_image_local_path, quality=95, subsampling=0)
                 else:
                     image.save(converted_image_local_path)
-            
+
         except Exception as e:
             exception_message = "FAILED_TO_RESIZE_IMAGE: " + str(e) + " "
             handle_exception(e, logger=logger, exception_message=exception_message)
 
         finally:
-            image.close()
+            if image:
+                image.close()
         
         resized_image_created = True
         
@@ -2212,9 +2221,16 @@ class WeVoteImageManager(models.Manager):
         """
         try:
             image_local_path = "/tmp/" + image_local_path
-            python_image_library_image.save(image_local_path, format=python_image_library_image.format)
+            image_format = python_image_library_image.format
+
+            # Preserve animation frames for GIF and WEBP
+            if image_format and image_format.lower() in {'gif', 'webp'}:
+                python_image_library_image.save(image_local_path, format=image_format, save_all=True)
+            else:
+                python_image_library_image.save(image_local_path, format=image_format)
+
             image_stored = True
-        except HTTPError as error:  # something wrong with url
+        except HTTPError as error:
             image_stored = False
             exception_message = "store_image_locally failed because of http error"
             handle_exception(error, logger=logger, exception_message=exception_message)

--- a/voter/controllers.py
+++ b/voter/controllers.py
@@ -4769,24 +4769,27 @@ def voter_save_photo_from_file_reader(
                     byte_data = svg2png(bytestring=byte_data)
                 except Exception as e:
                     status += "PROBLEM_CONVERTING_SVG_TO_PNG: {error} ".format(error=e)
+
             image_data_source = BytesIO(byte_data)
-            image = None
-            image_types_to_check = ["gif", "tiff"]
-            if img_dict and img_dict["type"] and any(
-                    image_type in img_dict["type"].lower() for image_type in image_types_to_check):
-                image = Image.open(image_data_source)
-                image_data_destination = BytesIO()
-                image.save(image_data_destination, format="WEBP", save_all=True, loop=0)
-                image = Image.open(image_data_destination)
-            else:
-                image = Image.open(image_data_source)
+            image = Image.open(image_data_source)
+
             format_to_cache = image.format
             if format_to_cache and format_to_cache.lower() == "mpo":
-                # An MPO file is a stereoscopic image consisting of two overlapping 2D images in JPG format
                 format_to_cache = "JPEG"
-            python_image_library_image = ImageOps.exif_transpose(image)
-            image_copy = python_image_library_image.copy()
-            image_copy.thumbnail((PROFILE_IMAGE_ORIGINAL_MAX_WIDTH, PROFILE_IMAGE_ORIGINAL_MAX_HEIGHT), Image.Resampling.LANCZOS)
+
+            # Check if animated BEFORE any processing that would strip frames
+            is_animated = getattr(image, 'n_frames', 1) > 1
+
+            if is_animated:
+                # Skip exif_transpose and thumbnail — both strip animation frames
+                python_image_library_image = image
+            else:
+                python_image_library_image = ImageOps.exif_transpose(image)
+                image_copy = python_image_library_image.copy()
+                image_copy.thumbnail(
+                    (PROFILE_IMAGE_ORIGINAL_MAX_WIDTH, PROFILE_IMAGE_ORIGINAL_MAX_HEIGHT),
+                    Image.Resampling.LANCZOS)
+
             python_image_library_image.format = format_to_cache
             image_data_found = True
         except Exception as e:


### PR DESCRIPTION
Summary
This PR fixes a regression introduced by PR #3052 where animated GIF and WEBP images uploaded as profile photos lost their animation — only the first frame was being saved. GIFs were also being incorrectly converted to WEBP format.

The bug had multiple layers, all in the image processing pipeline:

**Layer 1** — `_voter/controllers.py voter_save_photo_from_file_reader_` (primary cause)

The uploaded image was being processed before reaching the caching code. Two things were happening:

1. GIFs were being converted to WEBP unconditionally:
`# Old broken code
image_types_to_check = ["gif", "tiff"]
if img_dict and img_dict["type"] and any(...):
    image.save(image_data_destination, format="WEBP", save_all=True, loop=0)
    image = Image.open(image_data_destination)
`

2.`ImageOps.exif_transpose()` and `thumbnail()` were being called on all images including animated ones — both strip animation frames. 

By the time the image reached cache_voter_master_uploaded_image it already had only 1 frame.

**Layer 2** — `_image/models.py resize_we_vote_master_image_`
`image.convert()` was being called before checking if the image was animated. convert() strips all animation frames, so even if the master survived with frames intact, the resized versions would lose them.

**Layer 3** — `_image/models.py store_python_image_locally_`
save_all=True was not being passed when saving GIF/WEBP, so only the first frame was written to disk.

**Fix**
`_voter/controllers.py_`

- Removed the unconditional GIF→WEBP conversion block

- Added is_animated check using getattr(image, 'n_frames', 1) > 1

- Skipped ImageOps.exif_transpose() and thumbnail() for animated images since both strip frames

`# New code
is_animated = getattr(image, 'n_frames', 1) > 1

```
if is_animated:
    # Skip exif_transpose and thumbnail — both strip animation frames
    python_image_library_image = image
else:
    python_image_library_image = ImageOps.exif_transpose(image)
    image_copy = python_image_library_image.copy()
    image_copy.thumbnail(
        (PROFILE_IMAGE_ORIGINAL_MAX_WIDTH, PROFILE_IMAGE_ORIGINAL_MAX_HEIGHT),
        Image.Resampling.LANCZOS)`
```
`_image/models.py — resize_we_vote_master_image_`

- Moved media_type check to happen before any convert() call

- Used shutil.copy2 to copy animated files as-is instead of resizing frame by frame (Pillow cannot reliably resize animated images)

- Fixed finally block to add if image: null check

`# New code
if media_type in {'image/gif', 'image/webp'}:
    # Pillow cannot reliably resize animated images frame by frame
    # Copy the original file as-is to preserve all animation frames
    import shutil
    shutil.copy2(original_image_local_path, converted_image_local_path)
else:
    # resize logic for non-animated formats
    ...`
image/models.py — _`store_python_image_locally`_

- Added save_all=True for GIF/WEBP formats
`# New code
if image_format and image_format.lower() in {'gif', 'webp'}:
    python_image_library_image.save(image_local_path, format=image_format, save_all=True)
else:
    python_image_library_image.save(image_local_path, format=image_format)`

**Known Limitations / Follow-up Required**

- Animated GIF and WEBP resized versions are copied as-is from the master (not resized) because Pillow cannot reliably resize animated images frame by frame. The proper long-term fix is to configure the Fastly CDN image optimizer to handle animated formats. A separate ticket should be raised for this.

- CDN should also be reconfigured to leave GIFs as-is and not convert them to WEBP.
