### PR TITLE
Update dev dockerfile for security

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -94,7 +94,7 @@ services:
     volumes:
       - pgadmin_data:/var/lib/pgadmin
     ports:
-      - "127.0.0.1:8080:80"
+      - "127.0.0.1:9000:80" # expose pgadmin at http://localhost:9000/
     networks:
       - wevote
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,7 +20,6 @@ services:
     user: postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - /tmp/docker:/tmp                 # Needed to get backup files into psql to test fastback
 
 
   localstack:
@@ -78,12 +77,11 @@ services:
       - DEV_SERVER_SSL_KEY=${DEV_SERVER_SSL_KEY:-cert/wevotedeveloper.com_key.txt}
     volumes:
       - .:/wevote/code
-      - /tmp/docker:/tmp                 # Needed to get backfiles into psql to test fastback
 
     networks:
       - wevote
     ports:
-      - "0.0.0.0:8000:8000"    # WeVote API at http://localhost:8000 or https://wevotedeveloper.com:8000
+      - "127.0.0.1:8000:8000"  # WeVote API at http://localhost:8000 or https://wevotedeveloper.com:8000
       - "127.0.0.1:5678:5678"  # debugpy port for remote debugging
 
   pgadmin:
@@ -96,7 +94,7 @@ services:
     volumes:
       - pgadmin_data:/var/lib/pgadmin
     ports:
-      - "0.0.0.0:8080:80"
+      - "127.0.0.1:8080:80"
     networks:
       - wevote
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -29,10 +29,11 @@ RUN useradd wevote && mkdir -p /var/log/wevote /wevote && chown wevote:wevote /v
 # define docker runtime
 WORKDIR /wevote/code
 USER wevote
+# expose following ports:
+#  8000 for django api server
+#  5678 for debugpy
 EXPOSE 8000
-EXPOSE 9000
 EXPOSE 5678
-EXPOSE 5432
 
 ENV RUNNING_IN_DEVELOPER_MODE=True
 ENV RUNNING_IN_DOCKER=True


### PR DESCRIPTION
Update dev docker environment:

1. Remove /tmp mountpoints in containers which was causing permission issues when writing temporary files (pdf2html conversion, for example).
2. Remove `EXPOSE` lines for unused ports from Dockerfile.dev, document ports still left
3. Change bind host for all services to `127.0.0.1`, which is only accessibly locally, instead of 0.0.0.0, which is accessible by anyone on your local network. 
4. Change the port to access pgadmin to 9000, from 8080.

@SailingSteve  @mjacquot1 Please let me know if there is some reason this does not work, and we can look for a solution that does. 