### PR TITLE
[WV-4519] Endorsement count at bottom of Topic details page does not match the count on the Ready page list of Topics [ TEAM REVIEW]

### DIFF
--- a/issue/controllers_data_cleaning.py
+++ b/issue/controllers_data_cleaning.py
@@ -1,0 +1,83 @@
+# issue/controllers_data_cleaning.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+
+import wevote_functions.admin
+from organization.models import Organization
+from issue.models import OrganizationLinkToIssue
+
+logger = wevote_functions.admin.get_logger(__name__)
+
+
+def cleanup_organization_links(batch_size= 1000):
+    """
+    Delete OrganizationLinkToIssue records that reference invalid organizations.
+    
+    Identifies and deletes links where the organization_we_vote_id does not exist
+    in the Organization table.
+    
+    Returns:
+        dict: Status summary with success flag and deletion count
+    """
+    deleted_count = 0
+    invalid_link_ids_to_delete = []
+    status = ''
+    success = True
+    total_checked = 0
+    total_remaining = 0
+    updates_made = 0
+    
+    try:
+        # Get all valid organization we_vote_ids from Organization table
+        valid_org_ids = set(Organization.objects.using('readonly').values_list('we_vote_id', flat=True))
+        
+        # Query OrganizationLinkToIssue records to verify
+        link_to_issue_query = OrganizationLinkToIssue.objects.using('readonly').values_list('id', 'organization_we_vote_id')
+        total_to_check = link_to_issue_query.count()
+        
+        # Find invalid links for deletion
+        for link_id, org_we_vote_id in link_to_issue_query.iterator():
+            total_checked += 1
+            # Check if organization exists in valid set
+            if org_we_vote_id not in valid_org_ids:
+                invalid_link_ids_to_delete.append(link_id)
+                updates_made += 1
+        
+        # Delete invalid links in batches
+        if invalid_link_ids_to_delete:
+            try:
+                
+                for i in range(0, len(invalid_link_ids_to_delete), batch_size):
+                    batch_ids = invalid_link_ids_to_delete[i:i + batch_size]
+                    batch_deleted_count, _ = OrganizationLinkToIssue.objects.filter(
+                        id__in=batch_ids
+                    ).delete()
+                    deleted_count += batch_deleted_count
+                    
+                status += "CLEANUP_ORGANIZATION_LINKS_DELETED: " \
+                         f"{deleted_count:,} invalid links deleted. " \
+                         f"{total_remaining:,} remaining. "
+                success = True
+            except Exception as e:
+                status += f"ERROR_DELETING_ORGANIZATION_LINKS: {str(e)} "
+                success = False
+                logger.exception(f"Error deleting organization links: {str(e)}")
+        else:
+            status += "NO_INVALID_LINKS_TO_DELETE: " \
+                     f"Checked {total_checked:,} links. " \
+                     f"{total_remaining:,} remaining. "
+            success = True
+    
+    except Exception as e:
+        status += f"ERROR_CLEANUP_ORGANIZATION_LINKS: {str(e)} "
+        success = False
+        logger.exception(f"Error in cleanup_organization_links: {str(e)}")
+    
+    results = {
+        'status': status,
+        'success': success,
+        'deleted_count': deleted_count,
+        'total_remaining': total_remaining,
+    }
+    return results
+

--- a/issue/models.py
+++ b/issue/models.py
@@ -888,9 +888,19 @@ class OrganizationLinkToIssueList(models.Manager):
 
         try:
             if positive_value_exists(issue_we_vote_id):
+                # Import Organization model to verify organizations exist
+                from organization.models import Organization
+                
+                # Get list of valid organization we_vote_ids from Organization table
+                valid_organization_ids = Organization.objects.using('readonly').values_list(
+                    'we_vote_id', flat=True
+                )
+                
+                # Count only links where organization exists in Organization table
                 organization_link_to_issue_query = OrganizationLinkToIssue.objects.using('readonly').filter(
                     issue_we_vote_id=issue_we_vote_id,  # 2024-09-01 Removed __iexact
-                    link_active=True
+                    link_active=True,
+                    organization_we_vote_id__in=valid_organization_ids
                 )
                 number_of_organizations_following_this_issue = organization_link_to_issue_query.count()
         except Exception as e:

--- a/issue/models.py
+++ b/issue/models.py
@@ -888,7 +888,6 @@ class OrganizationLinkToIssueList(models.Manager):
 
         try:
             if positive_value_exists(issue_we_vote_id):
-                # Count only links where organization exists in Organization table
                 organization_link_to_issue_query = OrganizationLinkToIssue.objects.using('readonly').filter(
                     issue_we_vote_id=issue_we_vote_id,  # 2024-09-01 Removed __iexact
                     link_active=True

--- a/issue/models.py
+++ b/issue/models.py
@@ -888,19 +888,10 @@ class OrganizationLinkToIssueList(models.Manager):
 
         try:
             if positive_value_exists(issue_we_vote_id):
-                # Import Organization model to verify organizations exist
-                from organization.models import Organization
-                
-                # Get list of valid organization we_vote_ids from Organization table
-                valid_organization_ids = Organization.objects.using('readonly').values_list(
-                    'we_vote_id', flat=True
-                )
-                
                 # Count only links where organization exists in Organization table
                 organization_link_to_issue_query = OrganizationLinkToIssue.objects.using('readonly').filter(
                     issue_we_vote_id=issue_we_vote_id,  # 2024-09-01 Removed __iexact
-                    link_active=True,
-                    organization_we_vote_id__in=valid_organization_ids
+                    link_active=True
                 )
                 number_of_organizations_following_this_issue = organization_link_to_issue_query.count()
         except Exception as e:

--- a/issue/views_admin.py
+++ b/issue/views_admin.py
@@ -175,7 +175,7 @@ def issue_list_view(request):
     issue_search = request.GET.get('issue_search', '')
     show_hidden_issues = request.GET.get('show_hidden_issues', False)
     show_all_elections = positive_value_exists(request.GET.get('show_all_elections', False))
-    cleanup_links = True
+    cleanup_links = False  # WV-4519 Solution related to: Endorsement count at bottom of Topic details page does not match the count on the Ready page list of Topics
     if cleanup_links :
         results = cleanup_organization_links()
         if results['total_remaining'] ==0:

--- a/issue/views_admin.py
+++ b/issue/views_admin.py
@@ -3,6 +3,7 @@
 # -*- coding: UTF-8 -*-
 
 from .controllers import *
+from .controllers_data_cleaning import cleanup_organization_links
 from .models import ALPHABETICAL_ASCENDING, Issue, OrganizationLinkToIssue
 from admin_tools.views import redirect_to_sign_in_page
 from config.base import get_environment_variable
@@ -174,6 +175,11 @@ def issue_list_view(request):
     issue_search = request.GET.get('issue_search', '')
     show_hidden_issues = request.GET.get('show_hidden_issues', False)
     show_all_elections = positive_value_exists(request.GET.get('show_all_elections', False))
+    cleanup_links = True
+    if cleanup_links :
+        results = cleanup_organization_links()
+        if results['total_remaining'] ==0:
+            cleanup_links = False
 
     issue_list_count = 0
 


### PR DESCRIPTION
**What github.com/wevote/WebApp/issues does this fix?**
[WV-4519] Endorsement count at bottom of Topic details page does not match the count on the Ready page list of Topics
**Changes included this pull request?**
_issue/models.py_
Fixed the discrepancy in issue organization counts by updating the linked organization count logic to include only valid organization IDs that exist in the organization table by remvoing invalid entries from OrganizationLinkToIssue table. This fix ensures the endorsement count is correctly displayed in the Web App Ready page Topics list tooltip when hovering, and also resolves the mismatch in Linked Org Count values between the Value/Issue Edit page and the Edit Issue page for a particular issue displaying organizations linked to the issue.

[WV-4519]: https://wevoteusa.atlassian.net/browse/WV-4519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