### PR TITLE
Make sure only unexpired tokens are checked.

### DIFF
--- a/wevote_tokens/models/single_use_tokens.py
+++ b/wevote_tokens/models/single_use_tokens.py
@@ -146,7 +146,7 @@ class SingleUseTokenManager(models.Manager):
     @staticmethod
     def get_tokens_by_user_id(user_id, scope):
         try:
-            return list(SingleUseToken.objects.filter(_user_id=user_id, _scope=scope).values('pk'))
+            return list(SingleUseToken.objects.filter(_user_id=user_id, _scope=scope, _expiration_datetime__gt=timezone.now()).values('pk'))
         except Exception as e:
             return 'ERROR GETTING TOKENS BY USER ID'
 

--- a/wevote_tokens/tests/test_single_use_token.py
+++ b/wevote_tokens/tests/test_single_use_token.py
@@ -5,6 +5,8 @@ import json
 from datetime import timedelta
 from django.utils import timezone
 import time
+from unittest.mock import patch
+
 
 # Only used to test SingleUseToken model
 class TestSingleUseToken(TestCase):
@@ -394,3 +396,81 @@ class TestSingleUseTokenManager(TestCase):
             message_addon)
         self._assert_is_not_none(token_info, ['expiration_datetime'], message_addon)
         self._assert_true(token_info, ['success'], message_addon)
+
+    def test_get_tokens_by_user_id_all_unexpired(self):
+        voter = self.test_voter
+        scope = self.test_scope
+        message_addon = "All Unexpired Tokens Returned"
+
+        token_pk_1 = self._get_test_token_pk(voter=voter, scope=scope)
+        token_pk_2 = self._get_test_token_pk(voter=voter, scope=scope)
+        token_pk_3 = self._get_test_token_pk(voter=voter, scope=scope)
+
+        tokens = SingleUseTokenManager.get_tokens_by_user_id(voter, scope)
+        returned_pks = sorted([token['pk'] for token in tokens])
+
+        self._assert_equal(
+            {'returned_pks': returned_pks, 'count': len(returned_pks)},
+            ['returned_pks', 'count'],
+            [sorted([token_pk_1, token_pk_2, token_pk_3]), 3],
+            message_addon)
+
+    def test_get_tokens_by_user_id_mixed_expiration(self):
+        voter = self.test_voter
+        scope = self.test_scope
+        message_addon = "Only Unexpired Token Returned"
+
+        expired_pk_1 = self._get_test_token_pk(voter=voter, scope=scope, expiration_seconds=0)
+        expired_pk_2 = self._get_test_token_pk(voter=voter, scope=scope, expiration_seconds=0)
+        time.sleep(1)
+        unexpired_pk = self._get_test_token_pk(voter=voter, scope=scope)
+
+        tokens = SingleUseTokenManager.get_tokens_by_user_id(voter, scope)
+        returned_pks = [token['pk'] for token in tokens]
+
+        self._assert_equal(
+            {'returned_pks': returned_pks, 'count': len(returned_pks)},
+            ['returned_pks', 'count'],
+            [[unexpired_pk], 1],
+            message_addon)
+        self.assertNotIn(expired_pk_1, returned_pks, message_addon)
+        self.assertNotIn(expired_pk_2, returned_pks, message_addon)
+
+    def test_get_tokens_by_user_id_equal_expiration(self):
+        voter = self.test_voter
+        scope = self.test_scope
+        message_addon = "Equal Expiration Token Not Returned"
+
+        token_pk = self._get_test_token_pk(voter=voter, scope=scope, expiration_seconds=0)
+        token = SingleUseToken.objects.get(pk=token_pk)
+
+        with patch(
+            'wevote_tokens.models.single_use_tokens.timezone.now',
+            return_value=token._expiration_datetime):
+            tokens = SingleUseTokenManager.get_tokens_by_user_id(voter, scope)
+
+        self._assert_equal(
+            {'tokens': tokens, 'count': len(tokens)},
+            ['tokens', 'count'],
+            [[], 0],
+            message_addon)
+        self._assert_true(
+            {'exists': SingleUseToken.objects.filter(pk=token_pk).exists()},
+            ['exists'],
+            message_addon)
+
+    def test_get_tokens_by_user_id_exception(self):
+        voter = self.test_voter
+        scope = self.test_scope
+        message_addon = "Get Tokens By User ID Exception"
+
+        with patch(
+            'wevote_tokens.models.single_use_tokens.SingleUseToken.objects.filter',
+            side_effect=Exception('db error')):
+            tokens = SingleUseTokenManager.get_tokens_by_user_id(voter, scope)
+
+        self._assert_equal(
+            {'tokens': tokens},
+            ['tokens'],
+            ['ERROR GETTING TOKENS BY USER ID'],
+            message_addon)


### PR DESCRIPTION
This should reduce some of the redundant SQL calls. This makes sure only unexpired tokens are checked for verification.

Testing:
Added unit tests. 