### PR TITLE
WV-2423 Add VoteUSA candidate refresh to polling location ballot retrieval

### DIFF
--- a/import_export_batches/views_admin.py
+++ b/import_export_batches/views_admin.py
@@ -43,6 +43,7 @@ from import_export_ballotpedia.controllers import groom_ballotpedia_data_for_pro
 from import_export_ctcl.controllers import CTCL_VOTER_INFO_URL
 from import_export_google_civic.controllers import REPRESENTATIVES_BY_ADDRESS_URL
 from import_export_vote_usa.controllers import VOTE_USA_VOTER_INFO_URL
+from import_export_vote_usa.controllers_candidates import update_existing_candidates_from_candidates_api
 import json
 import math
 from polling_location.models import KIND_OF_LOG_ENTRY_BALLOT_RECEIVED, KIND_OF_LOG_ENTRY_REPRESENTATIVES_RECEIVED, \
@@ -3451,6 +3452,14 @@ def retrieve_ballots_for_polling_locations_api_v4_view(request):
         status += 'FAILED_TO_CREATE_VOLUNTEER_TASK_COMPLETED: ' \
                   '{error} [type: {error_type}]'.format(error=e, error_type=type(e))
 
+    if positive_value_exists(google_civic_election_id) and positive_value_exists(state_code):
+        update_candidates_results = update_existing_candidates_from_candidates_api(
+            google_civic_election_id=google_civic_election_id, 
+            state_code=state_code)
+        if not update_candidates_results['success']:
+            status += 'UPDATE_EXISTING_CANDIDATES_FROM_CANDIDATES_API_FAILED: '
+            status += update_candidates_results.get('status', '')
+            
     if positive_value_exists(use_batch_process):
         from import_export_batches.controllers_batch_process import \
             schedule_retrieve_ballots_for_polling_locations_api_v4

--- a/import_export_vote_usa/controllers.py
+++ b/import_export_vote_usa/controllers.py
@@ -25,6 +25,7 @@ VOTE_USA_CANDIDATE_QUERY_URL = "https://vote-usa.org/api/v1.asmx/candidatesQuery
 VOTE_USA_ELECTION_QUERY_URL = "https://vote-usa.org/api/v1.asmx/electionQuery"
 VOTE_USA_VOTER_INFO_URL = "https://vote-usa.org/api/v1.asmx/voterInfoQuery"
 VOTE_USA_VOTER_INFO_QUERY_TYPE = "voterinfo"
