### PR TITLE
Fixes related to WV-4977 for non-Docker development environment. WV-4876 Trapped the bug that prevented sorting on in election_list_dropdown.html. Also supporting reverse sort when looking at past elections.

### DIFF
--- a/apis_v1/templatetags/template_filters.py
+++ b/apis_v1/templatetags/template_filters.py
@@ -6,8 +6,10 @@
 
 from django import template
 from django.contrib.humanize.templatetags.humanize import intcomma
+from django.template.defaultfilters import _property_resolver
 
 from wevote_functions import functions, functions_date
+from wevote_functions.functions import positive_value_exists
 
 register = template.Library()
 
@@ -55,3 +57,36 @@ def pennies_to_money(number):
     result += intcomma(rest[1:]) if is_neg else intcomma(rest)
     result += '.' + number_string[-2:]
     return result
+
+
+@register.filter(name="dictsort_none_safe")
+def dictsort_none_safe(value, arg, reverse_date_order):
+    """
+    Like Django's built-in dictsort, but treats a null (None) sort field as an
+    empty string instead of returning "" for the whole list. Works on both dict
+    keys and object attributes. On any other failure, returns the list unsorted.
+    """
+    resolver = _property_resolver(arg)
+    reverse_sort = positive_value_exists(reverse_date_order)
+
+    def sort_key(item):
+        resolved = resolver(item)
+        # None sorts before any real value, and never gets compared to a str.
+        return (resolved is None, resolved if resolved is not None else "")
+
+    try:
+        return sorted(value, key=sort_key, reverse=reverse_sort)
+    except (AttributeError, TypeError):
+        return value
+
+
+@register.filter(name="sort_election_list_for_dropdown")
+def sort_election_list_for_dropdown(election_list, reverse_date_order=False):
+    """
+    When show_all_elections is True, sort by election_day_text descending (newest
+    first). Otherwise use the default state_code, then election_day_text ordering.
+    Both paths are null-safe.
+    """
+    return dictsort_none_safe(
+        dictsort_none_safe(election_list, "state_code", False),
+        "election_day_text", reverse_date_order)

--- a/retrieve_tables/controllers_local.py
+++ b/retrieve_tables/controllers_local.py
@@ -279,7 +279,11 @@ def restore_one_file_to_local_server(aws_s3_file_url, table_name):
         # env_in_container = subprocess.run(['ls', '-la', script_path], env=env, capture_output=True, text=True)
         # print(f"ls -la {script_path}:  {env_in_container.stdout}")
 
-        table_restore_result = subprocess.run(command_list, shell=True, env=env)
+        # The Docker branch builds a shell string (uses "< file" redirection) so it needs shell=True.
+        # The non-Docker branch builds an argument list, which must run with shell=False, otherwise
+        # only "pg_restore" is executed and its arguments are dropped.
+        table_restore_result = subprocess.run(command_list, shell=in_docker, env=env,
+                                              capture_output=True, text=True)
 
         # Any return code other than 0 is an error
         if table_restore_result.returncode != 0:

--- a/templates/admin_tools/data_cleanup_organization_analysis.html
+++ b/templates/admin_tools/data_cleanup_organization_analysis.html
@@ -79,7 +79,7 @@
         method="get"
         action="{% url 'organization:organization_position_list' organization.id %}">
     {% csrf_token %}
