### PR TITLE
WV-2664: Decouple heart follow/dislike from Choose/Oppose (first-action-wins)

### DIFF
--- a/apis_v1/controllers.py
+++ b/apis_v1/controllers.py
@@ -85,7 +85,14 @@ def organization_dislike(  # organizationDislike
 
     save_oppose_position = False
     if positive_value_exists(make_position_update) and positive_value_exists(politician_we_vote_id):
-        save_oppose_position = True
+        # WV-2664: Honor the docstring intent above ("create an Oppose position IFF a position
+        # doesn't already exist"). Without this check, clicking the dislike icon on a candidate
+        # the voter has already Chosen would silently flip their position to Oppose.
+        from position.models import PositionListManager
+        existing_position_exists = PositionListManager().positions_exist_for_voter_and_politician(
+            voter_id=voter_id, politician_we_vote_id=politician_we_vote_id)
+        if not existing_position_exists:
+            save_oppose_position = True
     if save_oppose_position:
         from support_oppose_deciding.controllers import voter_opposing_save
         position_results = voter_opposing_save(
@@ -229,7 +236,14 @@ def organization_follow(  # organizationFollow
 
     save_support_position = False
     if positive_value_exists(make_position_update) and positive_value_exists(politician_we_vote_id):
-        save_support_position = True
+        # WV-2664: Honor the docstring intent above ("create a Support position IFF a position
+        # doesn't already exist"). Without this check, clicking the heart on a candidate the
+        # voter has already Opposed would silently flip their position to Support.
+        from position.models import PositionListManager
+        existing_position_exists = PositionListManager().positions_exist_for_voter_and_politician(
+            voter_id=voter_id, politician_we_vote_id=politician_we_vote_id)
+        if not existing_position_exists:
+            save_support_position = True
     if save_support_position:
         from support_oppose_deciding.controllers import voter_supporting_save
         position_results = voter_supporting_save(

--- a/follow/models.py
+++ b/follow/models.py
@@ -932,6 +932,26 @@ class FollowOrganizationManager(models.Manager):
         return "FollowOrganizationManager"
 
     @staticmethod
+    def voter_has_active_heart_preference(voter_id=0, organization_we_vote_id=''):
+        """
+        WV-2664: Does this voter already have an active heart (FOLLOWING or FOLLOW_DISLIKE) for this
+        organization? Used to preserve first-action-wins. Reads the primary DB, not 'readonly',
+        which can lag behind a write in the same dispatcher cycle.
+        """
+        if not positive_value_exists(voter_id) or not positive_value_exists(organization_we_vote_id):
+            return False
+        try:
+            return FollowOrganization.objects.using('default').filter(
+                voter_id=voter_id,
+                organization_we_vote_id=organization_we_vote_id,
+                following_status__in=[FOLLOWING, FOLLOW_DISLIKE],
+            ).exists()
+        except Exception:
+            # WV-2664: Fail closed. Assume the voter already has a heart preference so a DB error
+            # can't cause first-action-wins to be violated by re-flipping an existing heart.
+            return True
+
+    @staticmethod
     def fetch_follow_organization_count(
             following_status=FOLLOWING,
             organization_we_vote_id_being_followed='',

--- a/position/models.py
+++ b/position/models.py
@@ -1083,6 +1083,30 @@ class PositionListManager(models.Manager):
     #     return outgoing_position_list
 
     @staticmethod
+    def positions_exist_for_voter_and_politician(voter_id=0, politician_we_vote_id=''):
+        """
+        WV-2664: Does this voter already have a position (public or friends-only) for this
+        politician? Used so a heart / dislike click does not silently flip an existing Choose/Oppose.
+        Reads the primary DB, not 'readonly', to avoid replica lag right after a write.
+        """
+        if not positive_value_exists(voter_id) or not positive_value_exists(politician_we_vote_id):
+            return False
+        try:
+            return (
+                PositionEntered.objects.using('default').filter(
+                    voter_id=voter_id, politician_we_vote_id=politician_we_vote_id,
+                ).exists()
+                or PositionForFriends.objects.using('default').filter(
+                    voter_id=voter_id, politician_we_vote_id=politician_we_vote_id,
+                ).exists()
+            )
+        except Exception:
+            # WV-2664: Fail closed. This guard exists to PREVENT a heart/dislike click from silently
+            # flipping an existing position, so on an unexpected DB error assume a position exists
+            # rather than allowing the flip.
+            return True
+
+    @staticmethod
     def calculate_positions_followed_by_voter(
             voter_id,
             all_positions_list,

--- a/support_oppose_deciding/controllers.py
+++ b/support_oppose_deciding/controllers.py
@@ -610,23 +610,32 @@ def voter_opposing_save(  # voterOpposingSave
         positive_value_exists(politician_we_vote_id) and \
         (positive_value_exists(organization_id) and positive_value_exists(organization_we_vote_id))
     if politician_organization_can_be_followed:
-        # Now dislike the organization
-        from apis_v1.controllers import organization_dislike
-        org_results = organization_dislike(
-            make_position_update=False,
-            organization_id=organization_id,
-            organization_we_vote_id=organization_we_vote_id,
-            politician_we_vote_id=politician_we_vote_id,
-            user_agent_string=user_agent_string,
-            user_agent_object=user_agent_object,
-            voter=voter,
-            voter_device_id=voter_device_id,
-            voter_id=voter_id,
-        )
-        status += org_results['status']
-        final_results_dict['status'] = status
-        if not org_results['success']:
-            final_results_dict['success'] = False
+        # WV-2664: Preserve "first-action-wins" for the heart icon. Only auto-dislike if the
+        # voter has no active heart preference yet (no FOLLOWING / FOLLOW_DISLIKE record).
+        # Without this guard, Oppose -> un-Oppose -> Choose would silently flip the dislike
+        # icon to a heart, since this internal organization_dislike call would overwrite
+        # the voter's prior FOLLOW_DISLIKE record with FOLLOWING.
+        from follow.models import FollowOrganizationManager
+        voter_already_has_heart_preference = FollowOrganizationManager().voter_has_active_heart_preference(
+            voter_id=voter_id, organization_we_vote_id=organization_we_vote_id)
+        if not voter_already_has_heart_preference:
+            # Now dislike the organization
+            from apis_v1.controllers import organization_dislike
+            org_results = organization_dislike(
+                make_position_update=False,
+                organization_id=organization_id,
+                organization_we_vote_id=organization_we_vote_id,
+                politician_we_vote_id=politician_we_vote_id,
+                user_agent_string=user_agent_string,
+                user_agent_object=user_agent_object,
+                voter=voter,
+                voter_device_id=voter_device_id,
+                voter_id=voter_id,
+            )
+            status += org_results['status']
+            final_results_dict['status'] = status
+            if not org_results['success']:
+                final_results_dict['success'] = False
 
     return final_results_dict
 
@@ -1074,21 +1083,30 @@ def voter_supporting_save(  # voterSupportingSave
         positive_value_exists(politician_we_vote_id) and \
         (positive_value_exists(organization_id) and positive_value_exists(organization_we_vote_id))
     if politician_organization_can_be_followed:
-        # Now follow the organization
-        from apis_v1.controllers import organization_follow
-        org_results = organization_follow(
-            make_position_update=False,
-            organization_id=organization_id,
-            organization_we_vote_id=organization_we_vote_id,
-            politician_we_vote_id=politician_we_vote_id,
-            user_agent_string=user_agent_string,
-            user_agent_object=user_agent_object,
-            voter=voter,
-            voter_device_id=voter_device_id,
-            voter_id=voter_id,
-        )
-        status += org_results['status']
-        final_results_dict['status'] = status
-        if not org_results['success']:
-            final_results_dict['success'] = False
+        # WV-2664: Preserve "first-action-wins" for the heart icon. Only auto-follow if the
+        # voter has no active heart preference yet (no FOLLOWING / FOLLOW_DISLIKE record).
+        # Without this guard, Choose -> un-Choose -> Oppose would silently flip the heart from
+        # red to dislike, since this internal organization_follow call would overwrite the
+        # voter's prior FOLLOWING record with FOLLOW_DISLIKE.
+        from follow.models import FollowOrganizationManager
+        voter_already_has_heart_preference = FollowOrganizationManager().voter_has_active_heart_preference(
+            voter_id=voter_id, organization_we_vote_id=organization_we_vote_id)
+        if not voter_already_has_heart_preference:
+            # Now follow the organization
+            from apis_v1.controllers import organization_follow
+            org_results = organization_follow(
+                make_position_update=False,
+                organization_id=organization_id,
+                organization_we_vote_id=organization_we_vote_id,
+                politician_we_vote_id=politician_we_vote_id,
+                user_agent_string=user_agent_string,
+                user_agent_object=user_agent_object,
+                voter=voter,
+                voter_device_id=voter_device_id,
+                voter_id=voter_id,
+            )
+            status += org_results['status']
+            final_results_dict['status'] = status
+            if not org_results['success']:
+                final_results_dict['success'] = False
     return final_results_dict


### PR DESCRIPTION
TL;DR: On the backend, your heart (like/dislike) and your Choose/Oppose position no longer quietly overwrite each other. Only your *first* action on a candidate links the two; after that, clicking one leaves the other alone. And if the database hiccups mid-check, the code now plays it safe and preserves whatever you already had instead of risking a wrong flip.

Preserve "first-action-wins" so a heart/dislike or Choose/Oppose click no longer silently flips the voter's other stance:

- organization_dislike / organization_follow only create an Oppose/Support position when none already exists (PositionListManager.positions_exist_for_voter_and_politician).
- voter_opposing_save / voter_supporting_save only auto-dislike/auto-follow the org when the voter has no active heart yet (FollowOrganizationManager.voter_has_active_heart_preference).
- New guard helpers read the primary DB ('default') to avoid replica lag, and fail closed on a DB error so a transient failure can't flip an existing position or heart.