### PR TITLE
[WV-4554]Add a debugging port to the Docker container configuration to enable remote debugging support with the VS Code IDE. [TEAM_REVIEW]

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -62,6 +62,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=test
       - AWS_DEFAULT_REGION=us-east-1
       - AWS_SQS_WEB_QUEUE_URL=http://localstack:4566/000000000000/job-queue.fifo
+      - PYDEVD_DISABLE_FILE_VALIDATION=1
     volumes:
       - .:/wevote/code
     networks:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -7,7 +7,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 # install python dependencies
 COPY requirements.txt /tmp
-RUN pip install -r /tmp/requirements.txt --no-cache-dir
+RUN pip install -r /tmp/requirements.txt --no-cache-dir && \
+    pip install debugpy
 
 # copy entrypoint script
 COPY docker/dev/entrypoint /usr/local/bin/docker-entrypoint
@@ -19,6 +20,7 @@ RUN useradd wevote && mkdir -p /var/log/wevote /wevote && chown wevote:wevote /v
 WORKDIR /wevote/code
 USER wevote
 EXPOSE 8000
+EXPOSE 5678
 
 ENTRYPOINT ["docker-entrypoint"]
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker/dev/entrypoint
+++ b/docker/dev/entrypoint
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+import debugpy
 
 def log(line: str):
     print(line, flush=True)
@@ -38,7 +39,13 @@ os.system("python manage.py migrate")
 log("Running 'manage.py createsuperuser'")
 os.system("python manage.py createsuperuser --noinput")
 
+# Start debugpy listener
+try:
+    log("Starting debugpy on 0.0.0.0:5678")
+    debugpy.listen(("0.0.0.0", 5678))
+    log("Debugger is ready and waiting for VS Code or PyCharm to attach...")
+except Exception as e:
+    log(f"Error starting debugpy: {e}")
 
 sys.exit(subprocess.call(sys.argv[1:]))
-
 


### PR DESCRIPTION
**What github.com/wevote/WebApp/issues does this fix?**
[WV-4554]Add a debugging port to the Docker container configuration to enable remote debugging support with the VS Code IDE.
**Changes included this pull request?**
- docker/Dockerfile.dev
Added pip install debugpy to enable remote debugging on port 5678.
Exposed port 5678 for the same purpose.
- docker/dev/entrypoint
Started debugpy on 0.0.0.0:5678 to allow VS Code to attach to the debugger.
- compose.yaml
Added PYDEVD_DISABLE_FILE_VALIDATION=1 to the API environment variable list to disable frozen modules validation and avoid missing breakpoints while debugging.

[WV-4554]: https://wevoteusa.atlassian.net/browse/WV-4554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