-    {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+    {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=True %}
   </form>
 {% endif %}
 {# End of if election_list #}

--- a/templates/admin_tools/data_cleanup_position_list_analysis.html
+++ b/templates/admin_tools/data_cleanup_position_list_analysis.html
@@ -21,7 +21,7 @@
               method="get"
               action="{% url 'admin_tools:data_cleanup_position_list_analysis' %}">
           {% csrf_token %}
-          {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+          {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=True %}
         </form>
       {% endif %}
       {# End of if election_list #}

--- a/templates/admin_tools/sync_data_with_master_dashboard.html
+++ b/templates/admin_tools/sync_data_with_master_dashboard.html
@@ -118,7 +118,7 @@
       <br />
 
       {% if election_list %}
-        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=True %}
         <br />
       {% endif %}
       {# End of if election_list #}

--- a/templates/analytics/index.html
+++ b/templates/analytics/index.html
@@ -66,7 +66,7 @@
           action="{% url 'analytics:analytics_index' %}">
       {% csrf_token %}
       {% if election_list %}
-        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=True %}
       {% endif %}
       {# End of if election_list #}
     </form>

--- a/templates/analytics/organization_election_metrics.html
+++ b/templates/analytics/organization_election_metrics.html
@@ -19,7 +19,7 @@
     {% csrf_token %}
     <input type="hidden" name="state_code" value="{{ state_code }}" />
     {% if election_list %}
-      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=True %}
     {% endif %}
     {# End of if election_list #}
   </form>

--- a/templates/analytics/sitewide_election_metrics.html
+++ b/templates/analytics/sitewide_election_metrics.html
@@ -18,7 +18,7 @@
     {% csrf_token %}
     <input type="hidden" name="state_code" value="{{ state_code }}" />
     {% if election_list %}
-      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=True %}
     {% endif %}
     {# End of if election_list #}
   </form>

--- a/templates/candidate/candidate_data_cleaning.html
+++ b/templates/candidate/candidate_data_cleaning.html
@@ -32,7 +32,7 @@
            value="{{ exclude_candidate_analysis_done }}" />#}
 
     {% if election_list %}
-      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=show_all_elections %}
     {% endif %}
     {# End of if election_list #}
 

--- a/templates/candidate/candidate_list.html
+++ b/templates/candidate/candidate_list.html
@@ -66,7 +66,7 @@
         {% endif %}
 
         {% if election_list %}
-          {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+          {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=show_all_elections %}
         {% endif %}
 
         {# Default to showing only upcoming elections #}

--- a/templates/election/election_list_dropdown.html
+++ b/templates/election/election_list_dropdown.html
@@ -8,12 +8,14 @@
             {% if 0 == selected_election_id|convert_to_int %}selected="selected"{% endif %}>
       {{ default_option_text|default:"-- Filter by Election --" }}
     </option>
-    {% for one_election in election_list|dictsort:"state_code"|dictsort:"election_day_text" %}
+    {% with reverse_date_order=reverse_date_order|default:False %}
+    {% for one_election in election_list|sort_election_list_for_dropdown:reverse_date_order %}
       <option value="{{ one_election.google_civic_election_id }}"
               {% if one_election.google_civic_election_id|slugify == selected_election_id|slugify %} selected="selected"{% endif %}>
         {% if one_election.state_code %}{{ one_election.election_day_text}} {% endif %}
         {{ one_election.state_code }}: {{ one_election.election_name }} &ndash; {{ one_election.google_civic_election_id }}
       </option>
     {% endfor %}
+    {% endwith %}
   </select>
 {% endif %}

--- a/templates/import_export_batches/batch_process_list.html
+++ b/templates/import_export_batches/batch_process_list.html
@@ -277,7 +277,7 @@
                           action="{% url 'import_export_batches:batch_process_list' %}">
                       {% csrf_token %}
                       {% if election_list %}
-                        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+                        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=show_all_elections %}
                       {% endif %}
                       {# End of if election_list #}
 

--- a/templates/import_export_batches/batch_process_log_entry_list.html
+++ b/templates/import_export_batches/batch_process_log_entry_list.html
@@ -19,7 +19,7 @@
         action="{% url 'import_export_batches:batch_process_log_entry_list' %}">
     {% csrf_token %}
     {% if election_list %}
-      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=show_all_elections %}
       {% if google_civic_election_id %}
         <a href="{% url 'import_export_batches:batch_process_log_entry_list' %}?state_code={{ state_code }}&candidate_search={{ candidate_search }}{% if show_all_elections %}&show_all_elections=1{% endif %}&batch_process_id={{ batch_process_id }}&batch_process_chunk_id={{ batch_process_chunk_id }}">
         clear</a>

--- a/templates/import_export_vote_smart/candidate_list.html
+++ b/templates/import_export_vote_smart/candidate_list.html
@@ -15,7 +15,7 @@
           method="get"
           action="{% url 'candidate:candidate_list' %}">
       {% csrf_token %}
-      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=True %}
     </form>
   {% endif %}
   {# End of if election_list #}

--- a/templates/import_export_vote_smart/group_rating_list.html
+++ b/templates/import_export_vote_smart/group_rating_list.html
@@ -35,7 +35,7 @@
             method="get"
             action="{% url 'import_export_vote_smart:special_interest_group_rating_list' special_interest_group.sigId %}">
         {% csrf_token %}
-        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=True %}
       </form>
     {% endif %}
     {# End of if election_list #}

--- a/templates/issue/issue_list.html
+++ b/templates/issue/issue_list.html
@@ -19,7 +19,7 @@
     <br />
 
     {% if election_list %}
-      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=show_all_elections %}
     {% endif %}
     {# End of if election_list #}
 

--- a/templates/measure/measure_list.html
+++ b/templates/measure/measure_list.html
@@ -27,7 +27,7 @@
           action="{% url 'measure:measure_list' %}">
       {% csrf_token %}
       {% if election_list %}
-        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=show_all_elections %}
       {% endif %}
       {# End of if election_list #}
 

--- a/templates/office/office_list.html
+++ b/templates/office/office_list.html
@@ -42,7 +42,7 @@
     {% csrf_token %}
 
     {% if election_list %}
-      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id %}
+      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id reverse_date_order=show_all_elections %}
     {% endif %}
     {# End of if election_list #}
 

--- a/templates/office/offices_copy.html
+++ b/templates/office/offices_copy.html
@@ -13,7 +13,7 @@
     {% csrf_token %}
     {% if election_list %}
       Copy From:
-      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=from_google_civic_election_id select_id="from_google_civic_election_id" select_name="from_google_civic_election_id" %}
+      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=from_google_civic_election_id select_id="from_google_civic_election_id" select_name="from_google_civic_election_id" reverse_date_order=show_all_elections %}
     {% endif %}
     {# End of if election_list #}
 
@@ -114,7 +114,7 @@
 
       {% if election_list %}
         Copy To:
-        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=to_google_civic_election_id select_id="to_google_civic_election_id" select_name="to_google_civic_election_id" %}
+        {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=to_google_civic_election_id select_id="to_google_civic_election_id" select_name="to_google_civic_election_id" reverse_date_order=show_all_elections %}
       {% endif %}
       {# End of if election_list #}
       {% if to_google_civic_election_id and from_google_civic_election_id != to_google_civic_election_id %}

--- a/templates/position/position_list.html
+++ b/templates/position/position_list.html
@@ -59,7 +59,7 @@
         action="{% url 'position:position_list' %}">
     {% csrf_token %}
     {% if election_list %}
-      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id select_id="google_civic_election_id" select_name="google_civic_election_id" %}
+      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id select_id="google_civic_election_id" select_name="google_civic_election_id" reverse_date_order=show_all_elections %}
     {% endif %}
     {# End of if election_list #}
 

--- a/templates/voter_guide/voter_guide_list.html
+++ b/templates/voter_guide/voter_guide_list.html
@@ -56,7 +56,7 @@
         action="{% url 'voter_guide:voter_guide_list' %}">
     {% csrf_token %}
     {% if election_list %}
-      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id select_id="google_civic_election_id" select_name="google_civic_election_id" %}
+      {% include "election/election_list_dropdown.html" with election_list=election_list selected_election_id=google_civic_election_id select_id="google_civic_election_id" select_name="google_civic_election_id" reverse_date_order=show_all_elections %}
     {% else %}
       (no elections found)
     {% endif %}


### PR DESCRIPTION
Fixes related to WV-4977 for non-Docker development environment. WV-4876 Trapped the bug that prevented sorting on in election_list_dropdown.html. Also supporting reverse sort when looking at past elections.

Used the following AI prompts to find a fix:

In the file "election/election_list_dropdown.html", the dictsort functions fail if the state_code field in one_election is null. Is there a way to prevent this?

How can I change this for loop to reverse sort by "election_day_text" if the "show_all_elections" variable that is passed in is set to True?

In every other Django template where we use include "election/election_list_dropdown.html" please pass in show_all_elections like this reverse_date_order=show_all_elections if the variable show_all_elections is in the template file.

How can I modify election_list_dropdown.html to assume 'reverse_date_order' is False if it hasn't been passed into this file?