### PR TITLE
WV-1001: Fix Follow Topic button not updating followers count on API server

### DIFF
--- a/apis_v1/views/views_voter.py
+++ b/apis_v1/views/views_voter.py
@@ -9,6 +9,7 @@ from sendgrid import sendgrid
 from sendgrid.helpers.mail import Mail, Email, To, Content
 from django.contrib import messages
 from django.core.exceptions import RequestDataTooBig
+from django.db.models import F
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django_user_agents.utils import get_user_agent
@@ -28,7 +29,7 @@ from email_outbound.controllers import voter_email_address_retrieve_for_api, vot
     voter_email_address_verify_for_api
 from email_outbound.models import EmailManager
 from follow.controllers import voter_issue_follow_for_api
-from follow.models import FollowIssueList
+from follow.models import FOLLOWING, FollowIssue, FollowIssueList
 from geoip.controllers import voter_location_retrieve_from_ip_for_api
 from image.controllers import TWITTER, FACEBOOK, cache_master_and_resized_image, create_resized_images
 from import_export_ballotpedia.controllers import voter_ballot_items_retrieve_from_ballotpedia_for_api_v4
@@ -36,7 +37,7 @@ from import_export_facebook.controllers import voter_facebook_sign_in_retrieve_f
     voter_facebook_sign_in_save_auth_for_api, voter_facebook_save_to_current_account_for_api
 from import_export_google_civic.controllers import voter_ballot_items_retrieve_from_google_civic_for_api
 from import_export_twitter.controllers import voter_twitter_save_to_current_account_for_api
-from issue.models import IssueManager
+from issue.models import Issue, IssueManager
 from organization.models import INDIVIDUAL, Organization, OrganizationManager
 from position.controllers import voter_all_positions_retrieve_for_api, \
     voter_position_retrieve_for_api, voter_position_comment_save_for_api, voter_position_visibility_save_for_api
@@ -1519,6 +1520,23 @@ def voter_issue_follow_view(request):  # issueFollow
     user_agent_object = get_user_agent(request)
     ignore_value = positive_value_exists(request.GET.get('ignore', False))
 
+    # Capture the voter's prior follow state for this issue so we can adjust
+    # Issue.issue_followers_count by the actual transition delta (atomic SQL UPDATE)
+    # rather than recounting FollowIssue rows post-toggle. Atomic delta sidesteps a
+    # read-after-write race against the readonly replica, and is robust when the
+    # cached count and the FollowIssue table aren't in sync (e.g. dev environments
+    # where the master sync brings counts but not the underlying rows).
+    voter_we_vote_id = fetch_voter_we_vote_id_from_voter_device_link(voter_device_id)
+    prior_following = False
+    if positive_value_exists(voter_we_vote_id) and positive_value_exists(issue_we_vote_id):
+        try:
+            prior_row = FollowIssue.objects.using('default').get(
+                voter_we_vote_id=voter_we_vote_id,
+                issue_we_vote_id=issue_we_vote_id)
+            prior_following = (prior_row.following_status == FOLLOWING)
+        except FollowIssue.DoesNotExist:
+            prior_following = False
+
     result = voter_issue_follow_for_api(voter_device_id=voter_device_id,
                                         issue_we_vote_id=issue_we_vote_id,
                                         follow_value=follow_value,
@@ -1527,17 +1545,16 @@ def voter_issue_follow_view(request):  # issueFollow
     result['google_civic_election_id'] = google_civic_election_id
 
     try:
-        # Update the issue_followers_count in the issue table now that a new person has followed or unfollowed an issue
-        issue_manager = IssueManager()
-        results = issue_manager.retrieve_issue(
-            issue_we_vote_id=issue_we_vote_id,
-            read_only=False)
-        if results['issue_found']:
-            issue = results['issue']
-            follow_issue_list_manager = FollowIssueList()
-            issue.issue_followers_count = \
-                follow_issue_list_manager.fetch_follow_issue_count_by_issue_we_vote_id(issue_we_vote_id)
-            issue.save()
+        if result.get('success') and positive_value_exists(issue_we_vote_id):
+            now_following = bool(follow_value)
+            if now_following and not prior_following:
+                Issue.objects.filter(we_vote_id=issue_we_vote_id).update(
+                    issue_followers_count=F('issue_followers_count') + 1)
+            elif prior_following and not now_following:
+                Issue.objects.filter(
+                    we_vote_id=issue_we_vote_id,
+                    issue_followers_count__gt=0,
+                ).update(issue_followers_count=F('issue_followers_count') - 1)
     except Exception as e:
         result['status'] += " COULD_NOT_UPDATE_ISSUE_FOLLOWERS_COUNT: " + str(e) + " "
 

--- a/follow/models.py
+++ b/follow/models.py
@@ -724,9 +724,12 @@ class FollowIssueList(models.Model):
 
     @staticmethod
     def fetch_follow_issue_count_by_issue_we_vote_id(issue_we_vote_id):
+        # Query the primary DB (not 'readonly') because this is invoked immediately after a write
+        # in voter_issue_follow_view; the readonly replica can lag and return a pre-write count,
+        # which then gets saved back to Issue.issue_followers_count and effectively loses the update.
         follow_issue_list_length = 0
         try:
-            follow_issue_list_query = FollowIssue.objects.using('readonly').all()
+            follow_issue_list_query = FollowIssue.objects.using('default').all()
             follow_issue_list_query = follow_issue_list_query.filter(issue_we_vote_id=issue_we_vote_id)
             follow_issue_list_query = follow_issue_list_query.filter(following_status=FOLLOWING)
             follow_issue_list_length = follow_issue_list_query.count()


### PR DESCRIPTION
## Summary
Fixes two bugs that caused `Issue.issue_followers_count` to not increment when a voter clicks Follow Topic on the Ready page.

1. **Replica lag race** — `voter_issue_follow_view` writes a new `FollowIssue` row to the primary DB, then immediately calls `FollowIssueList.fetch_follow_issue_count_by_issue_we_vote_id`, which queries `.using('readonly')`. If the readonly replica is lagging and doesn't yet have the new row, the stale (pre-write) count gets saved back to the primary, effectively undoing the increment.
2. **Master Sync count/row skew (dev environments)** — Master Sync brings `Issue.issue_followers_count` (e.g. 1,234 followers) but not the underlying `FollowIssue` rows. After clicking Follow locally there is just one row, so the recount-from-rows approach overwrites 1,234 → 1.

## Fix
- `follow/models.py` — `fetch_follow_issue_count_by_issue_we_vote_id` now queries the primary DB (`'default'`) rather than `'readonly'`, since it's invoked immediately after a write.
- `apis_v1/views/views_voter.py` — Instead of recounting all `FollowIssue` rows after the toggle, capture the voter's prior follow state for this issue and apply an atomic `F('issue_followers_count') ± 1` delta. This sidesteps the replica race entirely and is robust against the dev-env count/row skew. The decrement is guarded with `issue_followers_count__gt=0` so the count can't go negative.

## Test plan
- [ ] Signed-out: click Follow on a Ready-page topic → followers count increments on the API server
- [ ] Signed-in: click Follow → increments; click Unfollow → decrements (and does not go below zero)
- [ ] Toggle Follow rapidly → final count reflects final state with no lost updates
- [ ] Dev environment where `Issue.issue_followers_count` ≫ local `FollowIssue` row count → following does not clobber the cached count

Jira: https://wevoteusa.atlassian.net/browse/WV-1001