### PR TITLE
[WV-4666]On Election Listing page, create a script that strips state name & election date from election name [TEAMREVIEW]

### DIFF
--- a/election/urls.py
+++ b/election/urls.py
@@ -28,6 +28,6 @@ urlpatterns = [
     re_path(r'^import/$',
         views_admin.elections_import_from_master_server_view, name='elections_import_from_master_server'),
     re_path(r'^nationwide_election_list/$', views_admin.nationwide_election_list_view, name='nationwide_election_list'),
-    re_path(r'^test/$',
-        views_admin.test_view, name='test'),
+    re_path(r'^adjust_election_names/$', views_admin.adjust_election_names_view, name='adjust_election_names'),
+    re_path(r'^test/$', views_admin.test_view, name='test'),
 ]

--- a/election/views_admin.py
+++ b/election/views_admin.py
@@ -3054,3 +3054,98 @@ def election_ballot_location_visualize_view(request):
     }
 
     return render(request, 'election/election_ballot_location_visualize.html', template_values)
+
+@login_required
+def adjust_election_names_view(request):
+    # admin, analytics_admin, partner_organization, political_data_manager, political_data_viewer, verified_volunteer
+    authority_required = {'political_data_manager'}
+    if not voter_has_authority(request, authority_required):
+        return redirect_to_sign_in_page(request, authority_required)
+
+    election_manager = ElectionManager()
+
+    # Retrieve all upcoming elections for the dropdown
+    upcoming_results = election_manager.retrieve_upcoming_elections(read_only=True)
+    upcoming_election_list = upcoming_results['election_list'] if upcoming_results['success'] else []
+
+    if request.method == 'POST':
+        remove_date = positive_value_exists(request.POST.get('remove_date', False))
+        remove_state_name = positive_value_exists(request.POST.get('remove_state_name', False))
+        remove_party = positive_value_exists(request.POST.get('remove_party', False))
+
+        target_google_civic_election_id = request.POST.get('google_civic_election_id', '')
+
+        # Determine which elections to process
+        elections_to_process = []
+        if positive_value_exists(target_google_civic_election_id):
+            # Process single election
+            results = election_manager.retrieve_election(target_google_civic_election_id, read_only=False)
+            if results['election_found']:
+                elections_to_process.append(results['election'])
+        else:
+            # Process all upcoming elections
+            upcoming_editable_results = election_manager.retrieve_upcoming_elections(read_only=False)
+            if upcoming_editable_results['success']:
+                elections_to_process = upcoming_editable_results['election_list']
+
+        import re
+        from wevote_functions.functions import STATE_CODE_MAP
+
+        changes_made = []
+        for election in elections_to_process:
+            old_name = election.election_name
+            new_name = old_name
+
+            if remove_date:
+                # Remove full dates with year: e.g., "November 5, 2024", "June 3, 2026"
+                months = r'(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Oct|Nov|Dec)'
+                new_name = re.sub(rf'\b{months}\.?\s+\d{{1,2}}(?:\s*,\s*|\s+)?\d{{4}}\b', '', new_name, flags=re.IGNORECASE)
+                # Remove year: e.g., "2024" or "2020"
+                new_name = re.sub(r'\b\d{4}\b', '', new_name)
+                # Remove month and day: e.g. "November 5", "June 3"
+                new_name = re.sub(rf'\b{months}\.?\s+\d{{1,2}}\b', '', new_name, flags=re.IGNORECASE)
+                # Remove month names
+                new_name = re.sub(rf'\b{months}\b', '', new_name, flags=re.IGNORECASE)
+
+            if remove_state_name:
+                state_names = list(STATE_CODE_MAP.values())
+                state_abbreviations = list(STATE_CODE_MAP.keys())
+
+                state_names_sorted = sorted(state_names, key=len, reverse=True)
+                for name in state_names_sorted:
+                    new_name = re.sub(rf'\b{re.escape(name)}\b', '', new_name, flags=re.IGNORECASE)
+                for code in state_abbreviations:
+                    new_name = re.sub(rf'\b{re.escape(code)}\b', '', new_name, flags=re.IGNORECASE)
+                if election.state_code:
+                    new_name = re.sub(rf'\b{re.escape(election.state_code)}\b', '', new_name, flags=re.IGNORECASE)
+
+            if remove_party:
+                parties = ['Democratic Party', 'Republican Party', 'Democratic', 'Republican', 'Libertarian Party', 'Libertarian', 'Green Party', 'Green']
+                for party in parties:
+                    new_name = re.sub(rf'\b{re.escape(party)}\b', '', new_name, flags=re.IGNORECASE)
+
+            # Clean up whitespace and stray commas
+            new_name = re.sub(r',\s*,', ',', new_name)
+            new_name = re.sub(r'\s*,\s*$', '', new_name)
+            new_name = re.sub(r'^\s*,\s*', '', new_name)
+            new_name = re.sub(r'\s+', ' ', new_name).strip()
+
+            if new_name != old_name:
+                election.election_name = new_name
+                election.save()
+                changes_made.append(f"'{old_name}' -> '{new_name}'")
+
+        if len(changes_made) > 0:
+            messages.add_message(request, messages.INFO, f"Successfully adjusted {len(changes_made)} election name(s): " + ", ".join(changes_made))
+        else:
+            messages.add_message(request, messages.INFO, "No election names needed adjustment based on the selected options.")
+
+        return HttpResponseRedirect(reverse('election:election_list', args=()))
+
+    template_values = {
+        'upcoming_election_list': upcoming_election_list,
+        'remove_date': False,
+        'remove_state_name': False,
+        'remove_party': False,
+    }
+    return render(request, 'election/adjust_election_names.html', template_values)

