### PR TITLE
WV-4722 Lint & Format Python Code: E741

### DIFF
--- a/politician/controllers_generate_color.py
+++ b/politician/controllers_generate_color.py
@@ -7,7 +7,7 @@ import math, re
 def generate_background(politician, base=None):
     # specify how many bins will be generated for color sorting, the number of bins is base**3
     base = base or 3
- 
+
     # this is the speed bottleneck, not sure if this can be sped up
     try:
         res = request.urlopen(politician.we_vote_hosted_profile_image_url_large).read()
@@ -25,7 +25,7 @@ def generate_background(politician, base=None):
             left_list.append(pixel)
 
         bins = []
-        for bin in range(base**3, 0, -1):
+        for _ in range(base ** 3, 0, -1):
             bins.append([])
 
         divisor = 255/base
@@ -37,17 +37,17 @@ def generate_background(politician, base=None):
            bin_index = (r_binned * (base**2)) + (g_binned * base) + b_binned
            bins[bin_index].append((r,g,b))
 
-        bins.sort(key=lambda l: -len(l))
+        bins.sort(key=lambda color_bin: -len(color_bin))
 
         final_color = [0, 0, 0, 255]
         denominator = 0
 
-        for bin in range(0, 2, 1):
-            for rgb in bins[bin]:
+        for color_bin in range(0, 2, 1):
+            for rgb in bins[color_bin]:
                 final_color[0] += rgb[0]
                 final_color[1] += rgb[1]
                 final_color[2] += rgb[2]
-            denominator += len(bins[bin])
+            denominator += len(bins[color_bin])
 
         final_color[0]=math.floor(final_color[0]/denominator)
         final_color[1]=math.floor(final_color[1]/denominator)


### PR DESCRIPTION
- Ruff rule E741: ambiguous variable name
- Renamed `bin` to `color_bin` as it shadow's Python's built-in `bin()`