### PR TITLE
Updates to make deployment pipelines more stable

### DIFF
--- a/codebuild/buildspec-batch-lambda.yaml
+++ b/codebuild/buildspec-batch-lambda.yaml
@@ -28,7 +28,6 @@ phases:
       - echo Pushing batch processor Lambda image
       - docker push $BATCH_LAMBDA_REPO_URI:$IMAGE_TAG
       - echo Updating Lambda function to image $BATCH_LAMBDA_REPO_URI:$IMAGE_TAG
-      - echo "Attempting to update Lambda function code..."
       - |
         MAX_ATTEMPTS=5
         ATTEMPT=1

--- a/codebuild/buildspec-batch-lambda.yaml
+++ b/codebuild/buildspec-batch-lambda.yaml
@@ -21,16 +21,47 @@ phases:
     on-failure: ABORT
     commands:
       - echo Build started at $(date)
-      - docker build -f docker/Dockerfile.lambda-batch -t wevote-batch-processor:latest .
+      - docker build -f docker/Dockerfile.lambda-batch -t $BATCH_LAMBDA_REPO_URI:$IMAGE_TAG .
   post_build:
     on-failure: ABORT
     commands:
-      - echo Tagging and pushing batch processor Lambda image
-      - docker tag wevote-batch-processor:latest $BATCH_LAMBDA_REPO_URI:$IMAGE_TAG
-      - docker tag wevote-batch-processor:latest $BATCH_LAMBDA_REPO_URI:latest
+      - echo Pushing batch processor Lambda image
       - docker push $BATCH_LAMBDA_REPO_URI:$IMAGE_TAG
-      - docker push $BATCH_LAMBDA_REPO_URI:latest
       - echo Updating Lambda function to image $BATCH_LAMBDA_REPO_URI:$IMAGE_TAG
-      - aws lambda update-function-code --function-name $BATCH_LAMBDA_FUNCTION_NAME --image-uri $BATCH_LAMBDA_REPO_URI:$IMAGE_TAG
+      - echo "Attempting to update Lambda function code..."
+      - |
+        MAX_ATTEMPTS=5
+        ATTEMPT=1
+        SLEEP_TIME=7
+
+        while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+          echo "Deployment attempt $ATTEMPT..."
+
+          # Capture both the output and the exit code of the CLI command
+          UPDATE_OUTPUT=$(aws lambda update-function-code --function-name "$BATCH_LAMBDA_FUNCTION_NAME" --image-uri "$BATCH_LAMBDA_REPO_URI:$IMAGE_TAG" 2>&1)
+          EXIT_CODE=$?
+
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "Successfully initiated Lambda update!"
+            break
+          fi
+
+          # Check if the failure was due to an account/resource conflict lock
+          if echo "$UPDATE_OUTPUT" | grep -qE "ResourceConflictException|TooManyRequestsException"; then
+            echo "Account level lock hit. Another pipeline is mutating Lambda resources."
+            echo "Waiting $SLEEP_TIME seconds before retrying..."
+            sleep $SLEEP_TIME
+            ATTEMPT=$((ATTEMPT + 1))
+            SLEEP_TIME=$((SLEEP_TIME * 2)) # Exponential backoff
+          else
+            echo "Fatal deployment error: $UPDATE_OUTPUT"
+            exit 1
+          fi
+        done
+
+        if [ $ATTEMPT -gt $MAX_ATTEMPTS ]; then
+          echo "Error: Timed out waiting for AWS Lambda control plane lock to clear."
+          exit 1
+        fi
       - aws lambda wait function-updated --function-name $BATCH_LAMBDA_FUNCTION_NAME
       - echo Lambda update complete

--- a/codebuild/buildspec-worker-lambda.yaml
+++ b/codebuild/buildspec-worker-lambda.yaml
@@ -28,7 +28,6 @@ phases:
       - echo Pushing Lambda image
       - docker push $LAMBDA_REPO_URI:$IMAGE_TAG
       - echo Updating Lambda function to image $LAMBDA_REPO_URI:$IMAGE_TAG
-      - echo "Attempting to update Lambda function code..."
       - |
         MAX_ATTEMPTS=5
         ATTEMPT=1

--- a/codebuild/buildspec-worker-lambda.yaml
+++ b/codebuild/buildspec-worker-lambda.yaml
@@ -21,16 +21,47 @@ phases:
     on-failure: ABORT
     commands:
       - echo Build started at $(date)
