### PR TITLE
Introduce OpenTelemetry to enable advanced metric collection.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,7 +2,10 @@ from django.core.management import execute_from_command_line
 import os
 import sys
 
+from opentelemetry.instrumentation.django import DjangoInstrumentor
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    # Collect OpenTelemetry application metrics
+    DjangoInstrumentor().instrument()
     execute_from_command_line(sys.argv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,8 @@ oauthlib==3.2.2
 pandas~=2.2.3           # recommend engine - comment out if initial installation is failing
 jira>=3.5               # JIRA API client for JiraUtil integration
 openpyxl>=3.1           # required by pandas for .xlsx support
+opentelemetry-sdk>=1.42.1
+opentelemetry-instrumentation-django>=0.63b1
 phonenumbers==8.13.26
 pillow==12.1.1
 pip-tools==7.4.1


### PR DESCRIPTION
- Add OpenTelemetry SDK and Django instrumentation packages. 
- Add hook to main manage.py script to enable instrumentation.

These changes should be transparent, and simply adds a instrumentation hook for collecting metrics. By default, the metrics are not send anywhere, unless the environment variables `OTEL_SERVICE_NAME` and `OTEL_EXPORTER_OTLP_ENDPOINT` are defined. When these are defined, the metrics will periodically be pushed to the defined endpoint.