### PR TITLE
Fixed skipped record in JIRA load + added additonal Instructions [WV-4864]

### DIFF
--- a/import_export_jira/controllers.py
+++ b/import_export_jira/controllers.py
@@ -251,6 +251,35 @@ class JiraExcelLoader:
         self.subtask_names = subtask_names  # None means auto-detect from file headers
         self.df: Optional[pd.DataFrame] = None
         self.epics: Optional[List[JiraEpic]] = None
+        self.header_row_index: int = 0
+
+    def _detect_header_row_count(self) -> int:
+        """
+        Detect how many leading rows are headers by finding the first row
+        whose Election Date column holds a real, parseable date rather than
+        header text (e.g. "Election Date" or a section title like "JIRA EPIC").
+
+        Returns:
+            Number of leading header rows (defaults to 2 if detection fails,
+            matching the legacy Arkansas-style template).
+        """
+        max_check = min(5, self.df.shape[0])
+        for row_idx in range(max_check):
+            val = self.df.iloc[row_idx, COL_ELECTION_DATE]
+            if pd.isna(val):
+                continue
+            if isinstance(val, (datetime, pd.Timestamp)):
+                return row_idx
+            try:
+                pd.to_datetime(val)
+                return row_idx
+            except (ValueError, TypeError):
+                continue
+        logger.warning(
+            "Could not auto-detect header row count from Election Date column; "
+            "defaulting to 2 header rows."
+        )
+        return 2
 
     def load(self) -> List[JiraEpic]:
         """
@@ -291,15 +320,23 @@ class JiraExcelLoader:
             raise ValueError(f"Invalid or corrupted file: {e}") from e
 
         # Validate minimum structure
-        if self.df.shape[0] < 3:
-            raise ValueError("File must have at least 3 rows (headers + data)")
+        if self.df.shape[0] < 2:
+            raise ValueError("File must have at least 2 rows (headers + data)")
         if self.df.shape[1] < COL_STORY_TITLE + 1:
             raise ValueError(
                 f"File must have at least {COL_STORY_TITLE + 1} columns, found {self.df.shape[1]}"
             )
 
+        # Detect how many leading rows are headers. Some files have a single
+        # header row (column names only); others (e.g. the Arkansas-style
+        # template) have an extra section-title row above the column names.
+        # Hardcoding this caused the first real data row to be silently
+        # dropped for single-header-row files.
+        header_row_count = self._detect_header_row_count()
+        self.header_row_index = header_row_count - 1
+
         # Validate that we have data rows (not just headers)
-        data_df = self.df.iloc[2:].reset_index(drop=True)
+        data_df = self.df.iloc[header_row_count:].reset_index(drop=True)
         if data_df.empty:
             raise ValueError("Excel file contains no data rows")
 
@@ -325,8 +362,10 @@ class JiraExcelLoader:
             self.subtask_names = []
             for i in range(MAX_SUBTASK_COLUMNS):
                 col = COL_SUBTASK_URL_START + i
-                if col < self.df.shape[1] and pd.notna(self.df.iloc[0, col]):
-                    val = str(self.df.iloc[0, col]).strip()
+                if col < self.df.shape[1] and pd.notna(
+                    self.df.iloc[self.header_row_index, col]
+                ):
+                    val = str(self.df.iloc[self.header_row_index, col]).strip()
                     if val:
                         self.subtask_names.append(val)
 
@@ -460,8 +499,10 @@ class JiraExcelLoader:
         header_suggestions = []
         for i in range(MAX_SUBTASK_COLUMNS):
             col = COL_SUBTASK_URL_START + i
-            if col < self.df.shape[1] and pd.notna(self.df.iloc[0, col]):
-                val = str(self.df.iloc[0, col]).strip()
+            if col < self.df.shape[1] and pd.notna(
+                self.df.iloc[self.header_row_index, col]
+            ):
+                val = str(self.df.iloc[self.header_row_index, col]).strip()
                 if val:
                     header_suggestions.append(val)
 

--- a/import_export_jira/templates/import_export_jira/jira_import.html
+++ b/import_export_jira/templates/import_export_jira/jira_import.html
@@ -44,7 +44,11 @@
 
 {# ---- Upload form ---- #}
 <h2>Upload Election Spreadsheet</h2>
-<p>Upload an Arkansas-style <code>.xlsx</code> or <code>.csv</code> file to preview or import its data into JIRA.</p>
+<p>Upload a spreadsheet that has been exported from Vote USA <code>.xlsx</code> or <code>.csv</code> file to preview or import its data into JIRA.</p>
+
+<p> Preview - will simply analyse the file and produce counts: Epics, Stories and Subtasks.</p>
+
+<p> Create subtasks from file - will create subtasks for each story based on the file content. This can be overiden by selecting the checkbox and adding up to 4 subtasks manually. </p>
 
 <form method="post" enctype="multipart/form-data" id="upload-form">
     {% csrf_token %}

--- a/import_export_jira/tests.py
+++ b/import_export_jira/tests.py
@@ -134,11 +134,11 @@ class JiraExcelLoaderTests(TestCase):
     @patch("pandas.read_excel")
     def test_load_insufficient_rows(self, mock_read_excel):
         """Test validation for insufficient rows."""
-        mock_read_excel.return_value = pd.DataFrame([[1, 2], [3, 4]])
+        mock_read_excel.return_value = pd.DataFrame([[1] * 14])
         loader = JiraExcelLoader("/tmp/test.xlsx")
         with self.assertRaises(ValueError) as context:
             loader.load()
-        self.assertIn("at least 3 rows", str(context.exception))
+        self.assertIn("at least 2 rows", str(context.exception))
 
     @patch("pandas.read_excel")
     def test_load_insufficient_columns(self, mock_read_excel):
@@ -192,6 +192,71 @@ class JiraExcelLoaderTests(TestCase):
         self.assertEqual(len(epics), 1)
         self.assertEqual(len(epics[0].stories), 1)
         mock_read_csv.assert_called_once()
+
+    @patch("pandas.read_excel")
+    def test_load_single_header_row_does_not_drop_first_story(
+        self, mock_read_excel
+    ):
+        """
+        Regression test: files with a single header row (column names only,
+        no extra section-title row) must not lose the first data row's story.
+        """
+        header = [
+            "Election Date",
+            "Epic Title",
+            "Election Name",
+            "Election Id",
+            "Report URL",
+            "Office",
+            "Jurisdiction",
+            "State",
+            "County Code",
+            "County",
+            "Local Name",
+            "Candidate Name",
+            "Candidate Id",
+            "Story Title",
+        ] + [""] * 4
+        first_row = [
+            "2024-11-05",
+            "2024 General: Senate",
+            "General",
+            "G-001",
+            "url",
+            "Senate",
+            "Statewide",
+            "CA",
+            "001",
+            "County",
+            "",
+            "First Candidate",
+            "C-001",
+            "First Candidate - Senate",
+        ] + [""] * 4
+        second_row = [
+            "2024-11-05",
+            "2024 General: Senate",
+            "General",
+            "G-001",
+            "url",
+            "Senate",
+            "Statewide",
+            "CA",
+            "001",
+            "County",
+            "",
+            "Second Candidate",
+            "C-002",
+            "Second Candidate - Senate",
+        ] + [""] * 4
+        mock_read_excel.return_value = pd.DataFrame([header, first_row, second_row])
+        loader = JiraExcelLoader("/tmp/test.xlsx")
+        epics = loader.load()
+        self.assertEqual(len(epics), 1)
+        candidate_names = [s.candidate_name for s in epics[0].stories]
+        self.assertIn("First Candidate", candidate_names)
+        self.assertIn("Second Candidate", candidate_names)
+        self.assertEqual(len(epics[0].stories), 2)
 
     @patch("pandas.read_csv")
     def test_load_csv_with_override(self, mock_read_csv):


### PR DESCRIPTION
Fixed skipped record (head was defined as 2 lines). Added a couple of line of instructions