--- a/templates/election/adjust_election_names.html
+++ b/templates/election/adjust_election_names.html
@@ -1,0 +1,72 @@
+{# templates/election/adjust_election_names.html #}
+{% extends "template_base.html" %}
+
+{% block title %}Adjust Election Names{% endblock %}
+
+{% block content %}
+  {% load template_filters %}
+  
+  <a href="{% url 'election:election_list' %}">< Back to Elections</a>
+
+  <h1>Adjust Election Names</h1>
+  <p>Use this tool to adjust/clean the names of upcoming elections in the database.</p>
+
+  <form action="{% url 'election:adjust_election_names' %}"
+        method="post"
+        style="max-width: 800px; display: flex; flex-direction: column; gap: 15px; margin-top: 20px;">
+    {% csrf_token %}
+
+    <div style="display: flex; flex-wrap: wrap; align-items: flex-start; gap: 15px; margin-bottom: 15px;">
+      <div style="flex: 1 1 200px; font-weight: bold; padding-top: 4px; max-width: 200px; min-width: 150px;">Cleaning Options</div>
+      <div style="flex: 2 1 300px; display: flex; flex-direction: column; gap: 8px; min-width: 250px;">
+        <label for="remove_date_id" style="font-weight: normal; cursor: pointer;">
+          <input type="checkbox"
+                 name="remove_date"
+                 id="remove_date_id"
+                 value="1"
+                 {% if remove_date %}checked{% endif %} />
+          Remove date (e.g. year, month, day patterns)
+        </label>
+        <label for="remove_state_name_id" style="font-weight: normal; cursor: pointer;">
+          <input type="checkbox"
+                 name="remove_state_name"
+                 id="remove_state_name_id"
+                 value="1"
+                 {% if remove_state_name %}checked{% endif %} />
+          Remove State name
+        </label>
+        <label for="remove_party_id" style="font-weight: normal; cursor: pointer;">
+          <input type="checkbox"
+                 name="remove_party"
+                 id="remove_party_id"
+                 value="1"
+                 {% if remove_party %}checked{% endif %} />
+          Remove Party (ex/ “Democratic Party”, “Republican Party”)
+        </label>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 15px; margin-bottom: 15px;">
+      <label for="google_civic_election_id_id" style="flex: 1 1 200px; font-weight: bold; max-width: 200px; min-width: 150px; margin-bottom: 0;">Select Upcoming Election</label>
+      <div style="flex: 2 1 300px; min-width: 250px;">
+        <select id="google_civic_election_id_id" name="google_civic_election_id" class="form-control" style="width: 100%; max-width: 600px; height: auto; padding: 6px 12px;">
+          <option value="">-- Apply to ALL Upcoming Elections --</option>
+          {% for election in upcoming_election_list %}
+            <option value="{{ election.google_civic_election_id }}">{{ election.election_name }} ({{ election.election_day_text }}) - {{ election.google_civic_election_id }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+
+    <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 15px; margin-top: 10px;">
+      <div style="flex: 1 1 200px; max-width: 200px; min-width: 150px;">
+        <a href="{% url 'election:election_list' %}">cancel</a>
+      </div>
+      <div style="flex: 2 1 300px; min-width: 250px;">
+        <input type="submit" class="btn btn-success" value="Change now" />
+      </div>
+    </div>
+
+  </form>
+
+{% endblock %}

--- a/templates/election/election_list.html
+++ b/templates/election/election_list.html
@@ -679,6 +679,9 @@
       <p>
         <a href="{% url 'election:election_edit' 0 %}" target="_blank">Add Upcoming Election Manually <span class="glyphicon glyphicon-new-window"></span></a>
       </p>
+      <p>
+        <a href="{% url 'election:adjust_election_names' %}" target="_blank">Adjust Election Names <span class="glyphicon glyphicon-new-window"></span></a>
+      </p>
 
       <script>
     function displayLoadingBanner() {


### PR DESCRIPTION
**What github.com/wevote/weconnect/issues does this fix?**
[WV-4666]On Election Listing page, create a script that strips state name & election date from election name

**Changes included this pull request?**
_election/urls.py_
Created url link to adjust_election_names

_election/views_admin.py_
Added capability to strip the required option based on checkboxes are checked, convert a name like this:
“August 11, 2026 Minnesota Democratic Party State Primary“
To a name like this:
“State Primary”

_templates/election/adjust_election_names.html_
created new “Adjust Election Names” script page with these options:
- Checkbox “Remove date”
- Checkbox “Remove State name”
- Checkbox “ Remove Party” (ex/ “Democratic Party”)
- Dropdown with all upcoming elections so you have the option to run the script on only one election. If no election is selected, run the script on all upcoming elections.
- Change now (submit button)

_templates/election/election_list.html_
added a link to this “Adjust Election Names” script page at the end of page.

[WV-4666]: https://wevoteusa.atlassian.net/browse/WV-4666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