### PR TITLE
Add password reset for WeVoteServer sign in (WV-4734)

### DIFF
--- a/admin_tools/tests/test_password_reset.py
+++ b/admin_tools/tests/test_password_reset.py
@@ -1,0 +1,262 @@
+# admin_tools/tests/test_password_reset.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+
+"""
+Tests for the WeVoteServer password reset flow (staff, developers and volunteers).
+See admin_tools/views_password_reset.py.
+
+These lean on the behavior we actually care about: an attacker must not be able to learn which
+email addresses have accounts, a reset link must only work once, and nobody gets signed in
+without typing the new password.
+"""
+
+import re
+
+from django.contrib.auth import authenticate
+from django.core import mail
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from unittest import mock
+
+from admin_tools import views_password_reset
+from admin_tools.views_password_reset import generate_suggested_password
+from voter.models import Voter
+
+TEST_EMAIL = 'wv4734_tester@example.com'
+OLD_PASSWORD = 'OldPassw0rd!xyz'
+NEW_PASSWORD = 'Str0ng-New-Pass!42'
+
+
+@override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+class PasswordResetFlowTests(TestCase):
+    databases = '__all__'
+
+    def setUp(self):
+        cache.clear()
+        mail.outbox = []
+        # Do not actually sleep during tests.
+        self._original_delay = views_password_reset.DELIBERATE_DELAY_SECONDS
+        self._original_target = views_password_reset.RESET_RESPONSE_TARGET_SECONDS
+        views_password_reset.DELIBERATE_DELAY_SECONDS = 0
+        views_password_reset.RESET_RESPONSE_TARGET_SECONDS = 0
+        self.voter = Voter(email=TEST_EMAIL, is_active=True, is_verified_volunteer=True)
+        self.voter.set_password(OLD_PASSWORD)
+        self.voter.save()
+
+    def tearDown(self):
+        views_password_reset.DELIBERATE_DELAY_SECONDS = self._original_delay
+        views_password_reset.RESET_RESPONSE_TARGET_SECONDS = self._original_target
+        cache.clear()
+
+    def request_reset(self, email):
+        return self.client.post(reverse('password_reset'), {'email': email})
+
+    def get_set_password_page(self):
+        """Walk from the emailed link to the form where the new password is typed."""
+        reset_path = re.search(r'/password_reset/confirm/[^\s]+', mail.outbox[0].body).group(0).rstrip('.')
+        response = self.client.get(reset_path)
+        return reset_path, response['Location']
+
+    def test_request_page_loads_and_offers_no_signup(self):
+        response = self.client.get(reverse('password_reset'))
+        self.assertEqual(response.status_code, 200)
+        # Account creation is deliberately not part of this flow.
+        self.assertNotIn(b'sign up', response.content.lower())
+        self.assertNotIn(b'signup', response.content.lower())
+
+    def test_unknown_email_is_indistinguishable_from_known_email(self):
+        """The whole point: no user enumeration."""
+        self.request_reset('nobody-here@example.com')
+        unknown_page = self.client.get(reverse('password_reset_done')).content
+        self.assertEqual(len(mail.outbox), 0)
+
+        cache.clear()
+        self.request_reset(TEST_EMAIL)
+        known_page = self.client.get(reverse('password_reset_done')).content
+        self.assertEqual(len(mail.outbox), 1)
+
+        self.assertEqual(unknown_page, known_page)
+
+    def test_reset_email_contains_a_working_link(self):
+        self.request_reset(TEST_EMAIL)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn('/password_reset/confirm/', mail.outbox[0].body)
+
+        _, set_password_url = self.get_set_password_page()
+        response = self.client.get(set_password_url)
+        self.assertEqual(response.status_code, 200)
+        page = response.content.decode('utf-8')
+        self.assertIn('new_password1', page)
+        self.assertIn('new_password2', page)
+
+    @override_settings(ALLOWED_HOSTS=['*'])
+    def test_reset_link_ignores_forged_host_header(self):
+        # WV-4734 FIX 1: even if a forged Host is accepted, the emailed link must point at our
+        # configured server, not the attacker's domain, so the token cannot be stolen.
+        self.client.post(
+            reverse('password_reset'), {'email': TEST_EMAIL}, HTTP_HOST='evil.example.com')
+        self.assertEqual(len(mail.outbox), 1)
+        body = mail.outbox[0].body
+        self.assertNotIn('evil.example.com', body)
+        canonical = views_password_reset.canonical_link_email_context()
+        if canonical:
+            self.assertIn(canonical['domain'], body)
+
+    def test_set_password_page_offers_a_suggested_password(self):
+        self.request_reset(TEST_EMAIL)
+        _, set_password_url = self.get_set_password_page()
+        page = self.client.get(set_password_url).content.decode('utf-8')
+        self.assertIsNotNone(re.search(r'id="suggested_password"\s+value="[^"]+"', page))
+
+    def test_weak_password_is_rejected(self):
+        self.request_reset(TEST_EMAIL)
+        _, set_password_url = self.get_set_password_page()
+        response = self.client.post(set_password_url, {'new_password1': '123', 'new_password2': '123'})
+        self.assertEqual(response.status_code, 200)  # redisplayed with errors
+        self.assertIsNotNone(authenticate(username=TEST_EMAIL, password=OLD_PASSWORD))
+
+    def test_mismatched_passwords_are_rejected(self):
+        self.request_reset(TEST_EMAIL)
+        _, set_password_url = self.get_set_password_page()
+        response = self.client.post(
+            set_password_url, {'new_password1': NEW_PASSWORD, 'new_password2': NEW_PASSWORD + 'zz'})
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(authenticate(username=TEST_EMAIL, password=OLD_PASSWORD))
+
+    def test_successful_reset_redirects_to_login_without_signing_in(self):
+        self.request_reset(TEST_EMAIL)
+        _, set_password_url = self.get_set_password_page()
+        response = self.client.post(
+            set_password_url, {'new_password1': NEW_PASSWORD, 'new_password2': NEW_PASSWORD})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response['Location'].endswith('/login/'))
+        self.assertIsNotNone(authenticate(username=TEST_EMAIL, password=NEW_PASSWORD))
+        self.assertIsNone(authenticate(username=TEST_EMAIL, password=OLD_PASSWORD))
+        # The person must sign in with the new password, so no session should exist yet.
+        self.assertNotIn('_auth_user_id', self.client.session)
+
+    def test_reset_link_only_works_once(self):
+        self.request_reset(TEST_EMAIL)
+        reset_path, set_password_url = self.get_set_password_page()
+        self.client.post(set_password_url, {'new_password1': NEW_PASSWORD, 'new_password2': NEW_PASSWORD})
+
+        response = self.client.get(reset_path)
+        if response.status_code == 302:
+            response = self.client.get(response['Location'])
+        self.assertIn(b'no longer valid', response.content)
+
+    def test_send_suppression_sends_only_one_email(self):
+        # Two quick requests for the same email: suppression lets only the first send.
+        self.request_reset(TEST_EMAIL)
+        self.request_reset(TEST_EMAIL)
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_email_flood_still_leaves_owner_a_working_link(self):
+        # The anti-lockout guarantee. An attacker hammers the victim's address. Suppression means
+        # only one email goes out, it goes to the victim's own inbox, and its link still works, so
+        # the victim is never blocked from resetting their own password.
+        for _ in range(15):
+            self.request_reset(TEST_EMAIL)
+        self.assertEqual(len(mail.outbox), 1)
+        _, set_password_url = self.get_set_password_page()
+        response = self.client.post(
+            set_password_url, {'new_password1': NEW_PASSWORD, 'new_password2': NEW_PASSWORD})
+        self.assertEqual(response.status_code, 302)
+        self.assertIsNotNone(authenticate(username=TEST_EMAIL, password=NEW_PASSWORD))
+
+    def test_going_over_ip_limit_bans_the_source(self):
+        with mock.patch.object(views_password_reset, 'RESET_REQUESTS_PER_IP', 2):
+            for _ in range(4):
+                self.request_reset('someone-else@example.com')
+        self.assertTrue(views_password_reset.is_banned('request', '127.0.0.1'))
+
+    def test_rate_limited_request_still_looks_normal(self):
+        # A throttled or banned request must not look different, or it becomes an oracle.
+        with mock.patch.object(views_password_reset, 'RESET_REQUESTS_PER_IP', 2):
+            for _ in range(5):
+                response = self.request_reset(TEST_EMAIL)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response['Location'].endswith('/password_reset/sent/'))
+
+    def test_cascading_ban_escalates_and_resets(self):
+        ip_address = '203.0.113.9'
+        offense_key = 'password_reset_offense_request_' + views_password_reset._hashed(ip_address)
+        self.assertFalse(views_password_reset.is_banned('request', ip_address))
+
+        views_password_reset.register_offense('request', ip_address)
+        self.assertTrue(views_password_reset.is_banned('request', ip_address))
+        first_level = cache.get(offense_key)
+
+        views_password_reset.register_offense('request', ip_address)
+        self.assertEqual(cache.get(offense_key), first_level + 1)
+
+        # Bans are per scope: a request ban does not touch the confirm endpoint.
+        self.assertFalse(views_password_reset.is_banned('confirm', ip_address))
+
+    def test_confirm_endpoint_is_rate_limited(self):
+        # Hammering the confirm endpoint with guessed links eventually gets a generic throttle page.
+        with mock.patch.object(views_password_reset, 'CONFIRM_ATTEMPTS_PER_IP', 3):
+            last_response = None
+            for _ in range(5):
+                last_response = self.client.get(
+                    '/password_reset/confirm/MQ/abc12-0123456789abcdef0123456789abcd/')
+            self.assertEqual(last_response.status_code, 429)
+            self.assertIn(b'Too Many Attempts', last_response.content)
+
+    def test_inactive_account_gets_no_email(self):
+        self.voter.is_active = False
+        self.voter.save()
+        self.request_reset(TEST_EMAIL)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_account_without_usable_password_gets_no_email(self):
+        """Regular voters sign in with emailed codes and have no password to reset."""
+        self.voter.set_unusable_password()
+        self.voter.save()
+        self.request_reset(TEST_EMAIL)
+        self.assertEqual(len(mail.outbox), 0)
+
+
+class ResponseDeadlineTests(TestCase):
+    """
+    The reset request runs to a fixed total time so a real account (which sends an email) cannot be
+    told apart from a nonexistent one by timing. These check the padding math without real sleeping.
+    """
+    def test_deadline_pads_short_requests(self):
+        with mock.patch.object(views_password_reset, 'RESET_RESPONSE_TARGET_SECONDS', 1.0), \
+                mock.patch.object(views_password_reset.time, 'monotonic', return_value=0.3), \
+                mock.patch.object(views_password_reset.time, 'sleep') as fake_sleep:
+            views_password_reset.sleep_until_deadline(0.0)  # 0.3s elapsed of a 1.0s budget
+            fake_sleep.assert_called_once()
+            self.assertAlmostEqual(fake_sleep.call_args[0][0], 0.7, places=3)
+
+    def test_deadline_does_not_sleep_when_already_over(self):
+        with mock.patch.object(views_password_reset, 'RESET_RESPONSE_TARGET_SECONDS', 0.1), \
+                mock.patch.object(views_password_reset.time, 'monotonic', return_value=5.0), \
+                mock.patch.object(views_password_reset.time, 'sleep') as fake_sleep:
+            views_password_reset.sleep_until_deadline(0.0)  # 5.0s elapsed, past the budget
+            fake_sleep.assert_not_called()
+
+
+class SuggestedPasswordTests(TestCase):
+    databases = '__all__'
+
+    def test_suggested_password_is_strong_and_varies(self):
+        first = generate_suggested_password()
+        second = generate_suggested_password()
+        self.assertNotEqual(first, second)
+        self.assertGreaterEqual(len(first), 20)
+        self.assertTrue(any(character.islower() for character in first))
+        self.assertTrue(any(character.isupper() for character in first))
+        self.assertTrue(any(character.isdigit() for character in first))
+        self.assertTrue(any(not character.isalnum() for character in first))
+
+    def test_suggested_password_avoids_confusable_characters(self):
+        for _ in range(20):
+            password = generate_suggested_password()
+            for character in '0O1lI':
+                self.assertNotIn(character, password)

