### PR TITLE
Fix exception occurring in production when getting voter_id from voter_device_link.

### DIFF
--- a/ballot/controllers_upcoming_empty_election.py
+++ b/ballot/controllers_upcoming_empty_election.py
@@ -26,7 +26,7 @@ def retrieve_next_election_from_this_state(
         voter_address and hasattr(voter_address, 'voter_id') and positive_value_exists(voter_address.voter_id)
     if not voter_address_exists:
         # Get the voter_id from the voter_device_link
-        voter_id = voter_device_link.voter_id if 'voter_id' in voter_device_link else 0
+        voter_id = voter_device_link.voter_id if hasattr(voter_device_link, 'voter_id') else 0
         if positive_value_exists(voter_id):
             voter_address_results = voter_address_manager.retrieve_ballot_address_from_voter_id(voter_id)
             if voter_address_results['voter_address_found']:


### PR DESCRIPTION
This should fix the exception below.


Noticed this error from newrelic errors:

Error: `argument of type 'VoterDeviceLink' is not iterable`
```
Traceback (most recent call last):
...
File "/wevote/code/wevote_social/middleware.py", line 59, in __call__
File "/usr/local/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
File "/usr/local/lib/python3.12/site-packages/newrelic/hooks/framework_django.py", line 490, in wrapper
File "/wevote/code/apis_v1/views/views_voter.py", line 958, in voter_ballot_items_retrieve_view
File "/wevote/code/ballot/controllers.py", line 1073, in voter_ballot_items_retrieve_for_api
File "/wevote/code/ballot/controllers.py", line 1449, in choose_election_and_prepare_ballot_data
File "/wevote/code/ballot/controllers_upcoming_empty_election.py", line 29, in retrieve_next_election_from_this_state
```