### PR TITLE
Pass AWS keys into boto3 for image S3 and square-crop static WebP/GIF.

### DIFF
--- a/image/models.py
+++ b/image/models.py
@@ -43,6 +43,16 @@ WIKIPEDIA_IMAGE_NAME = "wikipedia_image"
 
 AWS_REGION_NAME = get_environment_variable("AWS_REGION_NAME")
 AWS_STORAGE_BUCKET_NAME = get_environment_variable("AWS_STORAGE_BUCKET_NAME")
+AWS_ACCESS_KEY_ID = get_environment_variable("AWS_ACCESS_KEY_ID", no_exception=True)
+AWS_SECRET_ACCESS_KEY = get_environment_variable("AWS_SECRET_ACCESS_KEY", no_exception=True)
+
+# AWS S3 client
+def _aws_s3_client():
+    kwargs = {'region_name': AWS_REGION_NAME}
+    if positive_value_exists(AWS_ACCESS_KEY_ID) and positive_value_exists(AWS_SECRET_ACCESS_KEY):
+        kwargs['aws_access_key_id'] = AWS_ACCESS_KEY_ID
+        kwargs['aws_secret_access_key'] = AWS_SECRET_ACCESS_KEY
+    return boto3.client('s3', **kwargs)
 
 GifImagePlugin.LOADING_STRATEGY = GifImagePlugin.LoadingStrategy.RGB_ALWAYS
 
@@ -374,7 +384,7 @@ class WeVoteImageManager(models.Manager):
         """
         try:
 
-            client = boto3.client("s3", region_name=AWS_REGION_NAME)
+            client = _aws_s3_client()
             client.delete_object(Bucket=AWS_STORAGE_BUCKET_NAME, Key=we_vote_image_file_location)
             image_deleted_from_aws = True
         except Exception as e:
@@ -2130,26 +2140,36 @@ class WeVoteImageManager(models.Manager):
             image = Image.open(original_image_local_path)
             media_type = image.get_format_mimetype()
 
-            # Check for animated formats FIRST — before any convert() call
-            # convert() strips all animation frames, so we skip it for gif/webp
-            if media_type in {'image/gif', 'image/webp'}:
-                # Pillow cannot reliably resize animated images frame by frame
-                # The proper long-term fix is Fastly CDN handling, but for now
-                # the pragmatic fix is to copy the original file as-is for animated
-                # formats instead of trying to resize
-                # Copy the original file as-is to preserve all animation frames.
-                import shutil
-                shutil.copy2(original_image_local_path, converted_image_local_path)
+            # convert()/single-frame resize strips animation. Skip resize only for animated
+            # gif/webp. Static gif/webp use the same crop/resize path as other stills.
+            # Animated frame-by-frame resize (or Fastly Image Optimizer) is a follow-up.
+            is_animated = (
+                media_type in {'image/gif', 'image/webp'}
+                and (
+                    getattr(image, 'is_animated', False)
+                    or getattr(image, 'n_frames', 1) > 1
+                )
+            )
+
+            if is_animated:
+                # Preserve animation frames. Avoid SameFileError when paths are identical.
+                if original_image_local_path != converted_image_local_path:
+                    import shutil
+                    shutil.copy2(original_image_local_path, converted_image_local_path)
+                resized_image_created = True
             else:
                 # Color conversion (safe for non-animated formats)
                 if image.has_transparency_data:
                     image = image.convert('RGBA')
                 else:
                     image = image.convert('RGB')
-                # GPS EXIF stripping
-                exif = image.getexif()
-                gps_ifd = exif.get_ifd(ExifTags.IFD.GPSInfo)
-                gps_ifd.clear()
+                # GPS EXIF stripping (not all formats have EXIF/GPS)
+                try:
+                    exif = image.getexif()
+                    gps_ifd = exif.get_ifd(ExifTags.IFD.GPSInfo)
+                    gps_ifd.clear()
+                except Exception:
+                    pass
                 # Resize
                 centering_x = 0.5
                 target_size = (image_width, image_height)
@@ -2166,6 +2186,7 @@ class WeVoteImageManager(models.Manager):
                     image.save(converted_image_local_path, quality=95, subsampling=0)
                 else:
                     image.save(converted_image_local_path)
+                resized_image_created = True
 
         except Exception as e:
             exception_message = "FAILED_TO_RESIZE_IMAGE: " + str(e) + " "
@@ -2174,9 +2195,7 @@ class WeVoteImageManager(models.Manager):
         finally:
             if image:
                 image.close()
-        
-        resized_image_created = True
-        
+
         results = {
             'status':                   status,
             'resized_image_created':    resized_image_created,
@@ -2248,7 +2267,7 @@ class WeVoteImageManager(models.Manager):
         :return:
         """
         try:
-            client = boto3.client("s3", region_name=AWS_REGION_NAME)
+            client = _aws_s3_client()
             upload_image_from_location = "/tmp/" + we_vote_image_file_name
             # print('-------------- temp file upload to aws ' +  upload_image_from_location)
             content_type = "image/{image_format}".format(image_format=image_format)
@@ -2271,7 +2290,11 @@ class WeVoteImageManager(models.Manager):
         :return:
         """
         try:
-            session = boto3.session.Session(region_name=AWS_REGION_NAME)
+            session_kwargs = {'region_name': AWS_REGION_NAME}
+            if positive_value_exists(AWS_ACCESS_KEY_ID) and positive_value_exists(AWS_SECRET_ACCESS_KEY):
+                session_kwargs['aws_access_key_id'] = AWS_ACCESS_KEY_ID
+                session_kwargs['aws_secret_access_key'] = AWS_SECRET_ACCESS_KEY
+            session = boto3.session.Session(**session_kwargs)
             s3 = session.resource("s3")
             s3.Bucket(AWS_STORAGE_BUCKET_NAME).put_object(Key=we_vote_image_file_location,
                                                           Body=image_file)
@@ -2291,7 +2314,7 @@ class WeVoteImageManager(models.Manager):
         :return:
         """
         try:
-            client = boto3.client("s3", region_name=AWS_REGION_NAME)
+            client = _aws_s3_client()
             download_image_at_location = "/tmp/" + we_vote_image_file_location
             client.download_file(AWS_STORAGE_BUCKET_NAME, we_vote_image_file_location, download_image_at_location)
             image_retrieved_from_aws = True


### PR DESCRIPTION
## Summary
- Pass `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from `environment_variables.json` into boto3 (via `get_environment_variable` + `positive_value_exists`) for image S3 upload/download/delete, so local/dev no longer depends on process env or `~/.aws` for those calls.
- Square-crop **static** WebP/GIF the same way as other still profile images; only **animated** WebP/GIF skip resize (and avoid `SameFileError` when src/dest paths match).
- Set `resized_image_created = True` only on successful resize/copy (not unconditionally after failures).

## Context
Follow-up to the profile square-crop work on WV-4728. Hitting `store_image_to_aws failed: Unable to locate credentials` because boto3 was created with region only. Static WebP/GIF were also skipped entirely by the animated copy path.

## Tested
- [x] Wide JPEG / PNG → `_200x200` / `_48x48` / `_32x32` are square
- [x] Static wide WebP → square sizes (no SameFileError)
- [x] Static wide GIF → square sizes
- [x] Animated WebP/GIF → remain non-square (expected for now)