--- a/admin_tools/views_password_reset.py
+++ b/admin_tools/views_password_reset.py
@@ -1,0 +1,348 @@
+# admin_tools/views_password_reset.py
+# Brought to you by We Vote. Be good.
+# -*- coding: UTF-8 -*-
+
+"""
+Password reset for WeVoteServer sign-in (staff, developers and volunteers).
+See config/urls.py for the url patterns, and templates/registration/password_reset_*.html.
+
+Notes on the design:
+- We deliberately do NOT offer account creation anywhere in this flow. This only resets the
+  password of an account that already exists.
+- We never reveal whether an email address is attached to an account. Every request ends on the
+  same "we sent it if it exists" page, including requests that were rate limited.
+- Django's built-in token is single use in practice: the token is built from the user's current
+  password hash and last_login, so it stops working once the password is changed.
+"""
+
+import hashlib
+import logging
+import secrets
+import time
+from urllib.parse import urlsplit
+
+from django.contrib import messages
+from django.contrib.auth import views as auth_views
+from django.contrib.auth.forms import PasswordResetForm
+from django.core.cache import cache
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+from django.urls import reverse_lazy
+
+from config.environment_variable_functions import get_environment_variable
+from email_outbound.models import EmailAddress
+from voter.models import Voter
+
+logger = logging.getLogger(__name__)
+
+# Rate limiting. All counters live in the Django cache (a database cache table), so nothing here
+# adds a migration. The design has three goals that pull in different directions: stop brute force
+# and enumeration, stop resource exhaustion, and never let one person lock someone else out of
+# resetting their own password.
+#
+# The primary axis is the IP address, not the email address. An email-based hard cap would let an
+# attacker burn a victim's allowance and block the victim's own reset, so we do not use one.
+RESET_REQUESTS_PER_IP = 10
+RESET_RATE_LIMIT_WINDOW_SECONDS = 60 * 60  # one hour
+
+# Send suppression, our email-side protection and the closest thing to a per email rate limit. If we
+# already emailed a reset link to an address in this window, we do not send another (the earlier link
+# still works), but the request still shows the normal "check your email" page. This stops inbox
+# bombing without ever turning the owner away, which a hard per email cap would do. A six minute
+# window works out to at most about ten reset emails per hour to any one address, generous enough
+# that a flustered user clicking a few times is never penalized.
+EMAIL_SEND_SUPPRESS_SECONDS = 6 * 60
+
+# Guessing the emailed link. The token itself is a large HMAC, so this is defense in depth against
+# someone hammering the confirm endpoint rather than a real chance of a hit.
+CONFIRM_ATTEMPTS_PER_IP = 30
+
+# Cascading ban. When an IP keeps going over a limit, it gets banned for a stretch that doubles each
+# time, from a few minutes up to a day. A real user never reaches the second step; an abuser digs a
+# deeper and deeper hole. The offense count is remembered for a while so the escalation sticks.
+BAN_BASE_SECONDS = 5 * 60
+BAN_MAX_SECONDS = 24 * 60 * 60
+BAN_OFFENSE_MEMORY_SECONDS = 24 * 60 * 60
+
+# A small fixed delay on each confirm attempt. It slows automated guessing of the emailed link and
+# is uniform so it never reveals whether a token was valid. Banned sources are rejected BEFORE this
+# delay, so a flood of banned traffic stays cheap to turn away.
+DELIBERATE_DELAY_SECONDS = 0.75
+
+# The reset REQUEST endpoint instead runs to a fixed total time (see sleep_until_deadline). For an
+# address that has an account we actually send an email, which for a real mail backend takes time;
+# for an address that does not, we send nothing. If we simply delayed a fixed amount up front, the
+# send time would be added on top and a real account would answer measurably slower, letting an
+# attacker tell real addresses from fake ones by timing. Running every request to the same total
+# deadline absorbs the send time into the budget so the two are indistinguishable. Must exceed the
+# slowest expected send.
+RESET_RESPONSE_TARGET_SECONDS = 1.0
+
+SUGGESTED_PASSWORD_LENGTH = 20
+
+
+def deliberate_delay():
+    time.sleep(DELIBERATE_DELAY_SECONDS)
+
+
+def sleep_until_deadline(started_at):
+    """
+    Sleep until RESET_RESPONSE_TARGET_SECONDS have passed since started_at, so a reset request takes
+    the same total time whether or not an email was sent. If the work already took longer than the
+    target, do not sleep. started_at should come from time.monotonic().
+    """
+    remaining = RESET_RESPONSE_TARGET_SECONDS - (time.monotonic() - started_at)
+    if remaining > 0:
+        time.sleep(remaining)
+
+
+def _hashed(value):
+    return hashlib.sha256(value.encode('utf-8')).hexdigest()
+
+
+def counter_at_limit(cache_key, limit, window_seconds):
+    """
+    Fixed window counter. Returns True if this key is already at or above its limit, otherwise
+    records one more hit and returns False. A cache problem never blocks a real reset.
+    """
+    try:
+        current_count = cache.get(cache_key)
+        if current_count is None:
+            cache.set(cache_key, 1, window_seconds)
+            return False
+        if current_count >= limit:
+            return True
+        try:
+            cache.incr(cache_key)
+        except ValueError:
+            # The entry expired between the get and the incr.
+            cache.set(cache_key, 1, window_seconds)
+        return False
+    except Exception:
+        return False
+
+
+def is_banned(scope, ip_address):
+    """True if this scope ('request' or 'confirm') is currently banned for this IP address."""
+    try:
+        return cache.get('password_reset_ban_{}_{}'.format(scope, _hashed(ip_address))) is not None
+    except Exception:
+        # Fail open: a cache problem must never turn a ban we cannot read into a lockout.
+        return False
+
+
+def register_offense(scope, ip_address):
+    """
+    Record that this IP went over a limit, and (re)apply a ban whose length doubles with each
+    offense, capped at BAN_MAX_SECONDS. Called only when a request gets past the ban check while
+    over the limit, so the offense count climbs about once per ban rather than once per request.
+    """
+    offense_key = 'password_reset_offense_{}_{}'.format(scope, _hashed(ip_address))
+    try:
+        level = cache.get(offense_key)
+        if level is None:
+            level = 1
+            cache.set(offense_key, level, BAN_OFFENSE_MEMORY_SECONDS)
+        else:
+            try:
+                level = cache.incr(offense_key)
+            except ValueError:
+                level = 1
+                cache.set(offense_key, level, BAN_OFFENSE_MEMORY_SECONDS)
+        ban_seconds = min(BAN_BASE_SECONDS * (2 ** (level - 1)), BAN_MAX_SECONDS)
+        cache.set('password_reset_ban_{}_{}'.format(scope, _hashed(ip_address)), 1, ban_seconds)
+    except Exception:
+        pass
+
+
+def email_recently_sent(email_address_text):
+    """
+    Send suppression. Returns True if we already sent a reset link to this address inside the
+    window (so we should not send again). On the first call it claims the slot and returns False.
+    Runs the same way whether or not the address has an account, so it never leaks that.
+    """
+    try:
+        cache_key = 'password_reset_sent_{}'.format(_hashed(email_address_text.strip().lower()))
+        if cache.get(cache_key) is not None:
+            return True
+        cache.set(cache_key, 1, EMAIL_SEND_SUPPRESS_SECONDS)
+        return False
+    except Exception:
+        # Fail open: if we cannot read the cache, allow the send rather than block a real reset.
+        return False
+
+
+def generate_suggested_password(length=SUGGESTED_PASSWORD_LENGTH):
+    """
+    Build a strong password we can offer the person to copy and paste. We leave out characters
+    that are easy to confuse with each other (0/O, 1/l/I) so it survives being read off a screen.
+    """
+    lowercase = 'abcdefghijkmnopqrstuvwxyz'
+    uppercase = 'ABCDEFGHJKLMNPQRSTUVWXYZ'
+    digits = '23456789'
+    punctuation = '!@#$%^&*-_=+'
+    alphabet = lowercase + uppercase + digits + punctuation
+
+    while True:
+        password = ''.join(secrets.choice(alphabet) for _ in range(length))
+        # Make sure the suggestion always satisfies the validators we enforce on the form.
+        if (any(character in lowercase for character in password) and
+                any(character in uppercase for character in password) and
+                any(character in digits for character in password) and
+                any(character in punctuation for character in password)):
+            return password
+
+
+def get_client_ip_address(request):
+    """
+    Use REMOTE_ADDR on purpose. X-Forwarded-For can be set by the caller, so trusting it here
+    would let anyone slip past the rate limit by making up a new value on each request.
+    """
+    return request.META.get('REMOTE_ADDR', '') or 'unknown'
+
+
+class WeVotePasswordResetForm(PasswordResetForm):
+    """
+    Django looks up the account by Voter.email. People sign in to WeVoteServer with any email
+    address that has been verified and linked to their account (see admin_tools.views
+    .login_we_vote), so we look those up too. Only verified, non deleted email addresses count.
+    """
+    def get_users(self, email):
+        users = list(super().get_users(email))
+        already_found_voter_ids = {voter.pk for voter in users}
+
+        try:
+            queryset = EmailAddress.objects.using('readonly').filter(
+                normalized_email_address__iexact=email,
+                email_ownership_is_verified=True,
+                deleted=False,
+            )
+            voter_we_vote_id_list = list(queryset.values_list('voter_we_vote_id', flat=True))
+        except Exception:
+            voter_we_vote_id_list = []
+
+        if voter_we_vote_id_list:
+            # Read the Voter from the default database. The token is derived from the current
+            # password hash, so a stale replica read could produce a token that does not work.
+            linked_voter_queryset = Voter.objects.filter(
+                we_vote_id__in=voter_we_vote_id_list,
+                is_active=True,
+            )
+            for voter in linked_voter_queryset:
+                if voter.pk not in already_found_voter_ids and voter.has_usable_password():
+                    users.append(voter)
+                    already_found_voter_ids.add(voter.pk)
+
+        return users
+
+
+def canonical_link_email_context():
+    """
+    Build the reset link from the configured WE_VOTE_SERVER_ROOT_URL instead of the incoming Host
+    header. Django's default fills the link's domain and protocol from request.get_host(), so a
+    forged Host (e.g. evil.example.com) would poison the emailed link and hand the one-time token to
+    an attacker. These keys override 'domain'/'protocol' in the reset email context, so the link is
+    always our real server regardless of ALLOWED_HOSTS. Returns {} if the URL is missing or
+    malformed, which falls back to Django's default rather than breaking the reset.
+    """
+    try:
+        root_url = get_environment_variable("WE_VOTE_SERVER_ROOT_URL")
+    except Exception:
+        root_url = ''
+    parts = urlsplit(root_url or '')
+    if parts.scheme and parts.netloc:
+        return {'domain': parts.netloc, 'protocol': parts.scheme}
+    # Failing open here silently restores the Host-header behavior this fix exists to prevent, so make
+    # a misconfiguration loud. WE_VOTE_SERVER_ROOT_URL must be set in every deployed environment.
+    logger.warning(
+        "WV-4734: WE_VOTE_SERVER_ROOT_URL is unset or malformed (%r); password reset links will fall "
+        "back to the request Host header, which is vulnerable to reset-link poisoning.", root_url)
+    return {}
+
+
+class WeVotePasswordResetView(auth_views.PasswordResetView):
+    """
+    Step 1. Ask for the email address and send the single use link.
+    """
+    form_class = WeVotePasswordResetForm
+    template_name = 'registration/password_reset_form.html'
+    email_template_name = 'registration/password_reset_email.html'
+    subject_template_name = 'registration/password_reset_subject.txt'
+    success_url = reverse_lazy('password_reset_done')
+    # WV-4734: force the emailed link to use our configured server URL, not the request Host, so a
+    # forged Host header cannot poison the reset link. Django merges this over the link context last.
+    extra_email_context = canonical_link_email_context()
+
+    def post(self, request, *args, **kwargs):
+        ip_address = get_client_ip_address(request)
+
+        # Reject a banned source cheaply, before any timing budget, database, or email work, so a
+        # flood cannot tie up workers. Same "check your email" page, so it reveals nothing.
+        if is_banned('request', ip_address):
+            return HttpResponseRedirect(self.get_success_url())
+
+        # Everything past here runs to a fixed total time so an account that exists (which triggers
+        # an email send) cannot be told apart from one that does not by timing the response.
+        started_at = time.monotonic()
+
+        # Count this attempt per IP. This counts malformed submissions too, so an attacker cannot
+        # dodge the limit with junk input. Going over the hourly cap escalates the cascading ban.
+        ip_key = 'password_reset_ip_{}'.format(_hashed(ip_address))
+        if counter_at_limit(ip_key, RESET_REQUESTS_PER_IP, RESET_RATE_LIMIT_WINDOW_SECONDS):
+            register_offense('request', ip_address)
+            response = HttpResponseRedirect(self.get_success_url())
+        else:
+            response = super().post(request, *args, **kwargs)
+
+        sleep_until_deadline(started_at)
+        return response
+
+    def form_valid(self, form):
+        # Send suppression instead of a per-email block: if we already emailed this address
+        # recently, do not send again, but still show the normal page. The real owner is never
+        # locked out; an attacker just cannot bomb one inbox. Claimed before the account lookup,
+        # so a real and a nonexistent address behave identically.
+        email_address_text = form.cleaned_data.get('email', '')
+        if email_address_text and email_recently_sent(email_address_text):
+            return HttpResponseRedirect(self.get_success_url())
+        return super().form_valid(form)
+
+
+class WeVotePasswordResetConfirmView(auth_views.PasswordResetConfirmView):
+    """
+    Step 2. The person arrives from the emailed link and sets a new password twice.
+    On success we send them to the sign in page. We do not sign them in automatically, so they
+    have to prove they know the new password.
+    """
+    template_name = 'registration/password_reset_confirm.html'
+    success_url = reverse_lazy('login')
+
+    def dispatch(self, request, *args, **kwargs):
+        # Rate limit and slow down guessing of the emailed link, per IP address. The throttle page
+        # is generic, so it never reveals whether the token in the URL was valid.
+        ip_address = get_client_ip_address(request)
+
+        # Turn away a banned source cheaply, before the delay.
+        if is_banned('confirm', ip_address):
+            return render(request, 'registration/password_reset_throttled.html', status=429)
+
+        deliberate_delay()
+
+        ip_key = 'password_reset_confirm_ip_{}'.format(_hashed(ip_address))
+        if counter_at_limit(ip_key, CONFIRM_ATTEMPTS_PER_IP, RESET_RATE_LIMIT_WINDOW_SECONDS):
+            register_offense('confirm', ip_address)
+            return render(request, 'registration/password_reset_throttled.html', status=429)
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['suggested_password'] = generate_suggested_password()
+        return context
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        messages.success(
+            self.request,
+            'Your password has been changed. Please sign in with your new password.')
+        return response