-      - docker build -f docker/Dockerfile.lambda-worker -t wevote-sqs-worker:latest .
+      - docker build -f docker/Dockerfile.lambda-worker -t $LAMBDA_REPO_URI:$IMAGE_TAG .
   post_build:
     on-failure: ABORT
     commands:
-      - echo Tagging and pushing Lambda image
-      - docker tag wevote-sqs-worker:latest $LAMBDA_REPO_URI:$IMAGE_TAG
-      - docker tag wevote-sqs-worker:latest $LAMBDA_REPO_URI:latest
+      - echo Pushing Lambda image
       - docker push $LAMBDA_REPO_URI:$IMAGE_TAG
-      - docker push $LAMBDA_REPO_URI:latest
       - echo Updating Lambda function to image $LAMBDA_REPO_URI:$IMAGE_TAG
-      - aws lambda update-function-code --function-name $LAMBDA_FUNCTION_NAME --image-uri $LAMBDA_REPO_URI:$IMAGE_TAG
+      - echo "Attempting to update Lambda function code..."
+      - |
+        MAX_ATTEMPTS=5
+        ATTEMPT=1
+        SLEEP_TIME=15
+
+        while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+          echo "Deployment attempt $ATTEMPT..."
+
+          # Capture both the output and the exit code of the CLI command
+          UPDATE_OUTPUT=$(aws lambda update-function-code --function-name "$LAMBDA_FUNCTION_NAME" --image-uri "$LAMBDA_REPO_URI:$IMAGE_TAG" 2>&1)
+          EXIT_CODE=$?
+
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "Successfully initiated Lambda update!"
+            break
+          fi
+
+          # Check if the failure was due to an account/resource conflict lock
+          if echo "$UPDATE_OUTPUT" | grep -qE "ResourceConflictException|TooManyRequestsException"; then
+            echo "Account level lock hit. Another pipeline is mutating Lambda resources."
+            echo "Waiting $SLEEP_TIME seconds before retrying..."
+            sleep $SLEEP_TIME
+            ATTEMPT=$((ATTEMPT + 1))
+            SLEEP_TIME=$((SLEEP_TIME * 2)) # Exponential backoff
+          else
+            echo "Fatal deployment error: $UPDATE_OUTPUT"
+            exit 1
+          fi
+        done
+
+        if [ $ATTEMPT -gt $MAX_ATTEMPTS ]; then
+          echo "Error: Timed out waiting for AWS Lambda control plane lock to clear."
+          exit 1
+        fi
       - aws lambda wait function-updated --function-name $LAMBDA_FUNCTION_NAME
       - echo Lambda update complete

--- a/codebuild/buildspec.yaml
+++ b/codebuild/buildspec.yaml
@@ -9,7 +9,6 @@ phases:
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=build}
       - ECR_LOGIN_HOST=$(echo $REPO_URI | sed 's#/.*##')
-      - IMAGE_NAME="wevote-api:latest"
       - echo Logging into ECR
       - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_LOGIN_HOST
   build:
@@ -18,16 +17,12 @@ phases:
       - echo Build started at $(date)
       - aws s3 cp s3://wevote-packages/GeoIP2-City.mmdb geoip2/city-db/GeoIP2-City.mmdb
       - echo $CODEBUILD_RESOLVED_SOURCE_VERSION > git_commit_hash
-      - docker build -f docker/Dockerfile.prod -t $IMAGE_NAME .
+      - docker build -f docker/Dockerfile.prod -t $REPO_URI:$IMAGE_TAG .
   post_build:
     on-failure: ABORT
     commands:
-      - echo Tagging docker images
-      - docker tag $IMAGE_NAME $REPO_URI:$IMAGE_TAG
-      - docker tag $IMAGE_NAME $REPO_URI:latest
-      - echo Pushing docker images to ECR
+      - echo Pushing docker image to ECR
       - docker push $REPO_URI:$IMAGE_TAG
-      - docker push $REPO_URI:latest
       - echo Writing image definitions
       - printf "[{\"name\":\"$ECS_CONTAINER_NAME\",\"imageUri\":\"$REPO_URI:$IMAGE_TAG\"}]" > imagedefinitions.json
 artifacts:


### PR DESCRIPTION
- Update buildspecs to not use intermediate image tag
- Stop using latest tag for images
- Add retry logic for updating Lambda code via ECR.