### PR TITLE
Restore center-crop to square for profile image resizing when target dimensions are square

### DIFF
--- a/image/models.py
+++ b/image/models.py
@@ -2158,6 +2158,9 @@ class WeVoteImageManager(models.Manager):
                     centering_y = ((image.height - image_offset_y) * 0.5) / image.height
                     centering = (centering_x, centering_y)
                     image = ImageOps.fit(image, target_size, Image.Resampling.LANCZOS, centering)
+                elif image_width == image_height:
+                    image = crop_to_square(image)
+                    image = image.resize(target_size, Image.Resampling.LANCZOS)
                 else:
                     image = ImageOps.contain(image, target_size, Image.Resampling.LANCZOS)
                 if media_type == 'image/jpeg':


### PR DESCRIPTION
## Summary

Restores square cropping for profile photo resizing when the target output size is square (e.g. 200×200, 48×48, 32×32). Rectangular source images are now center-cropped before resize instead of being fit with `ImageOps.contain`, which preserved aspect ratio and produced non-square output files.

## Problem

Profile photos are displayed as squares in the UI, but non-square uploads (e.g. wide rectangular images) were not being converted to square resized versions. This regressed in PR #3052, which replaced the previous `crop_to_square` logic with `ImageOps.contain` for all non–Facebook-background images.

## Related history

- Regression introduced: PR #3052
- Prior working logic: Jun 2025 jpeg resize fix (`crop_to_square` in `resize_we_vote_master_image`)