+VOTE_USA_CANDIDATE_QUERY_TYPE = "candidatequery"
 
 HEADERS_FOR_VOTE_USA_API_CALL = {
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',

--- a/import_export_vote_usa/controllers_candidates.py
+++ b/import_export_vote_usa/controllers_candidates.py
@@ -1,0 +1,167 @@
+import json
+import requests
+
+from election.models import ElectionManager
+from exception.models import handle_exception
+from office.models import ContestOffice
+from wevote_functions.functions import (
+    positive_value_exists,
+    extract_vote_usa_office_id,
+    augment_vote_usa_office_id_with_suffix,
+)
+import wevote_functions.admin
+
+from .models import VoteUSAApiCounterManager
+from import_export_vote_usa.controllers import (
+    VOTE_USA_API_KEY, 
+    VOTE_USA_CANDIDATE_QUERY_URL, 
+    HEADERS_FOR_VOTE_USA_API_CALL,
+    VOTE_USA_CANDIDATE_QUERY_TYPE,
+)
+
+
+logger = wevote_functions.admin.get_logger(__name__)
+
+
+def update_existing_candidates_from_candidates_api(google_civic_election_id=0, state_code=''):
+    status = ""
+    success = True
+
+    election_manager = ElectionManager()
+    results = election_manager.retrieve_election(google_civic_election_id)
+    if not results['election_found']:
+        success = False
+        status += 'ELECTION_NOT_FOUND '
+        results = {'success': success, 'status': status}
+        return results
+    
+    election = results['election']
+    election_day = election.election_day_text
+    if not positive_value_exists(election_day):
+        success = False
+        status += 'ELECTION_DAY_MISSING '
+        results = {'success': success, 'status': status}
+        return results
+    election_year_integer = int(election_day[:4])
+
+    if not positive_value_exists(state_code):
+        success = False
+        status += 'STATE_CODE_MISSING '
+        results = {'success': success, 'status': status}
+        return results
+    
+    try:
+        api_key = VOTE_USA_API_KEY
+        response = requests.get(
+            VOTE_USA_CANDIDATE_QUERY_URL,
+            headers=HEADERS_FOR_VOTE_USA_API_CALL,
+            params={
+                "accessKey": api_key,
+                "electionDay": election_day,
+                "state": state_code,
+            },
+            timeout=30
+        )
+        
+        try:
+            structured_json = json.loads(response.text)
+        except json.JSONDecodeError:
+            success = False
+            if 'maxJsonLength' in response.text:
+                status += 'VOTE_USA_CANDIDATES_API_RESPONSE_TOO_LARGE_FOR_VOTE_USA_SERVER '
+            else:
+                status += 'VOTE_USA_CANDIDATES_API_INVALID_RESPONSE: ' + response.text
+            logger.error(f"VoteUSA API unparsable response: {response.text}")
+            results = {'success': success, 'status': status}
+            return results
+
+        candidates_structured_json = structured_json.get('candidates', [])
+        if not positive_value_exists(candidates_structured_json):
+            status += 'NO_CANDIDATES_FOUND_IN_API_RESPONSE '
+            results = {'success': success, 'status': status}
+            return results
+    except Exception as e:
+        success = False
+        status += 'VOTE_USA_CANDIDATES_API_END_POINT_CRASH: ' + str(e) + ' '
+        handle_exception(e, logger=logger, exception_message=status)
+        results = {'success': success, 'status': status}
+        return results
+    
+    if 'success' in structured_json and structured_json['success'] is False:
+        success = False
+        status += 'VOTE_USA_CANDIDATES_API_ERROR: ' + structured_json.get('status', '') + ' '
+        results = {'success': success, 'status': status}
+        return results
+    
+    try:
+        # Use Vote USA API call counter to track the number of queries we are doing each day
+        api_counter_manager = VoteUSAApiCounterManager()
+        api_counter_manager.create_counter_entry(
+            VOTE_USA_CANDIDATE_QUERY_TYPE,
+            google_civic_election_id=google_civic_election_id)
+        
+        vote_usa_candidates_by_office = {}
+        for candidate in candidates_structured_json:
+            contests = candidate.get('contests', [])
+            if not contests:
+                continue
+            raw_vote_usa_office_id = contests[0].get('id', '')
+            if not raw_vote_usa_office_id:
+                continue
+            if raw_vote_usa_office_id not in vote_usa_candidates_by_office:
+                vote_usa_candidates_by_office[raw_vote_usa_office_id] = []
+            vote_usa_candidates_by_office[raw_vote_usa_office_id].append(candidate)
+        
+        # Raw VoteUSA office IDs include the election ID prefix (e.g. 'CA20221108GA|CAStateHouse51')
+        # We extract the base ID and re-append the party suffix for primaries (e.g. 'CAStateHouse51|PD'),
+        # or we use base ID as-is for general elections, special elections, and runoffs. 
+        vote_usa_to_wevote_office_id = {}
+        for raw_vote_usa_office_id in vote_usa_candidates_by_office.keys():
+            base_id = extract_vote_usa_office_id(raw_vote_usa_office_id)
+            suffix = raw_vote_usa_office_id.split('|')[0][-2:]
+            vote_usa_to_wevote_office_id[raw_vote_usa_office_id] = augment_vote_usa_office_id_with_suffix(base_id, suffix)
+            
+        contest_offices = ContestOffice.objects.filter(
+            google_civic_election_id=google_civic_election_id,
+            vote_usa_office_id__in=vote_usa_to_wevote_office_id.values()
+        )
+        
+        contest_office_dict = {office.vote_usa_office_id: office for office in contest_offices}
+
+        from import_export_google_civic.controllers import groom_and_store_google_civic_candidates_json_2021
+        for raw_vote_usa_office_id, office_candidates in vote_usa_candidates_by_office.items():
+            contest_office = contest_office_dict.get(vote_usa_to_wevote_office_id[raw_vote_usa_office_id])
+            if not contest_office:
+                status += 'CONTEST_OFFICE_NOT_FOUND_FOR_VOTE_USA_OFFICE_ID: ' + str(raw_vote_usa_office_id) + \
+                    ' (' + str(len(office_candidates)) + ' candidates skipped) '
+                continue
+            groom_results = groom_and_store_google_civic_candidates_json_2021(
+                candidates_structured_json=office_candidates,
+                google_civic_election_id=google_civic_election_id,
+                state_code=state_code,
+                contest_office_id=contest_office.id,
+                contest_office_we_vote_id=contest_office.we_vote_id,
+                contest_office_name=contest_office.office_name,
+                election_year_integer=election_year_integer,
+                update_or_create_rules={
+                    'create_candidates': False,  # don't create new ones
+                    'update_candidates': True,   # do full update on found ones
+                },
+                use_vote_usa=True,
+                vote_usa_office_id=raw_vote_usa_office_id,
+            )
+            if not groom_results['success']:
+                success = False
+                status += 'GROOM_CANDIDATES_FAILED_FOR_OFFICE: ' + str(raw_vote_usa_office_id) + ' '
+                status += groom_results['status']
+    except Exception as e:
+        success = False
+        status += 'UPDATE_EXISTING_CANDIDATES_FROM_CANDIDATES_API_ERROR: ' + str(e) + ' '
+        handle_exception(e, logger=logger, exception_message=status)
+        results = {'success': success, 'status': status}
+        return results
+
+    return {
+        'success': success,
+        'status': status,
+    }

--- a/wevote_functions/functions.py
+++ b/wevote_functions/functions.py
@@ -1217,7 +1217,6 @@ def extract_nickname_from_full_name(full_name):
 def extract_vote_usa_measure_id(raw_vote_usa_measure_id):
     return extract_vote_usa_office_id(raw_vote_usa_measure_id)
 
-
 def extract_vote_usa_office_id(raw_vote_usa_office_id):
     if positive_value_exists(raw_vote_usa_office_id):
         raw_vote_usa_office_id = raw_vote_usa_office_id.strip()
@@ -1234,8 +1233,14 @@ def extract_vote_usa_office_id(raw_vote_usa_office_id):
     else:
         return ''
 
-
 def augment_vote_usa_office_id(vote_usa_office_id, primary_party=''):
+    """
+    Appends a party suffix to a VoteUSA office ID (as extracted by extract_vote_usa_office_id)
+    for primary elections. Accepts the full party name (e.g. 'Democratic Party', 'Republican Party').
+    For general elections, special elections, and runoffs, returns the ID unchanged.
+    Valid primary parties: Conservative Party, Democratic Party, Green Party,
+    Independent Party, Libertarian Party, Republican Party.
+    """
     if positive_value_exists(primary_party):
         primary_party_suffix = ""
         if primary_party.lower() == 'conservative party':
@@ -1252,6 +1257,18 @@ def augment_vote_usa_office_id(vote_usa_office_id, primary_party=''):
             primary_party_suffix = 'PR'
         if positive_value_exists(primary_party_suffix):
             return vote_usa_office_id + '|' + primary_party_suffix
+    return vote_usa_office_id
+
+def augment_vote_usa_office_id_with_suffix(vote_usa_office_id, primary_party_suffix=''):
+    """
+    Appends a party suffix to a VoteUSA office ID (as extracted by extract_vote_usa_office_id)
+    for primary elections. Accepts the 2-letter suffix directly (e.g. 'PD', 'PR').
+    For general elections, special elections, and runoffs, returns the ID unchanged.
+    Valid primary suffixes: PC, PD, PG, PI, PL, PR.
+    """
+    PRIMARY_SUFFIXES = {'PC', 'PD', 'PG', 'PI', 'PL', 'PR'}
+    if primary_party_suffix in PRIMARY_SUFFIXES:
+        return vote_usa_office_id + '|' + primary_party_suffix
     return vote_usa_office_id
 
 


### PR DESCRIPTION
Fixes WV-2423

Add candidate data refresh from VoteUSA API when retrieving ballots for polling locations

* Create `update_existing_candidates_from_candidates_api` in import_export_vote_usa/controllers_candidates.py -- calls the VoteUSA candidatesQuery endpoint, then updates existing candidates in our database using the returned data. Does not create new candidates.
* Call the new function in `retrieve_ballots_for_polling_locations_api_v4_view` in import_export_batches/views_admin.py
* Add `augment_vote_usa_office_id_with_suffix` to wevote_functions/functions.py to convert raw VoteUSA office IDs to the format stored in our `ContestOffice` table
* Add a docstring to the neighboring `augment_vote_usa_office_id` for consistency
* Add specific error handling for VoteUSA's `maxJsonLength` server limit, which returns an error for large candidate datasets

Testing:
* Manually set a candidate's candidate_name field to a test value, then confirmed it was restored to the correct value after running the update -- verified both by calling `update_existing_candidates_from_candidates_api` directly in the Django shell and via `retrieve_ballots_for_polling_locations_api_v4_view` in the browser (IL 2026 State Primary, google_civic_election_id=1000453).
* Confirmed graceful error handling for large state primaries that exceed VoteUSA's maxJsonLength limit (TX 2022 Democratic Primary, google_civic_election_id=1000145).