--- a/config/base.py
+++ b/config/base.py
@@ -197,6 +197,28 @@ USE_TZ = True
 # Described here: https://docs.djangoproject.com/en/1.8/topics/auth/customizing/#a-full-example
 AUTH_USER_MODEL = 'voter.Voter'
 
+# Password rules, applied wherever a password is set, including the password reset flow.
+# See admin_tools/views_password_reset.py
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {'min_length': 12},
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+
+# How long a password reset link stays usable. Django's default is 3 days, which is a long time
+# for a link that can take over a staff account.
+PASSWORD_RESET_TIMEOUT = 60 * 60  # one hour
+
 # Static files (CSS, JavaScript, Images) Django 5+
 STATIC_URL = 'static/'      # April 2024, don't think this is correct, but can't run without it
 STATICFILES_DIRS = [

--- a/config/urls.py
+++ b/config/urls.py
@@ -23,6 +23,7 @@ from django.urls import include, re_path
 from django.contrib.auth import views as auth_views
 
 from admin_tools.views import login_we_vote, logout_we_vote
+from admin_tools.views_password_reset import WeVotePasswordResetConfirmView, WeVotePasswordResetView
 from config import startup, views
 
 urlpatterns = [
@@ -124,6 +125,16 @@ urlpatterns = [
     re_path(r'^logout/$', auth_views.auth_logout, name="logout"),
     re_path(r'^login_we_vote/$', login_we_vote, name="login_we_vote"),
     re_path(r'^logout_we_vote/$', logout_we_vote, name="logout_we_vote"),
+    # Password reset for staff, developers and volunteers. There is deliberately no sign up here.
+    # See admin_tools/views_password_reset.py
+    re_path(r'^password_reset/$',
+            WeVotePasswordResetView.as_view(), name="password_reset"),
+    re_path(r'^password_reset/sent/$',
+            auth_views.PasswordResetDoneView.as_view(
+                template_name='registration/password_reset_done.html'),
+            name="password_reset_done"),
+    re_path(r'^password_reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,32})/$',
+            WeVotePasswordResetConfirmView.as_view(), name="password_reset_confirm"),
     # This line provides the following patterns:
     # login, logout, password_reset, password_reset_done, password_reset_confirm, password_reset_complete
     re_path('', include(('social_django.urls', 'social'), namespace="social")),

--- a/templates/registration/login_we_vote.html
+++ b/templates/registration/login_we_vote.html
@@ -74,8 +74,7 @@
 
     </form>
 
-    {# Assumes you setup the password_reset view in your URLconf #}
-    {#  <p><a href="{% url 'auth:password_reset' %}">Lost password?</a></p> #}
+    <p><a href="{% url 'password_reset' %}">Forgot your password?</a></p>
     <br />
     <br />
 

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -1,0 +1,97 @@
+{% extends "template_base.html" %}
+{# See admin_tools.views_password_reset.WeVotePasswordResetConfirmView for the view that controls this #}
+
+{% block title %}Choose a New Password{% endblock %}
+
+{% block content %}
+  {% if validlink %}
+    <h1>Choose a New Password</h1>
+    <br />
+
+    <p>Enter your new password twice so we can be sure you typed it correctly.</p>
+    <br />
+
+    <div class="control-group">
+      <label class="control-label" for="suggested_password">Suggested password</label>
+      <div class="controls">
+        <input type="text"
+               id="suggested_password"
+               value="{{ suggested_password }}"
+               readonly
+               onclick="this.select();"
+               style="width: 250px" />
+        <button type="button" class="btn btn-secondary" onclick="copySuggestedPassword();">Copy</button>
+        <span id="suggested_password_copied" style="display: none; color: green;">Copied</span>
+      </div>
+      <div class="controls">
+        <small>You can use this one, or ignore it and pick your own. If you use it, save it in your
+          password manager first, because we will not show it again.</small>
+      </div>
+    </div>
+    <br />
+
+    <form method="post" action="">
+      {% csrf_token %}
+      {% if form.errors %}
+        <div style="color: red;">
+          {% for field in form %}
+            {% for error in field.errors %}<p>{{ error }}</p>{% endfor %}
+          {% endfor %}
+          {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
+        </div>
+      {% endif %}
+
+      <div class="control-group">
+        <label class="control-label" for="id_new_password1">New password</label>
+        <div class="controls">
+          <input type="password"
+                 id="id_new_password1"
+                 name="new_password1"
+                 autocomplete="new-password"
+                 required
+                 style="width: 250px" />
+        </div>
+      </div>
+      <div class="control-group">
+        <label class="control-label" for="id_new_password2">Confirm new password</label>
+        <div class="controls">
+          <input type="password"
+                 id="id_new_password2"
+                 name="new_password2"
+                 autocomplete="new-password"
+                 required
+                 style="width: 250px" />
+        </div>
+      </div>
+      <div>&nbsp;</div>
+      <div class="control-group">
+        <div class="controls">
+          <button type="submit" class="btn btn-primary">Change My Password</button>
+        </div>
+      </div>
+    </form>
+
+    <script>
+      function copySuggestedPassword () {
+        var suggestedPasswordField = document.getElementById('suggested_password');
+        suggestedPasswordField.select();
+        suggestedPasswordField.setSelectionRange(0, 99999);  // needed on mobile
+        document.execCommand('copy');
+        document.getElementById('suggested_password_copied').style.display = 'inline';
+      }
+    </script>
+  {% else %}
+    <h1>This Link Has Expired</h1>
+    <br />
+
+    <p>
+      This password reset link is no longer valid. It may have already been used, or it may be
+      more than an hour old.
+    </p>
+
+    <p><a href="{% url 'password_reset' %}">Request a new password reset link</a></p>
+    <br />
+
+    <p><a href="{% url 'login' %}">Back to sign in</a></p>
+  {% endif %}
+{% endblock %}

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -1,0 +1,22 @@
+{% extends "template_base.html" %}
+{# Shown after a reset link is requested. This page must not reveal whether the email address #}
+{# belongs to an account, so the wording is the same either way. #}
+
+{% block title %}Reset Password{% endblock %}
+
+{% block content %}
+  <h1>Check Your Email</h1>
+  <br />
+
+  <p>
+    If that email address is attached to a WeVoteServer account, we have sent it a link you can
+    use to choose a new password. The link can only be used once, and it expires after one hour.
+  </p>
+
+  <p>
+    If the email does not arrive within a few minutes, check your spam folder.
+  </p>
+  <br />
+
+  <p><a href="{% url 'login' %}">Back to sign in</a></p>
+{% endblock %}

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -1,0 +1,16 @@
+{% autoescape off %}Hello,
+
+Someone asked to reset the password for your WeVoteServer account ({{ user.email }}).
+
+To choose a new password, click the link below:
+
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+
+This link can only be used once, and it expires one hour after it was sent.
+
+If you did not ask for a password reset, you can ignore this email. Your password will not
+change until someone uses the link above.
+
+Thanks,
+We Vote
+{% endautoescape %}

--- a/templates/registration/password_reset_form.html
+++ b/templates/registration/password_reset_form.html
@@ -1,0 +1,43 @@
+{% extends "template_base.html" %}
+{# See admin_tools.views_password_reset.WeVotePasswordResetView for the view that controls this #}
+
+{% block title %}Reset Password{% endblock %}
+
+{% block content %}
+  <h1>Reset Password</h1>
+  <br />
+
+  <p>
+    Enter the email address you use to sign in to WeVoteServer and we will send you a link
+    to choose a new password.
+  </p>
+  <br />
+
+  <form method="post" action="">
+    {% csrf_token %}
+    {% if form.email.errors %}
+      <p style="color: red;">{{ form.email.errors|join:" " }}</p>
+    {% endif %}
+    <div class="control-group">
+      <label class="control-label" for="id_email">Email</label>
+      <div class="controls">
+        <input type="email"
+               id="id_email"
+               name="email"
+               placeholder="Email"
+               autocomplete="email"
+               required
+               style="width: 250px" />
+      </div>
+    </div>
+    <div>&nbsp;</div>
+    <div class="control-group">
+      <div class="controls">
+        <button type="submit" class="btn btn-primary">Send Reset Link</button>
+      </div>
+    </div>
+  </form>
+
+  <br />
+  <p><a href="{% url 'login' %}">Back to sign in</a></p>
+{% endblock %}

--- a/templates/registration/password_reset_subject.txt
+++ b/templates/registration/password_reset_subject.txt
@@ -1,0 +1,1 @@
+Reset your WeVoteServer password

--- a/templates/registration/password_reset_throttled.html
+++ b/templates/registration/password_reset_throttled.html
@@ -1,0 +1,21 @@
+{% extends "template_base.html" %}
+{# Generic throttle page for the confirm endpoint. Deliberately says nothing about whether the #}
+{# link was valid. #}
+
+{% block title %}Too Many Attempts{% endblock %}
+
+{% block content %}
+  <h1>Too Many Attempts</h1>
+  <br />
+
+  <p>
+    Too many password reset attempts have come from your connection. Please wait a little while
+    and try again.
+  </p>
+  <br />
+
+  <p><a href="{% url 'password_reset' %}">Request a new password reset link</a></p>
+  <br />
+
+  <p><a href="{% url 'login' %}">Back to sign in</a></p>
+{% endblock %}


### PR DESCRIPTION
This adds a password reset to the WeVoteServer sign in for staff, developers, and volunteers, built on Django's password reset and the forms in django.contrib.auth.forms (PasswordResetForm and SetPasswordForm). The emailed link is single use and expires after an hour, and there is no account creation in this flow.

It is careful about a few things: the request page looks the same whether or not the address has an account (and takes the same amount of time), so it can't be used to find accounts, and the link is built from the configured server URL rather than the request Host so a forged Host can't poison it. Rate limiting is per IP with a cascading ban rather than a hard per email cap, so nobody can lock someone else out of resetting their own password. All the counting uses the existing cache table, so there is no new migration.

It also turns on Django's password validators (AUTH_PASSWORD_VALIDATORS), which were not configured before, so weak passwords can no longer be set anywhere, with a minimum length of twelve.

The reset email goes out through whatever email backend is configured, which is SendGrid in production, so nothing new is needed there. The console backend is only for local testing, where the link prints to the terminal instead of being sent.

Tests are in admin_tools/tests/test_password_reset.py.
