### PR TITLE
Revert back to using NewRelic for application metrics, logging and traces.

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -12,11 +12,11 @@ COPY requirements.txt /tmp
 RUN pip install -r /tmp/requirements.txt --no-cache-dir
 
 # install New Relic Python agent for application performance monitoring
-#RUN pip install newrelic
+RUN pip install newrelic
 
 # install OpenTelemetry instrumentation for Python and Django
-RUN pip install opentelemetry-distro opentelemetry-instrumentation-django opentelemetry-exporter-otlp
-RUN opentelemetry-bootstrap -a install
+#RUN pip install opentelemetry-distro opentelemetry-instrumentation-django opentelemetry-exporter-otlp
+#RUN opentelemetry-bootstrap -a install
 
 # copy entrypoint script
 COPY docker/prod/entrypoint /usr/local/bin/docker-entrypoint
@@ -41,5 +41,5 @@ USER wevote
 EXPOSE 8000
 
 ENTRYPOINT ["docker-entrypoint"]
-CMD ["opentelemetry-instrument", "gunicorn", "--workers", "3", "--timeout", "1800", "--bind", "0.0.0.0:8000", "config.wsgi"]
+CMD ["newrelic-admin", "run-program", "gunicorn", "--workers", "3", "--worker-class", "gthread", "--timeout", "1800", "--bind", "0.0.0.0:8000", "config.wsgi"]
 


### PR DESCRIPTION
After testing out OpenTelemetry logging and metric collection, it seems like NewRelic is better suited for our use-cases and more intuitive to debug problems. In the future, we can revisit this if needed.