### PR TITLE
[WV-4876] Can the dropdown Filter for elections on Measures Page - Date, State [TEAM REVIEW]

### DIFF
--- a/templates/election/election_list_dropdown.html
+++ b/templates/election/election_list_dropdown.html
@@ -8,7 +8,7 @@
             {% if 0 == selected_election_id|convert_to_int %}selected="selected"{% endif %}>
       {{ default_option_text|default:"-- Filter by Election --" }}
     </option>
-    {% for one_election in election_list %}
+    {% for one_election in election_list|dictsort:"state_code"|dictsort:"election_day_text" %}
       <option value="{{ one_election.google_civic_election_id }}"
               {% if one_election.google_civic_election_id|slugify == selected_election_id|slugify %} selected="selected"{% endif %}>
         {% if one_election.state_code %}{{ one_election.election_day_text}} {% endif %}


### PR DESCRIPTION
**What github.com/wevote/WebApp/issues does this fix?**
[WV-4876] Can the dropdown Filter for elections on Measures Page - Date, State

**Changes included this pull request?**
_templates/election/election_list_dropdown.html_
Added sorting order date followed by State Id

[WV-4876]: https://wevoteusa.atlassian.net/browse/WV-4876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